### PR TITLE
Trailcode/hot keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.vs
 # Cursor IDE (local only). Shared assistant-oriented notes live in agents/.
 /.cursor/
+/scripts/__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Offline documentation:** the build copies Markdown guides (`usage.md`, `usage-settings.md`, etc.) into **`res/doc/`** next to the executable. **Help -> Usage Guide** and the view-roll **?** help control open the packaged file when present; otherwise they fall back to GitHub in the browser.
 - **View roll:** **Shift+NumPad 4** and **Shift+NumPad 6** roll the 3D view (Blender-style). **Settings** has **View roll step** (degrees per key press; default 45, stored as `gui.view_roll_step_deg`).
 - Help > About: in-app dialog with the app version, a short product description, and a link to the GitHub repository (replaces opening the README in the browser from that menu item).
 - **Sketch length dimensions (Dimension tool):** dimensions are stored as an unordered pair of sketch nodes (not attached to a single edge). They can be selected in sketch mode and removed with **Delete**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **View roll:** **Shift+NumPad 4** and **Shift+NumPad 6** roll the 3D view (Blender-style). **Settings** has **View roll step** (degrees per key press; default 45, stored as `gui.view_roll_step_deg`).
 - Help > About: in-app dialog with the app version, a short product description, and a link to the GitHub repository (replaces opening the README in the browser from that menu item).
 - **Sketch length dimensions (Dimension tool):** dimensions are stored as an unordered pair of sketch nodes (not attached to a single edge). They can be selected in sketch mode and removed with **Delete**.
 - **Project JSON:** root-level `ezyFormat` (current value `2`) on save. Sketches serialize `length_dimensions` as dense node-index pairs alongside linear edges as `[a, b, mid]` only.
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **View roll** default step is **45** degrees (was 15).
 - Window title shows the current project file name (e.g. after Open or Save), or `untitled` when there is no path yet; **File > New** clears the name so the title matches an empty document.
 - **Dimension tool behavior:** click a straight edge to toggle a length dimension between its endpoints, or click two nodes to toggle a dimension between them; clicks away from nodes and edges do not create spurious dimensions. Node picks take precedence over edge picks when both could apply; moving the mouse updates node snap feedback in this mode.
 - **Documentation:** `usage-sketch.md` and `usage.md` describe the tool as the **Dimension tool** and document the node-pair model.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,25 @@
 cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
 project(EzyCad)
 
+# Markdown / license copied to res/doc/ next to the executable (offline help); Emscripten MEMFS under /res/doc/.
+set(EZYCAD_RES_DOC_FILES
+    usage.md
+    usage-settings.md
+    usage-sketch.md
+    scripting.md
+    usage-occt-view.md
+    README.md
+    CHANGELOG.md
+    ezycad_code_style.md
+    bugs.md
+    LICENSE
+)
+
+set(EZYCAD_EM_DOC_PRELOAD_FLAGS "")
+foreach(_ezd IN LISTS EZYCAD_RES_DOC_FILES)
+  string(APPEND EZYCAD_EM_DOC_PRELOAD_FLAGS " --preload-file ${CMAKE_SOURCE_DIR}/${_ezd}@/res/doc/${_ezd}")
+endforeach()
+
 # CMP0167: Use legacy FindBoost module (avoids "FindBoost module is removed" warning in CMake 3.30+)
 if(POLICY CMP0167)
   cmake_policy(SET CMP0167 OLD)
@@ -291,6 +310,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Emscripten")
             --preload-file ${CMAKE_SOURCE_DIR}/res/default.ezy@/res/default.ezy \
             --preload-file ${CMAKE_SOURCE_DIR}/res/examples@/res/examples \
             --preload-file ${CMAKE_SOURCE_DIR}/res/scripts/lua@/res/scripts/lua \
+            ${EZYCAD_EM_DOC_PRELOAD_FLAGS} \
             --shell-file ${CMAKE_SOURCE_DIR}/web/EzyCad.html"
         )
     else()
@@ -324,6 +344,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Emscripten")
             --preload-file ${CMAKE_SOURCE_DIR}/res/default.ezy@/res/default.ezy \
             --preload-file ${CMAKE_SOURCE_DIR}/res/examples@/res/examples \
             --preload-file ${CMAKE_SOURCE_DIR}/res/scripts/lua@/res/scripts/lua \
+            ${EZYCAD_EM_DOC_PRELOAD_FLAGS} \
             --shell-file ${CMAKE_SOURCE_DIR}/web/EzyCad.html"
         )
     endif()
@@ -471,6 +492,20 @@ else()
         )
       endforeach()
     endif()
+    add_custom_command(
+        TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${PROJECT_NAME}>/res/doc
+        COMMENT "Creating res/doc for native (packaged markdown)"
+    )
+    foreach(_doc IN LISTS EZYCAD_RES_DOC_FILES)
+      add_custom_command(
+          TARGET ${PROJECT_NAME} POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              ${CMAKE_SOURCE_DIR}/${_doc}
+              $<TARGET_FILE_DIR:${PROJECT_NAME}>/res/doc/${_doc}
+          COMMENT "Copying res/doc/${_doc} for native"
+      )
+    endforeach()
 
     target_link_libraries(${PROJECT_NAME} ${PROJECT_NAME}_lib)
     target_link_libraries(${PROJECT_NAME} ${BINARY_DIR}/thirdParty/unofficial-flayan-glew.${GLEW_VERSION}/build/native/lib/x64/dynamic/glew32.lib)

