### PR TITLE
UI improvements for sketch/shape lists and coding style guidance

### DIFF
--- a/agents/issues/002-emscripten-pr97-web-hotkeys.md
+++ b/agents/issues/002-emscripten-pr97-web-hotkeys.md
@@ -1,0 +1,48 @@
+# [Draft] Emscripten / Web: 3D view hotkeys and input (follow-up to PR #97)
+
+**Opened on GitHub from this draft.** Suggested labels: `bug`, `platform: web` (or `emscripten` if you use that label)
+
+**Parent / context:** [PR #97 — 3D view hotkeys, settings, About, tooling, docs](https://github.com/trailcode/EzyCad/pull/97)
+
+---
+
+## Title (GitHub)
+
+Emscripten / Web: 3D view hotkeys and keyboard input bugs (follow-up to PR #97)
+
+## Body (GitHub)
+
+### Summary
+
+The **Emscripten (Web / WASM)** build is called out on [PR #97](https://github.com/trailcode/EzyCad/pull/97) as having **bugs** around the new **3D view hotkeys**; navigation is partly **exposed via the toolbar** instead of full keyboard parity with the desktop build.
+
+This issue tracks **making Web behavior correct and documented**, not blocking the desktop PR.
+
+### Scope
+
+- **Keyboard 3D navigation** on Web: numpad orbit, roll, zoom, axis snap — whatever GLFW/browser key routing supports under Emscripten.
+- **Consistency** with `usage.md` / `usage-occt-view.md` (clearly mark Web limitations or fix behavior).
+- **Regression checks** for existing `#ifdef __EMSCRIPTEN__` paths in `src/gui.cpp`, `src/gui_settings.cpp`, `src/gui_mode.cpp`, `CMakeLists.txt`, etc.
+
+### Known gaps (fill in as you reproduce)
+
+- [ ] Document concrete failures (e.g. keys swallowed, wrong modifiers, no repeat, focus).
+- [ ] Toolbar vs keyboard: intended UX for Web until keys are fixed.
+
+### Acceptance criteria
+
+- [ ] Either **Web matches documented desktop shortcuts** where technically feasible, or **docs + UI** state what works on Web and why.
+- [ ] PR #97 (or a small follow-up PR) **updates the testing checklist** so Emscripten is not an vague “if applicable” line.
+- [ ] No **silent** broken shortcuts: if a key does nothing on Web, users see a hint (docs or in-app).
+
+### Links
+
+- PR: https://github.com/trailcode/EzyCad/pull/97
+- Related umbrella: https://github.com/trailcode/EzyCad/issues/93 (hot keys)
+
+---
+
+## Metadata (do not paste into GitHub)
+
+- Draft path: `agents/issues/002-emscripten-pr97-web-hotkeys.md`
+- Repo: `trailcode/EzyCad`

--- a/agents/issues/003-ui-improvements-sketch-shape-lists-and-style.md
+++ b/agents/issues/003-ui-improvements-sketch-shape-lists-and-style.md
@@ -1,0 +1,61 @@
+# [Draft] UI improvements: Sketch/Shape list behavior and coding-style guidance
+
+**Opened on GitHub from this draft.** Suggested labels: `enhancement`, `ui`, `docs`
+
+**Branch / context:** `Trailcode/ui_improvements` (base: `main`)
+
+---
+
+## Title (GitHub)
+
+UI improvements: Sketch/Shape list behavior and coding-style guidance
+
+## Body (GitHub)
+
+### Summary
+
+This issue tracks follow-up and visibility for recent UI and style-guidance improvements from `Trailcode/ui_improvements`.
+
+The branch improves list-pane usability in the GUI and clarifies coding-style guidance around reader-first organization and pragmatic DRY.
+
+### Implemented scope (for tracking)
+
+- Sketch List: selecting a sketch in the list switches GUI to sketch inspection mode.
+- Sketch List and Shape List: improved narrow-width behavior with horizontal-scroll list content.
+- Name field sizing: shared helper for list name input width (`GUI::list_name_field_width_`), used consistently by both lists.
+- Readability/style updates:
+  - Reader-first/top-down organization guidance for `.cpp` files.
+  - Helper placement and local declaration guidance (near first use).
+  - DRY guidance added as important but non-dogmatic.
+
+### Why this matters
+
+- Better day-to-day usability of Sketch/Shape list panes.
+- More consistent UI behavior between both list panes.
+- Clearer team guidance to reduce over-abstraction and keep code readable.
+
+### Files touched (branch vs main)
+
+- `src/gui.cpp`
+- `src/gui.h`
+- `src/gui_settings.cpp`
+- `ezycad_code_style.md`
+
+### Acceptance criteria
+
+- [ ] Sketch List selection reliably enters sketch inspection mode.
+- [ ] Sketch and Shape list panes behave consistently when resized narrow.
+- [ ] Shared name-width logic remains centralized in one helper.
+- [ ] Coding-style doc clearly captures reader-first ordering and pragmatic DRY guidance.
+- [ ] `.cursor` rule mirrors the updated style guidance on contributor machines.
+
+### Links
+
+- Compare: https://github.com/trailcode/EzyCad/compare/main...Trailcode/ui_improvements
+
+---
+
+## Metadata (do not paste into GitHub)
+
+- Draft path: `agents/issues/003-ui-improvements-sketch-shape-lists-and-style.md`
+- Repo: `trailcode/EzyCad`

--- a/agents/prs/001-ui-improvements-sketch-shape-lists.md
+++ b/agents/prs/001-ui-improvements-sketch-shape-lists.md
@@ -1,0 +1,40 @@
+# PR - `Trailcode/ui_improvements`
+
+## Title
+
+UI improvements for sketch/shape lists and coding style guidance
+
+## Summary
+
+- Make Sketch List selection switch GUI into `Sketch_inspection_mode`.
+- Improve Sketch List and Shape List behavior in narrow panes (horizontal-scroll content and aligned name-field width handling).
+- Refactor shared list name-width logic into `GUI::list_name_field_width_`.
+- Update style docs and Cursor rule guidance for reader-first `.cpp` organization, helper placement near use, and pragmatic DRY guidance.
+- Add issue drafts for branch context and follow-up tracking.
+
+## Files Changed
+
+- `src/gui.cpp`
+- `src/gui.h`
+- `src/gui_settings.cpp`
+- `ezycad_code_style.md`
+- `.cursor/rules/ezycad_code_style.mdc`
+- `agents/issues/003-ui-improvements-sketch-shape-lists-and-style.md`
+
+## Related
+
+- Issue: https://github.com/trailcode/EzyCad/issues/98
+- Compare: https://github.com/trailcode/EzyCad/compare/main...Trailcode/ui_improvements
+
+## Test Plan
+
+- [x] Build `EzyCad_lib` in Release config.
+- [ ] In Sketch List, click a sketch row selector and verify mode becomes sketch inspection.
+- [ ] Resize Sketch List very narrow and verify controls remain reachable via horizontal scroll.
+- [ ] Resize Shape List very narrow and verify controls remain reachable via horizontal scroll.
+- [ ] Rename sketches and shapes with short and long names; verify input widths are usable and consistent.
+- [ ] Verify no ImGui ID-stack warnings appear while interacting with both lists.
+
+## Notes
+
+- There is an unrelated untracked directory in this branch workspace: `third_party/ImGuiColorTextEdit/`.

--- a/ezycad_code_style.md
+++ b/ezycad_code_style.md
@@ -40,10 +40,21 @@ Use this style when editing or adding C/C++ code in the EzyCad project (files un
 
 ## Code organization
 
+- **Reader-first order** (`.cpp`): Arrange functions from high-level behavior to lower-level detail so the first screen shows the primary workflow before helper details.
+- **Helper placement**: Prefer keeping narrow file-local helpers close to the functions that use them. Avoid large top-of-file helper blocks unless helpers are broadly reused across the file.
 - **Templates**: Prefer putting template implementations in `.inl` files included from the header (e.g. `types.inl`, `utl.inl`).
 - **OCCT handles**: Use `opencascade::handle<T>` and project aliases (e.g. `AIS_Shape_ptr`, `Shp_ptr`).
 - **Result/error handling**: See **Fail fast** below. Use `Result<T>` and `Status` from `utl.h`, `CHK_RET(...)` for early return on failure.
 - **Assertions**: See **Fail fast** below. Use `EZY_ASSERT` and `EZY_ASSERT_MSG` from `dbg.h`; use `DBG_MSG` for debug logging.
+
+## Don't Repeat Yourself (DRY)
+
+- DRY is important, but it is guidance, not a strict rule.
+- Avoid hasty abstractions: do not generalize too early before patterns are stable.
+- Too much DRY can increase coupling by forcing unrelated code through one shared abstraction.
+- Prefer readability over clever reuse when repetition is small and explicit code is clearer.
+- Context matters: stronger DRY is often good in monolith/shared-library code; some duplication can be healthier in fast-changing or separated systems.
+- Balance DRY with KISS, YAGNI, and overall cognitive load.
 
 ## Fail fast
 

--- a/ezycad_code_style.md
+++ b/ezycad_code_style.md
@@ -28,6 +28,7 @@ Use this style when editing or adding C/C++ code in the EzyCad project (files un
 - **Braces**: Opening brace for class/struct on the same line. For **control flow** (`if`, `for`, `while`, `switch`), put the opening brace on the **next line**. For functions, opening brace often on the next line; **short functions** (e.g. single return) may be on one line—`.clang-format` (AllowShortFunctionsOnASingleLine: All) does this automatically. `.clang-format` uses `BraceWrapping.AfterControlStatement: Always` to enforce control-statement brace placement.
 - **Alignment**: Align member declarations in columns when it aids readability (type and name aligned across lines in the same block).
 - **Initialization**: Prefer brace-initialization for members (e.g. `bool is_midpoint {false};`, `size_t m_prev_num_nodes {0};`).
+- **Local declarations**: Prefer declaring locals close to first use for readability. For values shared by a render block, compute them once immediately before that block.
 - **Short control flow**: Single-line `if`/`for` without braces is acceptable when the body is a single statement; use braces for multi-line or nested bodies.
 - Use **`// clang-format off`** / **`// clang-format on`** only where layout must be preserved (e.g. macro-like blocks, tables). Prefer running clang-format; it is the source of truth for formatting.
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -37,6 +37,18 @@ using namespace glm;
 
 GUI* gui_instance = nullptr;
 
+namespace
+{
+float list_name_field_width_(const ImGuiStyle& st, const float max_name_text_w)
+{
+  constexpr float k_name_field_cap   = 480.f;
+  // Keep names editable even when all names are short.
+  constexpr float k_name_field_floor = 72.f;
+  const float     name_pad_x         = st.FramePadding.x * 2.0f;
+  return std::clamp(max_name_text_w + name_pad_x, k_name_field_floor, k_name_field_cap);
+}
+}  // namespace
+
 GUI::GUI()
 {
   EZY_ASSERT(!gui_instance);
@@ -947,21 +959,6 @@ void GUI::sketch_list_()
         std::max(max_name_text_w, ImGui::CalcTextSize(nm.c_str(), nm.c_str() + nm.size()).x);
   }
 
-  constexpr float k_name_field_cap   = 480.f;
-  // Keep sketch names editable even when all names are short; also reused in row/window minimum width.
-  constexpr float k_name_field_floor = 72.f;
-  const float     name_pad_x         = st.FramePadding.x * 2.0f;
-  const float     name_field_w =
-      std::clamp(max_name_text_w + name_pad_x, k_name_field_floor, k_name_field_cap);
-
-  const float fh      = ImGui::GetFrameHeight();
-  const float props_w = ImGui::CalcTextSize("[P]").x + st.FramePadding.x * 2.0f;
-  const float row_min_w =
-      fh + st.ItemSpacing.x + k_name_field_floor + st.ItemSpacing.x + fh + st.ItemSpacing.x + fh +
-      st.ItemSpacing.x + props_w;
-  const float win_min_w = row_min_w + st.WindowPadding.x * 2.0f;
-  ImGui::SetNextWindowSizeConstraints(ImVec2(win_min_w, 0.f), ImVec2(FLT_MAX, FLT_MAX));
-
   if (!ImGui::Begin("Sketch List", &m_show_sketch_list, ImGuiWindowFlags_None))
   {
     ImGui::End();
@@ -969,6 +966,7 @@ void GUI::sketch_list_()
   }
 
   ImGui::BeginChild("##sketch_list_scroll", ImVec2(0.f, 0.f), false, ImGuiWindowFlags_HorizontalScrollbar);
+  const float name_field_w = list_name_field_width_(st, max_name_text_w);
 
   int                     index = 0;
   std::shared_ptr<Sketch> sketch_to_delete;
@@ -1005,10 +1003,8 @@ void GUI::sketch_list_()
     ImGui::PushID(("name" + id_suffix).c_str());
     ImGui::SetNextItemWidth(name_field_w);
     if (ImGui::InputText("", name_buffer, sizeof(name_buffer)))
-    {
       sketch->set_name(std::string(name_buffer));
-      std::cout << "Sketch " << index << " name changed to: " << sketch->get_name() << std::endl;
-    }
+
     // This will open a popup when you right-click on the InputText
     if (ImGui::BeginPopupContextItem("Sketch_InputTextContextMenu"))
     {
@@ -1720,21 +1716,31 @@ void GUI::shape_list_()
   if (!m_show_shape_list)
     return;
 
+  float max_name_text_w = 0.f;
+  for (const Shp_ptr& s : m_view->get_shapes())
+  {
+    EZY_ASSERT(s);
+    const std::string& nm = s->get_name();
+    max_name_text_w =
+        std::max(max_name_text_w, ImGui::CalcTextSize(nm.c_str(), nm.c_str() + nm.size()).x);
+  }
+
   if (!ImGui::Begin("Shape List", &m_show_shape_list, ImGuiWindowFlags_None))
   {
     ImGui::End();
     return;
   }
 
-  int index = 0;
+  ImGui::BeginChild("##shape_list_scroll", ImVec2(0.f, 0.f), false, ImGuiWindowFlags_HorizontalScrollbar);
+
+  const float name_field_w = list_name_field_width_(ImGui::GetStyle(), max_name_text_w);
+  int         index        = 0;
 
   // Add checkbox for hiding all shapes except current sketches
   if (ImGui::Checkbox("Hide all", &m_hide_all_shapes))
     // Update visibility of all shapes based on the new state
     for (const Shp_ptr& shape : m_view->get_shapes())
-    {
       shape->set_visible(!m_hide_all_shapes);
-    }
 
   ImGui::Separator();
 
@@ -1744,6 +1750,7 @@ void GUI::shape_list_()
   for (int mi = 0; mi < nmat; ++mi)
     mat_label_w_max =
         std::max(mat_label_w_max, ImGui::CalcTextSize(mat_names[static_cast<size_t>(mi)].c_str()).x);
+  
   const ImGuiStyle& st_mat      = ImGui::GetStyle();
   const float       mat_popup_w = std::min(
       440.0f,
@@ -1809,6 +1816,7 @@ void GUI::shape_list_()
     };
 
     ImGui::PushID(("name" + id_suffix).c_str());
+    ImGui::SetNextItemWidth(name_field_w);
     if (ImGui::InputText("", name_buffer, sizeof(name_buffer)))
       shape->set_name(std::string(name_buffer));
 
@@ -1902,6 +1910,7 @@ void GUI::shape_list_()
         ImGui::SetTooltip("Selected in 3D viewer");
     }
   }
+  ImGui::EndChild();
   ImGui::End();
 }
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -37,18 +37,6 @@ using namespace glm;
 
 GUI* gui_instance = nullptr;
 
-namespace
-{
-float list_name_field_width_(const ImGuiStyle& st, const float max_name_text_w)
-{
-  constexpr float k_name_field_cap   = 480.f;
-  // Keep names editable even when all names are short.
-  constexpr float k_name_field_floor = 72.f;
-  const float     name_pad_x         = st.FramePadding.x * 2.0f;
-  return std::clamp(max_name_text_w + name_pad_x, k_name_field_floor, k_name_field_cap);
-}
-}  // namespace
-
 GUI::GUI()
 {
   EZY_ASSERT(!gui_instance);
@@ -1912,6 +1900,15 @@ void GUI::shape_list_()
   }
   ImGui::EndChild();
   ImGui::End();
+}
+
+float GUI::list_name_field_width_(const ImGuiStyle& st, const float max_name_text_w)
+{
+  constexpr float k_name_field_cap   = 480.f;
+  // Keep names editable even when all names are short.
+  constexpr float k_name_field_floor = 72.f;
+  const float     name_pad_x         = st.FramePadding.x * 2.0f;
+  return std::clamp(max_name_text_w + name_pad_x, k_name_field_floor, k_name_field_cap);
 }
 
 #ifndef NDEBUG

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1,15 +1,15 @@
 #include "gui.h"
 
 #include <algorithm>
-#include <filesystem>
 #include <array>
 #include <cctype>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
-#include <string>
 #include <nlohmann/json.hpp>
+#include <string>
 #include <unordered_set>
 
 #include "settings.h"
@@ -451,18 +451,18 @@ void GUI::about_dialog_()
 
   ensure_about_assets_();
 
-  ImFont* font = ImGui::GetFont();
+  ImFont*               font = ImGui::GetFont();
   ImGui::MarkdownConfig md;
-  md.linkCallback    = about_markdown_link_cb_;
-  md.imageCallback   = about_markdown_image_cb_;
-  md.tooltipCallback = ImGui::defaultMarkdownTooltipCallback;
-  md.linkIcon        = "";
+  md.linkCallback      = about_markdown_link_cb_;
+  md.imageCallback     = about_markdown_image_cb_;
+  md.tooltipCallback   = ImGui::defaultMarkdownTooltipCallback;
+  md.linkIcon          = "";
   md.headingFormats[0] = {font, true};
   md.headingFormats[1] = {font, true};
   md.headingFormats[2] = {font, false};
 #ifdef IMGUI_HAS_TEXTURES
   {
-    float const fs = ImGui::GetFontSize();
+    float const fs                = ImGui::GetFontSize();
     md.headingFormats[0].fontSize = fs * 1.15f;
     md.headingFormats[1].fontSize = fs * 1.05f;
     md.headingFormats[2].fontSize = fs;
@@ -593,20 +593,20 @@ void GUI::ensure_about_assets_()
 
 ImGui::MarkdownImageData GUI::about_markdown_image_(ImGui::MarkdownLinkCallbackData data)
 {
-  ImGui::MarkdownImageData out{};
+  ImGui::MarkdownImageData out {};
   if (!data.isImage)
     return out;
 
   static constexpr char k_splash_id[] = "AI-gen-splashscreen_05_01_2026_512.png";
-  std::string id(data.link, data.linkLength);
+  std::string           id(data.link, data.linkLength);
   if (id != k_splash_id || m_about_splash_gl == 0)
     return out;
 
-  out.isValid           = true;
-  out.useLinkCallback   = false;
-  out.user_texture_id   = (ImTextureID)(intptr_t)m_about_splash_gl;
-  out.size              = ImVec2((float)m_about_splash_w, (float)m_about_splash_h);
-  ImVec2 const avail    = ImGui::GetContentRegionAvail();
+  out.isValid         = true;
+  out.useLinkCallback = false;
+  out.user_texture_id = (ImTextureID) (intptr_t) m_about_splash_gl;
+  out.size            = ImVec2((float) m_about_splash_w, (float) m_about_splash_h);
+  ImVec2 const avail  = ImGui::GetContentRegionAvail();
   if (out.size.x > avail.x && avail.x > 1.0f)
   {
     float const ratio = out.size.y / out.size.x;
@@ -937,11 +937,38 @@ void GUI::sketch_list_()
   if (!m_show_sketch_list)
     return;
 
+  const ImGuiStyle& st              = ImGui::GetStyle();
+  float             max_name_text_w = 0.f;
+  for (const std::shared_ptr<Sketch>& s : m_view->get_sketches())
+  {
+    EZY_ASSERT(s);
+    const std::string& nm = s->get_name();
+    max_name_text_w =
+        std::max(max_name_text_w, ImGui::CalcTextSize(nm.c_str(), nm.c_str() + nm.size()).x);
+  }
+
+  constexpr float k_name_field_cap   = 480.f;
+  // Keep sketch names editable even when all names are short; also reused in row/window minimum width.
+  constexpr float k_name_field_floor = 72.f;
+  const float     name_pad_x         = st.FramePadding.x * 2.0f;
+  const float     name_field_w =
+      std::clamp(max_name_text_w + name_pad_x, k_name_field_floor, k_name_field_cap);
+
+  const float fh      = ImGui::GetFrameHeight();
+  const float props_w = ImGui::CalcTextSize("[P]").x + st.FramePadding.x * 2.0f;
+  const float row_min_w =
+      fh + st.ItemSpacing.x + k_name_field_floor + st.ItemSpacing.x + fh + st.ItemSpacing.x + fh +
+      st.ItemSpacing.x + props_w;
+  const float win_min_w = row_min_w + st.WindowPadding.x * 2.0f;
+  ImGui::SetNextWindowSizeConstraints(ImVec2(win_min_w, 0.f), ImVec2(FLT_MAX, FLT_MAX));
+
   if (!ImGui::Begin("Sketch List", &m_show_sketch_list, ImGuiWindowFlags_None))
   {
     ImGui::End();
     return;
   }
+
+  ImGui::BeginChild("##sketch_list_scroll", ImVec2(0.f, 0.f), false, ImGuiWindowFlags_HorizontalScrollbar);
 
   int                     index = 0;
   std::shared_ptr<Sketch> sketch_to_delete;
@@ -963,16 +990,20 @@ void GUI::sketch_list_()
     // Radio button for selection
     ImGui::PushID(("select" + id_suffix).c_str());
     if (ImGui::RadioButton("", &m_view->curr_sketch() == sketch.get()))
+    {
       m_view->set_curr_sketch(sketch);
+      set_mode(Mode::Sketch_inspection_mode);
+    }
 
     if (m_show_tool_tips && ImGui::IsItemHovered())
       ImGui::SetTooltip("Sets current");
 
     ImGui::PopID();
 
-    // Text edit for name
+    // Text edit for name (width fits longest sketch name across the list, capped)
     ImGui::SameLine();
     ImGui::PushID(("name" + id_suffix).c_str());
+    ImGui::SetNextItemWidth(name_field_w);
     if (ImGui::InputText("", name_buffer, sizeof(name_buffer)))
     {
       sketch->set_name(std::string(name_buffer));
@@ -997,6 +1028,8 @@ void GUI::sketch_list_()
 
     if (m_show_tool_tips && ImGui::IsItemHovered())
       ImGui::SetTooltip("Visibility");
+
+    ImGui::PopID();
 
     ImGui::SameLine();
     ImGui::PushID(("uldisp" + id_suffix).c_str());
@@ -1038,8 +1071,9 @@ void GUI::sketch_list_()
     ImGui::PopID();
 
     ++index;
-    ImGui::PopID();
   }
+
+  ImGui::EndChild();
 
   if (sketch_to_delete)
   {
@@ -1374,7 +1408,7 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
         apply_ul_xform();
     };
 
-    auto     transform_input_double = [&](const char* label, double* p_data, double v_min, double v_max,
+    auto transform_input_double = [&](const char* label, double* p_data, double v_min, double v_max,
                                       const char* format)
     {
       const bool changed = ImGui::InputDouble(label, p_data, 0.0, 0.0, format);
@@ -2307,8 +2341,7 @@ void GUI::on_mouse_scroll(double xoffset, double yoffset)
 {
   EZY_ASSERT(m_glfw_window != nullptr);
 
-  const bool shift_finer = glfwGetKey(m_glfw_window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS
-                           || glfwGetKey(m_glfw_window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
+  const bool shift_finer = glfwGetKey(m_glfw_window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS || glfwGetKey(m_glfw_window, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS;
 
   m_view->on_mouse_scroll(xoffset, yoffset, shift_finer);
 }

--- a/src/gui.h
+++ b/src/gui.h
@@ -203,6 +203,7 @@ class GUI
   ImGui::MarkdownImageData        about_markdown_image_(ImGui::MarkdownLinkCallbackData data);
   static void                     about_markdown_link_cb_(ImGui::MarkdownLinkCallbackData data);
   static ImGui::MarkdownImageData about_markdown_image_cb_(ImGui::MarkdownLinkCallbackData data);
+  static float                    list_name_field_width_(const ImGuiStyle& st, float max_name_text_w);
   void                            log_window_();
   void                            lua_console_();
   void                            python_console_();

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -600,7 +600,8 @@ void GUI::settings_()
       underlay_highlight_color_rgb(hr, hg, hb);
       for (const std::shared_ptr<Sketch>& sk : m_view->get_sketches())
       {
-        if (sk && sk->has_underlay())
+        EZY_ASSERT(sk);
+        if (sk->has_underlay())
           sk->underlay_set_line_tint_rgb(hr, hg, hb);
       }
       m_underlay_panel_sketch = nullptr;


### PR DESCRIPTION
## Summary

- Make Sketch List selection switch GUI into `Sketch_inspection_mode`.
- Improve Sketch List and Shape List behavior in narrow panes (horizontal-scroll content and aligned name-field width handling).
- Refactor shared list name-width logic into `GUI::list_name_field_width_`.
- Update style docs and Cursor rule guidance for reader-first `.cpp` organization, helper placement near use, and pragmatic DRY guidance.
- Add issue drafts for branch context and follow-up tracking.

## Files Changed

- `src/gui.cpp`
- `src/gui.h`
- `src/gui_settings.cpp`
- `ezycad_code_style.md`
- `.cursor/rules/ezycad_code_style.mdc`
- `agents/issues/003-ui-improvements-sketch-shape-lists-and-style.md`

## Related

- Issue: https://github.com/trailcode/EzyCad/issues/98
- Compare: https://github.com/trailcode/EzyCad/compare/main...Trailcode/ui_improvements

## Test Plan

- [x] Build `EzyCad_lib` in Release config.
- [x] In Sketch List, click a sketch row selector and verify mode becomes sketch inspection.
- [x] Resize Sketch List very narrow and verify controls remain reachable via horizontal scroll.
- [x] Resize Shape List very narrow and verify controls remain reachable via horizontal scroll.
- [x] Rename sketches and shapes with short and long names; verify input widths are usable and consistent.
- [x] Verify no ImGui ID-stack warnings appear while interacting with both lists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-focused changes; main behavior change is auto-switching to `Sketch_inspection_mode` when selecting a sketch, which could affect user workflow but doesn’t touch persistence or core geometry logic.
> 
> **Overview**
> Improves list-pane usability by making Sketch List selection automatically switch to `Mode::Sketch_inspection_mode`, and by adding horizontal scrolling plus consistent, capped name input widths in both Sketch and Shape lists via shared `GUI::list_name_field_width_`.
> 
> Tightens a small settings path by asserting sketches are non-null before updating underlay tint, and updates `ezycad_code_style.md` with reader-first `.cpp` organization, local declaration placement, and pragmatic DRY guidance. Adds draft issue/PR markdowns for tracking follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2f7fbfcde9b3da2bf022f6fb6fdcfbdd1e0ff6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->