### PR TITLE
Fix: Operation axis visibility when switching between sketches

### DIFF
--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -1635,6 +1635,10 @@ void Sketch::set_visible(bool state)
 
     if (m_originating_face)
       m_ctx.Display(m_originating_face, AIS_WireFrame, 0, false);
+
+    // Show operation axis only if this sketch is current
+    if (m_operation_axis.has_value() && is_current())
+      m_ctx.Display(m_operation_axis->shp, AIS_WireFrame, 0, false);
   }
   else
   {
@@ -1650,6 +1654,10 @@ void Sketch::set_visible(bool state)
 
     if (m_originating_face)
       m_ctx.Erase(m_originating_face, false);
+
+    // Hide operation axis when sketch becomes invisible
+    if (m_operation_axis.has_value())
+      m_ctx.Erase(m_operation_axis->shp, false);
 
     m_nodes.hide_snap_annos();
     cancel_elm();
@@ -1727,6 +1735,10 @@ void Sketch::set_current()
     {
       sketch->set_edge_style(Edge_style::Background);
 
+      // Hide operation axis from other sketches
+      if (sketch->m_operation_axis.has_value())
+        m_ctx.Erase(sketch->m_operation_axis->shp, false);
+
       if (sketch->is_visible())
       {
         // Add snap points from other sketches, but only if they are visible.
@@ -1736,6 +1748,10 @@ void Sketch::set_current()
           m_nodes.add_outside_snap_pnt(pt3d);
       }
     }
+
+  // Show operation axis for current sketch if it exists and sketch is visible
+  if (m_operation_axis.has_value() && m_visible)
+    m_ctx.Display(m_operation_axis->shp, AIS_WireFrame, 0, false);
 
   // DBG_MSG("m_outside_snap_pts " << m_nodes.m_outside_snap_pts.size());
 }


### PR DESCRIPTION
# Fix: Operation axis visibility when switching between sketches

## Summary

Fixed a bug where operation axes from multiple sketches would remain visible when switching between sketches. Now only the current sketch's operation axis is displayed, providing a cleaner and less confusing user interface.

## Problem

When multiple sketches had operation axes defined, switching between them would not properly hide the operation axes from non-current sketches. This caused visual clutter and confusion, as multiple operation axes could be visible simultaneously.

**Steps to reproduce (before fix):**
1. Create two or more sketches
2. Define an operation axis in each sketch
3. Switch between sketches using the sketch list
4. **Observed**: All operation axes remain visible
5. **Expected**: Only the current sketch's operation axis should be visible

## Solution

Added operation axis visibility management in two key functions:

1. **`set_current()`** - When a sketch becomes current:
   - Hide operation axes from all other sketches
   - Display the current sketch's operation axis if it exists and the sketch is visible

2. **`set_visible()`** - When sketch visibility changes:
   - Show operation axis only if the sketch is current
   - Hide operation axis when sketch becomes invisible

## Changes

### Files Modified
- `src/sketch.cpp` - Updated `set_visible()` and `set_current()` functions

### Key Changes
- Added operation axis visibility management in `set_current()` to hide axes from non-current sketches
- Added operation axis display logic in `set_current()` for the current sketch
- Added operation axis visibility handling in `set_visible()` for both show and hide cases

## Testing

### Manual Testing
- ✅ Create two sketches with operation axes, switch between them - only current sketch's axis is visible
- ✅ Toggle sketch visibility - operation axis follows visibility state correctly
- ✅ Multiple sketches with mixed operation axis states - correct behavior

## Impact

- **User Experience**: Cleaner interface - only the relevant operation axis is visible
- **Visual Clarity**: Eliminates confusion from multiple visible operation axes
- **Consistency**: Operation axis visibility now follows the same pattern as edges, faces, and dimensions

## Related Issues

Fixes the issue where operation axes from multiple sketches would remain visible when switching between sketches.