--- a/agents/issues/001-imgui-openpopup-id-stack-and-tables.md
+++ b/agents/issues/001-imgui-openpopup-id-stack-and-tables.md
@@ -1,0 +1,40 @@
+# [Draft] ImGui: document pattern for OpenPopup vs BeginPopup outside tables
+
+**Paste into GitHub as a new issue.** Suggested labels: `documentation`, `imgui`, `low priority`
+
+---
+
+## Title
+
+Document ImGui popup ID stack: avoid OpenPopup inside `BeginTable` unless BeginPopup matches scope
+
+## Body
+
+### Summary
+
+Dear ImGui resolves `OpenPopup("id")` / `BeginPopup("id")` using the current **ID stack** (see [imgui#331](https://github.com/ocornut/imgui/issues/331)). Calling `OpenPopup` from inside a **table cell** while calling `BeginPopup` **after** `EndTable()` produces **different hashed popup IDs**, so the popup never opens.
+
+### Context in EzyCad
+
+We hit this when adding UI next to **Settings → 3D view navigation → View roll step** (slider inside `BeginTable`). The fix was to **defer** `OpenPopup` until after `ImGui::EndTable()`, in the same ID scope as `BeginPopup`.
+
+**View roll (for users):** **Shift+NumPad 4** and **Shift+NumPad 6** roll the 3D view around the screen axis (Blender-style). The step in degrees is **Settings → 3D view navigation → View roll step** (`gui.view_roll_step_deg`, default 45). See [usage.md#view-roll](https://github.com/trailcode/EzyCad/blob/main/usage.md#view-roll) and `src/gui_mode.cpp` (`GUI::on_key`).
+
+Related code: `src/gui_settings.cpp` (3D view navigation section). The experimental **Type** button + popup was removed; **Ctrl+click** on `SliderScalar` remains the supported way to type exact values.
+
+### Suggestion
+
+- Add a short note to **`ezycad_code_style.md`** or **`agents/README.md`** (or a tiny **`agents/imgui-notes.md`**) so future UI in tables does not repeat the mistake.
+- Optional: extract a tiny helper, e.g. `defer_open_popup_after_table(bool& pending)` — only if we add more table-adjacent popups.
+
+### Acceptance criteria
+
+- [ ] Project docs mention ImGui popup + table ID stack **or** link to imgui#331 / upstream FAQ.
+- [ ] No functional change required if docs-only.
+
+---
+
+## Metadata (do not paste)
+
+- Created for agent/local drafting under `agents/issues/`.
+- Repo: `trailcode/EzyCad`.

--- a/agents/issues/README.md
+++ b/agents/issues/README.md
@@ -1,0 +1,5 @@
+# GitHub issue drafts (repo-local)
+
+Markdown drafts for issues to open at **https://github.com/trailcode/EzyCad/issues**. Copy the body into a new issue on GitHub (title + description).
+
+These files are **not** a substitute for GitHub tracking; they keep wording and context in-repo for agents and contributors.

--- a/res/ezycad_settings.json
+++ b/res/ezycad_settings.json
@@ -13,6 +13,7 @@
     "show_lua_console": true,
     "show_options": true,
     "show_python_console": true,
+    "view_roll_step_deg": 45.0,
     "show_settings_dialog": true,
     "show_shape_list": true,
     "show_sketch_list": true,

--- a/scripts/pbf-to-png.ps1
+++ b/scripts/pbf-to-png.ps1
@@ -1,0 +1,41 @@
+# Convert PDF content (often mislabeled as .pbf) to PNG with configurable DPI.
+# Requires Python 3 and: pip install pymupdf
+#
+# Examples:
+#   .\pbf-to-png.ps1 -Input drawing.pbf -Dpi 300
+#   .\pbf-to-png.ps1 -Input doc.pdf -Output out.png -Dpi 150
+#   .\pbf-to-png.ps1 -Input manual.pdf -AllPages -Dpi 200
+
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [string] $Input,
+
+  [string] $Output,
+
+  [double] $Dpi = 150,
+
+  [switch] $AllPages,
+
+  [int] $Page
+)
+
+$here = $PSScriptRoot
+$py = Join-Path $here "pbf-to-png.py"
+if (-not (Test-Path $py)) {
+  Write-Error "Missing script: $py"
+  exit 1
+}
+
+$argsList = @($py, $Input, "--dpi", $Dpi)
+if ($Output) {
+  $argsList += @("-o", $Output)
+}
+if ($AllPages) {
+  $argsList += "--all-pages"
+}
+if ($PSBoundParameters.ContainsKey("Page")) {
+  $argsList += @("--page", $Page)
+}
+
+& python @argsList
+exit $LASTEXITCODE

--- a/scripts/pbf-to-png.py
+++ b/scripts/pbf-to-png.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Rasterize a PDF to PNG. Many tools mislabel PDFs as ".pbf"; this script opens the
+file with PyMuPDF, which recognizes PDF by content.
+
+Requires: pip install pymupdf
+
+Usage:
+  python pbf-to-png.py input.pbf -o out.png --dpi 300
+  python pbf-to-png.py doc.pdf --all-pages --dpi 150
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _is_pdf_file(path: Path) -> bool:
+    try:
+        with path.open("rb") as f:
+            head = f.read(5)
+    except OSError as e:
+        print(f"Error reading {path}: {e}", file=sys.stderr)
+        return False
+    return head.startswith(b"%PDF")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="Convert a PDF (often saved as .pbf) to PNG with configurable DPI."
+    )
+    p.add_argument(
+        "input",
+        type=Path,
+        help="Input file (.pdf or PDF content with another extension such as .pbf)",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output PNG path (single-page). For multiple pages with --all-pages, "
+        "this is treated as a filename pattern: stem-001.png, stem-002.png, ...",
+    )
+    p.add_argument(
+        "--dpi",
+        type=float,
+        default=150.0,
+        metavar="N",
+        help="Rasterization resolution in dots per inch (default: 150)",
+    )
+    p.add_argument(
+        "--all-pages",
+        action="store_true",
+        help="Export every page; filenames use stem-001.png style unless -o is omitted "
+        "(then uses input basename next to the input file)",
+    )
+    p.add_argument(
+        "--page",
+        type=int,
+        default=None,
+        metavar="N",
+        help="1-based page index to export (default with --all-pages: all pages; "
+        "otherwise: page 1 only)",
+    )
+    args = p.parse_args()
+
+    src = args.input
+    if not src.is_file():
+        print(f"Not a file: {src}", file=sys.stderr)
+        return 1
+
+    if not _is_pdf_file(src):
+        print(
+            f"{src} does not look like a PDF (missing %PDF header). "
+            "If this is a Mapbox/OSM vector tile or other binary PBF, use a different tool.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        import fitz  # PyMuPDF
+    except ImportError:
+        print(
+            "Missing dependency: install with  pip install pymupdf",
+            file=sys.stderr,
+        )
+        return 1
+
+    dpi = float(args.dpi)
+    if dpi <= 0:
+        print("--dpi must be positive", file=sys.stderr)
+        return 1
+
+    zoom = dpi / 72.0
+    mat = fitz.Matrix(zoom, zoom)
+
+    try:
+        doc = fitz.open(src)
+    except Exception as e:
+        print(f"Failed to open as PDF: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        n = doc.page_count
+        if args.page is not None:
+            if args.page < 1 or args.page > n:
+                print(f"--page must be between 1 and {n}", file=sys.stderr)
+                return 1
+            indices = [args.page - 1]
+        elif args.all_pages:
+            indices = list(range(n))
+        else:
+            indices = [0]
+
+        if len(indices) == 1:
+            out = args.output
+            if out is None:
+                out = src.with_suffix(".png")
+            else:
+                out = Path(out)
+            parent = out.parent
+            if parent and str(parent) != ".":
+                parent.mkdir(parents=True, exist_ok=True)
+            page = doc.load_page(indices[0])
+            pix = page.get_pixmap(matrix=mat, alpha=False)
+            pix.save(str(out))
+            print(out)
+        else:
+            base = args.output
+            if base is None:
+                stem = src.stem
+                out_dir = src.parent
+            else:
+                base = Path(base)
+                stem = base.stem
+                out_dir = base.parent
+                if not str(out_dir) or out_dir == Path("."):
+                    out_dir = src.parent
+            out_dir.mkdir(parents=True, exist_ok=True)
+            width = max(3, len(str(len(indices))))
+            for i, pi in enumerate(indices):
+                page = doc.load_page(pi)
+                pix = page.get_pixmap(matrix=mat, alpha=False)
+                name = f"{stem}-{i + 1:0{width}d}.png"
+                path = out_dir / name
+                pix.save(str(path))
+                print(path)
+    finally:
+        doc.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1,13 +1,16 @@
 #include "gui.h"
 
+#include "paths.h"
+
 #include <algorithm>
+#include <filesystem>
 #include <array>
 #include <cctype>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
+#include <string>
 #include <nlohmann/json.hpp>
 #include <unordered_set>
 
@@ -427,7 +430,7 @@ void GUI::menu_bar_()
       m_open_about_popup = true;
 
     if (ImGui::MenuItem("Usage Guide"))
-      open_url_("https://github.com/trailcode/EzyCad/blob/main/usage.md");
+      open_packaged_doc_or_url_("usage.md", nullptr, "https://github.com/trailcode/EzyCad/blob/main/usage.md");
 
     ImGui::EndMenu();
   }
@@ -508,6 +511,55 @@ void GUI::update_window_title_()
 
   m_cached_window_title = title;
   glfwSetWindowTitle(m_glfw_window, m_cached_window_title.c_str());
+}
+
+namespace
+{
+
+void open_local_file_default_app_(const std::filesystem::path& p)
+{
+#ifndef __EMSCRIPTEN__
+  std::error_code ec;
+  if (!std::filesystem::exists(p, ec))
+    return;
+
+#  ifdef _WIN32
+  std::string cmd = std::string("start \"\" \"") + p.string() + "\"";
+#  elif defined(__APPLE__)
+  std::string cmd = std::string("open \"") + p.string() + "\"";
+#  else
+  std::string cmd = std::string("xdg-open \"") + p.string() + "\"";
+#  endif
+  std::system(cmd.c_str());
+#else
+  (void) p;
+#endif
+}
+
+}  // namespace
+
+void GUI::open_packaged_doc_or_url_(const char* filename, const char* uri_fragment, const char* https_fallback)
+{
+#ifdef __EMSCRIPTEN__
+  (void) https_fallback;
+  std::string rel = std::string("res/doc/") + (filename ? filename : "");
+  if (uri_fragment && *uri_fragment)
+    rel += std::string("#") + uri_fragment;
+  EM_ASM({ window.open(new URL(UTF8ToString($0), window.location.href).href, '_blank'); }, rel.c_str());
+#else
+  const auto exe_dir = ezy::application_executable_directory();
+  if (exe_dir)
+  {
+    const std::filesystem::path p = *exe_dir / "res" / "doc" / filename;
+    std::error_code               ec;
+    if (std::filesystem::exists(p, ec))
+    {
+      open_local_file_default_app_(p);
+      return;
+    }
+  }
+  open_url_(https_fallback);
+#endif
 }
 
 void GUI::open_url_(const char* url)

--- a/src/gui.h
+++ b/src/gui.h
@@ -228,6 +228,9 @@ class GUI
   void                      persist_last_opened_project_path_(const std::string& path);
   std::string               serialized_project_json_() const;
   void                      open_url_(const char* url);
+  /// Prefer \c res/doc/\a filename next to the executable (offline); else open \a https_fallback in a browser.
+  void                      open_packaged_doc_or_url_(const char* filename, const char* uri_fragment,
+                                                       const char* https_fallback);
   void                      update_window_title_();
   [[nodiscard]] std::string project_title_segment_() const;
   /// Parses a float from manual dist/angle ImGui text fields (trimmed, full-string match).

--- a/src/gui.h
+++ b/src/gui.h
@@ -55,6 +55,10 @@ struct Example_file
 
 /// Default OCCT line-width scale for length dimensions when `edge_dim_line_width` is missing from settings JSON.
 inline constexpr float k_gui_edge_dim_line_width_default = 1.0f;
+/// Allowed range and default for `gui.view_roll_step_deg` (view roll hotkeys; must match Settings slider).
+inline constexpr double k_gui_view_roll_step_deg_min     = 0.1;
+inline constexpr double k_gui_view_roll_step_deg_max    = 180.0;
+inline constexpr double k_gui_view_roll_step_deg_default = 45.0;
 
 class GUI
 {
@@ -264,6 +268,8 @@ class GUI
   Fillet_mode                 m_fillet_mode  = Fillet_mode::Shape;
   int                         m_edge_dim_label_h {3};  // Prs3d_DTHP_Fit
   float                       m_edge_dim_line_width {k_gui_edge_dim_line_width_default};
+  /// Degrees per Blender-style view roll key (Shift+NumPad 4 / 6); persisted in `gui.view_roll_step_deg`.
+  double                      m_view_roll_step_deg {k_gui_view_roll_step_deg_default};
   std::vector<Toolbar_button> m_toolbar_buttons;
 
   // Message status window

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -101,6 +101,14 @@ void GUI::on_key(int key, int scancode, int action, int mods)
   if (action != GLFW_PRESS)
     return;
 
+  // Blender-style view roll: Shift + NumPad 4 (CCW) / NumPad 6 (CW) in model-dependent sense.
+  if ((mods & GLFW_MOD_SHIFT) != 0 && (key == GLFW_KEY_KP_4 || key == GLFW_KEY_KP_6))
+  {
+    const double step = m_view_roll_step_deg;
+    m_view->roll_view_z_deg(key == GLFW_KEY_KP_4 ? -step : step);
+    return;
+  }
+
   const ScreenCoords screen_coords(dvec2(ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y));
 
   bool ctrl_pressed = (mods & GLFW_MOD_CONTROL) != 0;

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -14,9 +14,6 @@
 namespace
 {
 const char* const k_settings_version = "1";
-/// usage.md on GitHub, ### View roll (same host as Help -> Usage Guide).
-const char* const k_usage_view_roll_url =
-    "https://github.com/trailcode/EzyCad/blob/main/usage.md#view-roll";
 
 /// `occt_view` JSON object: view background gradient and grid (shared with `save_occt_view_settings` / `occt_view_settings_json`).
 nlohmann::json build_occt_view_settings_object(const Occt_view& view)
@@ -345,9 +342,9 @@ void GUI::settings_()
 
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       if (ImGui::SmallButton("?##view_roll_help"))
-        open_url_(k_usage_view_roll_url);
+        open_packaged_doc_or_url_("usage.md", "view-roll", "https://github.com/trailcode/EzyCad/blob/main/usage.md#view-roll");
       if (ImGui::IsItemHovered())
-        ImGui::SetTooltip("Help: view roll (opens usage.md in your browser).");
+        ImGui::SetTooltip("Help: view roll (packaged res/doc/usage.md when available, else browser).");
 
       ImGui::EndTable();
     }

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 #include <sstream>
 
+#include "dbg.h"
 #include "gui.h"
 #include "imgui.h"
 #include "occt_view.h"
@@ -13,6 +14,9 @@
 namespace
 {
 const char* const k_settings_version = "1";
+/// usage.md on GitHub, ### View roll (same host as Help -> Usage Guide).
+const char* const k_usage_view_roll_url =
+    "https://github.com/trailcode/EzyCad/blob/main/usage.md#view-roll";
 
 /// `occt_view` JSON object: view background gradient and grid (shared with `save_occt_view_settings` / `occt_view_settings_json`).
 nlohmann::json build_occt_view_settings_object(const Occt_view& view)
@@ -40,6 +44,7 @@ std::string GUI::occt_view_settings_json() const
   j["gui"]       = {
       {   "edge_dim_label_h",    m_edge_dim_label_h},
       {"edge_dim_line_width", m_edge_dim_line_width},
+      {  "view_roll_step_deg",    m_view_roll_step_deg},
   };
   return j.dump(2);
 }
@@ -77,6 +82,7 @@ void GUI::save_occt_view_settings()
       {     "imgui_rounding_general",                                       m_imgui_rounding_general},
       {      "imgui_rounding_scroll",                                        m_imgui_rounding_scroll},
       {        "imgui_rounding_tabs",                                          m_imgui_rounding_tabs},
+      {        "view_roll_step_deg",                                        m_view_roll_step_deg},
 #ifndef NDEBUG
       {                   "show_dbg",                                                     m_show_dbg},
 #endif
@@ -197,6 +203,15 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
     m_imgui_rounding_scroll  = round_from_json("imgui_rounding_scroll", fb_scroll);
     m_imgui_rounding_tabs    = round_from_json("imgui_rounding_tabs", fb_tabs);
 
+    m_view_roll_step_deg = k_gui_view_roll_step_deg_default;
+    if (g.contains("view_roll_step_deg") && g["view_roll_step_deg"].is_number())
+    {
+      const double v = g["view_roll_step_deg"].get<double>();
+      EZY_ASSERT_MSG(v >= k_gui_view_roll_step_deg_min && v <= k_gui_view_roll_step_deg_max,
+                     "settings gui.view_roll_step_deg out of range [0.1, 180]");
+      m_view_roll_step_deg = v;
+    }
+
     if (g.contains("underlay_highlight_color") && g["underlay_highlight_color"].is_array() && g["underlay_highlight_color"].size() >= 3)
     {
       const json& a = g["underlay_highlight_color"];
@@ -303,6 +318,43 @@ void GUI::settings_()
 
   if (ImGui::Checkbox("Dark mode", &m_dark_mode))
     save_occt_view_settings();
+
+  if (ImGui::CollapsingHeader("3D view navigation", ImGuiTreeNodeFlags_DefaultOpen))
+  {
+    if (ImGui::BeginTable("settings_view_nav", 2, ImGuiTableFlags_SizingStretchProp))
+    {
+      ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, k_label_col_w);
+      ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::AlignTextToFramePadding();
+      ImGui::TextUnformatted("View roll step");
+      ImGui::TableSetColumnIndex(1);
+      // SliderScalar(ImGuiDataType_Double): drag slider, or Ctrl+click for precise keyboard input (standard ImGui).
+      if (ImGui::SliderScalar("##view_roll_step", ImGuiDataType_Double, &m_view_roll_step_deg,
+                              &k_gui_view_roll_step_deg_min, &k_gui_view_roll_step_deg_max, "%.2f deg",
+                              ImGuiSliderFlags_AlwaysClamp | ImGuiSliderFlags_ClampOnInput))
+        save_occt_view_settings();
+      m_view_roll_step_deg =
+          std::clamp(m_view_roll_step_deg, k_gui_view_roll_step_deg_min, k_gui_view_roll_step_deg_max);
+
+      if (ImGui::IsItemHovered())
+        ImGui::SetTooltip(
+            "Degrees per key press (Shift+NumPad 4 / Shift+NumPad 6). Ctrl+click the slider to type a value.");
+
+      ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+      if (ImGui::SmallButton("?##view_roll_help"))
+        open_url_(k_usage_view_roll_url);
+      if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Help: view roll (opens usage.md in your browser).");
+
+      ImGui::EndTable();
+    }
+
+    ImGui::TextWrapped(
+        "Blender-style view roll: hold Shift and press NumPad 4 or NumPad 6 to roll the view around the screen Z axis.");
+  }
 
   if (ImGui::CollapsingHeader("UI corner rounding"))
   {

--- a/src/lua_console.cpp
+++ b/src/lua_console.cpp
@@ -350,7 +350,7 @@ int l_ezy_help(lua_State* L)
       "  ezy.get_mode()                - return current mode name\n"
       "  ezy.set_mode(name)            - set mode by name\n"
       "  ezy.save_occt_view_settings() - write settings JSON (incl. view colors)\n"
-      "  ezy.occt_view_settings_json() - JSON: occt_view + gui edge_dim_label_h / edge_dim_line_width\n"
+      "  ezy.occt_view_settings_json() - JSON: occt_view + gui edge_dim_*, view_roll_step_deg\n"
       "  ezy.help()                    - print this help\n"
       "view:\n"
       "  view.sketch_count()           - number of sketches\n"

--- a/src/occt_view.cpp
+++ b/src/occt_view.cpp
@@ -24,6 +24,7 @@
 #include <TopExp_Explorer.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Compound.hxx>
+#include <V3d_TypeOfAxe.hxx>
 #include <V3d_View.hxx>
 #include <WNT_WClass.hxx>
 #include <WNT_Window.hxx>
@@ -283,6 +284,15 @@ void Occt_view::init_viewer()
   // m_view->SetTextureEnv(env_map);
 
   m_default_material = Graphic3d_MaterialAspect(Graphic3d_NOM_CHROME);
+}
+
+void Occt_view::roll_view_z_deg(double degrees)
+{
+  if (m_view.IsNull())
+    return;
+
+  m_view->Turn(V3d_Z, to_radians(degrees), Standard_True);
+  m_view->Redraw();
 }
 
 void Occt_view::init_default()

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -173,6 +173,9 @@ class Occt_view : protected AIS_ViewController
   bool get_camera(gp_Pnt& out_eye, gp_Pnt& out_center, gp_Dir& out_up) const;
   void set_camera(const gp_Pnt& eye, const gp_Pnt& center, const gp_Dir& up);
 
+  /// Roll the view about screen Z (view depth axis) by \a degrees, via \c V3d_View::Turn(\c V3d_Z, ...).
+  void roll_view_z_deg(double degrees);
+
   GUI&                    gui();
   AIS_InteractiveContext& ctx();
 

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -1,0 +1,52 @@
+#include "paths.h"
+
+#include <vector>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+
+namespace ezy
+{
+std::optional<std::filesystem::path> application_executable_directory()
+{
+#if defined(_WIN32)
+  std::vector<wchar_t> buf(MAX_PATH);
+  for (;;)
+  {
+    DWORD n = GetModuleFileNameW(nullptr, buf.data(), static_cast<DWORD>(buf.size()));
+    if (n == 0)
+      return std::nullopt;
+    if (n < buf.size())
+      return std::filesystem::path(buf.data()).parent_path();
+
+    buf.resize(buf.size() * 2);
+  }
+#elif defined(__APPLE__)
+  uint32_t sz = 0;
+  _NSGetExecutablePath(nullptr, &sz);
+  if (sz == 0)
+    return std::nullopt;
+  std::vector<char> buf(sz);
+  if (_NSGetExecutablePath(buf.data(), &sz) != 0)
+    return std::nullopt;
+  std::error_code ec;
+  auto            canon = std::filesystem::canonical(std::string(buf.data()), ec);
+  if (ec)
+    return std::nullopt;
+  return canon.parent_path();
+#elif defined(__linux__)
+  std::error_code ec;
+  auto            link = std::filesystem::read_symlink("/proc/self/exe", ec);
+  if (ec)
+    return std::nullopt;
+  return link.parent_path();
+#else
+  return std::nullopt;
+#endif
+}
+
+}  // namespace ezy

--- a/src/paths.h
+++ b/src/paths.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+
+namespace ezy
+{
+/// Directory containing the running executable, if detectable; empty on failure.
+std::optional<std::filesystem::path> application_executable_directory();
+}  // namespace ezy

--- a/src/python_console.cpp
+++ b/src/python_console.cpp
@@ -222,7 +222,7 @@ PYBIND11_EMBEDDED_MODULE(ezycad_native, m)
             "  ezy.get_mode()                - return current mode name\n"
             "  ezy.set_mode(name)            - set mode by name\n"
             "  ezy.save_occt_view_settings() - write settings JSON (incl. view colors)\n"
-            "  ezy.occt_view_settings_json() - JSON: occt_view + gui edge_dim_label_h / edge_dim_line_width\n"
+            "  ezy.occt_view_settings_json() - JSON: occt_view + gui edge_dim_*, view_roll_step_deg\n"
             "  ezy.help()            - print this help\n"
             "view:\n"
             "  view.sketch_count()          - number of sketches\n"

--- a/src/sketch_underlay.h
+++ b/src/sketch_underlay.h
@@ -42,55 +42,24 @@ class Sketch_underlay
   /// When true (default), bright pixels (white paper) become transparent in the texture; dark linework stays opaque.
   void set_key_white_transparent(bool on);
 
-  [[nodiscard]] bool key_white_transparent() const
-  {
-    return m_key_white_transparent;
-  }
-
   void set_line_tint_enabled(bool on);
   void set_line_tint_rgb(uint8_t r, uint8_t g, uint8_t b);
 
-  [[nodiscard]] bool line_tint_enabled() const
-  {
-    return m_line_tint_enabled;
-  }
-
   void line_tint_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const;
 
-  [[nodiscard]] float opacity() const
-  {
-    return m_opacity;
-  }
+  // clang-format off
 
-  [[nodiscard]] bool visible() const
-  {
-    return m_visible;
-  }
+  [[nodiscard]] bool     key_white_transparent() const { return m_key_white_transparent; }
+  [[nodiscard]] bool     line_tint_enabled()     const { return m_line_tint_enabled; }
+  [[nodiscard]] float    opacity()               const { return m_opacity; }
+  [[nodiscard]] bool     visible()               const { return m_visible; }
+  [[nodiscard]] gp_Pnt2d base()                  const { return m_base; }
+  [[nodiscard]] gp_Vec2d axis_u()                const { return m_axis_u; }
+  [[nodiscard]] gp_Vec2d axis_v()                const { return m_axis_v; }
+  [[nodiscard]] int      image_w()               const { return m_w; }
+  [[nodiscard]] int      image_h()               const { return m_h; }
 
-  [[nodiscard]] gp_Pnt2d base() const
-  {
-    return m_base;
-  }
-
-  [[nodiscard]] gp_Vec2d axis_u() const
-  {
-    return m_axis_u;
-  }
-
-  [[nodiscard]] gp_Vec2d axis_v() const
-  {
-    return m_axis_v;
-  }
-
-  [[nodiscard]] int image_w() const
-  {
-    return m_w;
-  }
-
-  [[nodiscard]] int image_h() const
-  {
-    return m_h;
-  }
+  // clang-format on
 
   void rebuild_and_display(const gp_Pln& pln, AIS_InteractiveContext& ctx);
   void erase(AIS_InteractiveContext& ctx);

--- a/usage-occt-view.md
+++ b/usage-occt-view.md
@@ -1,0 +1,48 @@
+# 3D viewer: Open CASCADE and `Occt_view`
+
+This page summarizes how EzyCad's 3D viewport relates to **Open CASCADE Technology (OCCT)** and how the **`Occt_view`** C++ class fits in. For everyday use (mouse, view roll, settings), start with **[usage.md](usage.md)** ([View Controls](usage.md#view-controls)) and **[usage-settings.md](usage-settings.md)**.
+
+## Stack at a glance
+
+| Piece | Role |
+| --- | --- |
+| **`V3d_View`** | OCCT 3D view: camera, projection, redraw. EzyCad keeps a `V3d_View` and drives pan/orbit/zoom through the interactive layer. |
+| **`AIS_InteractiveContext`** | Displays `AIS_InteractiveObject` instances (e.g. `AIS_Shape`), selection, and view updates. |
+| **`AIS_ViewController`** | OCCT helper for mouse-driven navigation; **`Occt_view`** subclasses it and forwards GLFW input (`on_mouse_*`, scroll, resize). |
+| **`Occt_view`** | Application facade: document shapes and sketches, modes, undo/redo serialization, import/export, dimensions, and wrappers such as **`roll_view_z_deg`** (implemented with `V3d_View::Turn(..., V3d_Z, ...)`). |
+
+The on-screen **triedron** and **view cube** (if enabled) are standard OCCT viewer features configured during **`Occt_view::init_default()`** and related setup.
+
+## User-facing behavior
+
+- **Mouse:** orbit (left drag), pan (middle drag), zoom (right drag or wheel), as described in [View Controls](usage.md#view-controls).
+- **View roll:** **Shift+NumPad 4** / **Shift+NumPad 6** with step stored as **`gui.view_roll_step_deg`** (default **45** degrees). See [usage.md -> View roll](usage.md#view-roll).
+
+## Settings on disk
+
+3D **appearance** (background gradient, grid line colors, gradient mode) lives under JSON **`occt_view`**. **View roll step** is under **`gui`** because it is edited in **Settings -> 3D view navigation**, not inside the OCCT appearance blob.
+
+Full key lists: **[usage-settings.md -> Settings file reference](usage-settings.md#settings-file-reference)** (`occt_view` and `gui` tables). **`view_roll_step_deg`** is documented there.
+
+The scripting helper **`ezy.occt_view_settings_json()`** returns a small JSON fragment including **`occt_view`** and selected **`gui`** keys (see [scripting.md](scripting.md)); it may not include every `gui` field.
+
+## `Occt_view` class (developers)
+
+Source: **`src/occt_view.h`** (implementation **`src/occt_view.cpp`**).
+
+**Occt_view** is the main entry point from **`GUI`** for everything tied to the 3D scene:
+
+- **Lifecycle:** `init_window`, `init_viewer`, `init_default`, `do_frame`, `flush_view_events`, `cleanup`.
+- **Document:** `to_json` / `load`, undo/redo, `new_file`, import/export helpers.
+- **Sketches and shapes:** accessors, add primitives, sketch extrude entry, selection and delete.
+- **Tool operations:** references to `Shp_move`, `Shp_rotate`, `Shp_extrude`, booleans, chamfer/fillet, etc.
+- **Camera / view:** `get_camera` / `set_camera`, **`roll_view_z_deg`**, `fit_face_in_view`, `get_view_plane`, ray-based queries for sketch and dimensions.
+- **Viewer chrome:** background and grid colors (`get_*` / `set_*` for gradient and grid); headless flag.
+
+Private helpers manage AIS display, hit testing, and OCCT event mapping; **`m_view`** is the underlying **`V3d_View`**.
+
+For API experiments or bindings, prefer extending **`Occt_view`** or **`GUI`** so OCCT types stay localized.
+
+---
+
+[Back to usage guide](usage.md) | [Settings](usage-settings.md)

--- a/usage-settings.md
+++ b/usage-settings.md
@@ -38,17 +38,19 @@ Open **View -> Settings**. The window title is **Settings**.
 - **Dark mode** — checkbox at the top (not inside a collapsible section).
 - At the bottom: **Defaults** — reloads bundled defaults from the app `res/` tree (including ImGui layout from that file).
 
-Between those, the pane has **five** collapsible sections. Expand a section to see its controls; when collapsed, only the section title bar is visible.
+Between those, the pane has **six** collapsible sections. Expand a section to see its controls; when collapsed, only the section title bar is visible.
 
-1. **UI corner rounding** — Sliders **0** to **16** for **Windows, frames, popups**; **Scrollbars and sliders** (has `(?)`); **Tabs**.
+1. **3D view navigation** — **View roll step** (degrees per key press for **Shift+NumPad 4** / **Shift+NumPad 6**; default **45**). Stored as **`gui.view_roll_step_deg`**. See [usage.md -> View roll](usage.md#view-roll) and **[usage-occt-view.md](usage-occt-view.md)**.
 
-2. **3D view background** — **Background color 1** and **Background color 2** (float RGB fields and swatches). **Gradient blend** — combo: **Horizontal**, **Vertical**, **Diagonal 1**, **Diagonal 2**, **Corner 1** … **Corner 4**.
+2. **UI corner rounding** — Sliders **0** to **16** for **Windows, frames, popups**; **Scrollbars and sliders** (has `(?)`); **Tabs**.
 
-3. **3D view grid** — **Fine grid lines** and **Major grid lines** (passed to Open CASCADE `Aspect_Grid::SetColors`: dense lines vs every-tenth emphasis lines). **Grid plane fill** — tint for a large XY plane slightly below z=0 so the ground area can differ from the sky gradient (see `(?)` in app). This third color is not part of OCCT grid line rendering.
+3. **3D view background** — **Background color 1** and **Background color 2** (float RGB fields and swatches). **Gradient blend** — combo: **Horizontal**, **Vertical**, **Diagonal 1**, **Diagonal 2**, **Corner 1** … **Corner 4**.
 
-4. **Sketch** — **Dimension line width** — slider **0.5** to **8.0** (has `(?)`). **Underlay highlight color** — RGB (has `(?)`).
+4. **3D view grid** — **Fine grid lines** and **Major grid lines** (passed to Open CASCADE `Aspect_Grid::SetColors`: dense lines vs every-tenth emphasis lines). **Grid plane fill** — tint for a large XY plane slightly below z=0 so the ground area can differ from the sky gradient (see `(?)` in app). This third color is not part of OCCT grid line rendering.
 
-5. **Startup project** — **Desktop only:** **Load last opened on startup** (checkbox, with `(?)`), then **Last opened path:** … or **(No path saved yet.)** Then **Save current as startup project**, **Clear saved startup** (with `(?)`). **WebAssembly:** no load-last row; only the two buttons and `(?)`. See [Startup project](#startup-project).
+5. **Sketch** — **Dimension line width** — slider **0.5** to **8.0** (has `(?)`). **Underlay highlight color** — RGB (has `(?)`).
+
+6. **Startup project** — **Desktop only:** **Load last opened on startup** (checkbox, with `(?)`), then **Last opened path:** … or **(No path saved yet.)** Then **Save current as startup project**, **Clear saved startup** (with `(?)`). **WebAssembly:** no load-last row; only the two buttons and `(?)`. See [Startup project](#startup-project).
 
 **Not in this pane**
 
@@ -130,11 +132,12 @@ String: ImGui `.ini` text for window positions and docking saved with **SaveIniS
 | `imgui_rounding_scroll` | number | Scrollbar and grab rounding (same clamp). |
 | `imgui_rounding_tabs` | number | Tab rounding (same clamp). |
 | `underlay_highlight_color` | array of 3 numbers | Default underlay tint (float RGB **0** to **1** per channel). |
+| `view_roll_step_deg` | number | Degrees per **Shift+NumPad 4** / **Shift+NumPad 6** view roll (allowed range **0.1** to **180** in code; default **45**). |
 | `load_last_opened_on_startup` | boolean | Desktop: open the last `.ezy` on launch. **Legacy:** `load_last_saved_on_startup` is read as a fallback if the newer key is absent. |
 | `last_opened_project_path` | string | Path of the last opened project for the option above. **Legacy:** `last_saved_project_path` is accepted if the newer key is missing. |
 
-Scripting API **`ezy.occt_view_settings_json()`** returns a JSON string with **`occt_view`** plus **`gui.edge_dim_label_h`** and **`gui.edge_dim_line_width`** (same keys as in this section). See [scripting.md](scripting.md).
+Scripting API **`ezy.occt_view_settings_json()`** returns a JSON string with **`occt_view`** plus selected **`gui`** keys (including **`gui.edge_dim_label_h`**, **`gui.edge_dim_line_width`**, **`gui.view_roll_step_deg`** when saved). See [scripting.md](scripting.md).
 
 ---
 
-For general workflows and tools, see [usage.md](usage.md). For 2D sketching, see [usage-sketch.md](usage-sketch.md).
+For general workflows and tools, see [usage.md](usage.md). For the OCCT viewer layer and **`Occt_view`**, see **[usage-occt-view.md](usage-occt-view.md)**. For 2D sketching, see [usage-sketch.md](usage-sketch.md).

--- a/usage.md
+++ b/usage.md
@@ -9,11 +9,12 @@
 6.  [Modeling Tools](#modeling-tools)
 7.  [Keyboard Shortcuts](#keyboard-shortcuts)
 8.  [View Controls](#view-controls)
-9.  [Tips and Tricks](#tips-and-tricks)
-10. [Scripting](#scripting-lua-and-python)
-11. [Support](#support)
-12. [Tool Icons](#tool-icons)
-13. [Settings](usage-settings.md)
+9.  [3D viewer (`Occt_view` / Open CASCADE)](usage-occt-view.md)
+10. [Tips and Tricks](#tips-and-tricks)
+11. [Scripting](#scripting-lua-and-python)
+12. [Support](#support)
+13. [Tool Icons](#tool-icons)
+14. [Settings](usage-settings.md)
 
 ## Introduction
 
@@ -515,6 +516,15 @@ The polar duplicate tool allows you to create multiple copies of selected shapes
 | <kbd>E</kbd> | Extrude mode |
 | <kbd>D</kbd> | Delete selected |
 
+### View navigation
+
+| | |
+| ---: | --- |
+| <kbd>Shift</kbd>+<kbd>NumPad 4</kbd> | [Roll the 3D view](#view-roll) one way (step in **Settings -> 3D view navigation**; default **45** degrees). |
+| <kbd>Shift</kbd>+<kbd>NumPad 6</kbd> | [Roll the 3D view](#view-roll) the other way. |
+
+Same idea as Blender **View Roll**. Plain **<kbd>NumPad 4</kbd>** / **<kbd>6</kbd>** without **Shift** are not view roll (in **Normal** mode, number keys set [selection filter](#shape-selection-filter-normal-mode-only)).
+
 ### Shape selection filter (Normal mode only)
 
 In **Normal** mode, number keys set the **Selection Mode** filter for picking 3D shapes (same control as **Options -> Selection Mode**). Main keyboard **<kbd>1</kbd>-<kbd>9</kbd>** and keypad **<kbd>1</kbd>-<kbd>9</kbd>** are supported. Order matches Open CASCADE `TopAbs_ShapeEnum` (see `utl_occt.h` / combo labels):
@@ -548,6 +558,14 @@ Open or close the **Lua** or **Python** consoles from **View -> Lua Console** or
 | **Middle drag** | Pan view |
 | **Right drag** | Zoom |
 | **Scroll Wheel** | Zoom in/out |
+
+### View roll
+
+Hold **Shift** and press **NumPad 4** or **NumPad 6** to rotate the view around the viewing axis (the axis pointing out of the screen), in fixed degree steps. The default step is **45** degrees per key press.
+
+To change the step, open **View -> Settings**, expand **3D view navigation**, and adjust **View roll step**. The value is saved in your settings file as **`gui.view_roll_step_deg`** (see [Settings file reference](usage-settings.md#settings-file-reference)).
+
+Implementation note: the application calls Open CASCADE `V3d_View::Turn` with `V3d_Z` for this rotation. More detail: **[3D viewer (`Occt_view`)](usage-occt-view.md)**.
 
 ### View Options
 
@@ -585,6 +603,7 @@ Open or close the **Lua** or **Python** consoles from **View -> Lua Console** or
 ### Documentation
 - [This usage guide](#ezycad-usage-guide)
 - [Settings](usage-settings.md) (Settings pane, View menu, JSON settings file, startup project)
+- [3D viewer (`Occt_view` / Open CASCADE)](usage-occt-view.md) (viewer stack, `Occt_view` role, settings keys)
 - [2D Sketching](usage-sketch.md) (including [add node](usage-sketch.md#add-node-tool))
 - [Scripting (Lua / Python)](scripting.md)
 - Hosted docs and video tutorials are not published yet; this repository's markdown guides are the reference for now.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds new global hotkey handling and introduces platform-specific `system()` calls to open local documentation files, plus build changes that affect packaging/preloading of resources.
> 
> **Overview**
> Adds **Blender-style view roll**: `Shift+NumPad 4/6` now rotates the 3D view by a configurable step, persisted as `gui.view_roll_step_deg` (default **45°**) and exposed in **Settings → 3D view navigation**.
> 
> Introduces **offline help packaging**: Markdown docs/licenses are copied (native) or preloaded (Emscripten) into `res/doc/`, and **Help → Usage Guide** (plus the new `?` help next to the roll setting) opens the packaged file when available, otherwise falling back to GitHub.
> 
> Adds supporting infrastructure: `Occt_view::roll_view_z_deg`, an executable-directory helper in `paths.*`, updates default settings JSON and scripting help text, and includes new documentation (`usage-occt-view.md`) plus a couple of repo-local issue drafts and a small PDF-to-PNG conversion script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739cae922a3800893762bd73e07fc3ea16f612b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->