### PR TITLE
Shape polar duplicate: show permanent sketch nodes in inspection and polar-duplicate modes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,16 +11,20 @@ AlignOperands: true
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true      # Changed to true
 AllowAllParametersOfDeclarationOnNextLine: true  # Changed to true
-AllowShortBlocksOnASingleLine: Empty
+AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakTemplateDeclarations: No    # Changed to No
 BinPackArguments: true                 # Changed to true
 BinPackParameters: true                # Changed to true
-BreakBeforeBraces: Allman              # Optional: consider Attach
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterStruct: true
+  AfterUnion: true
 IndentWidth: 2
 TabWidth: 2
 UseTab: Never
@@ -43,4 +47,4 @@ SpacesInSquareBrackets: false
 AlignArrayOfStructures: Right
 DerivePointerAlignment: false
 # Blank line between adjacent function/class definitions (Always | Never | Leave).
-SeparateDefinitionBlocks: Always
+SeparateDefinitionBlocks: Never

--- a/.clang-format
+++ b/.clang-format
@@ -22,9 +22,13 @@ BinPackArguments: true                 # Changed to true
 BinPackParameters: true                # Changed to true
 BreakBeforeBraces: Custom
 BraceWrapping:
+  AfterControlStatement: Always
+  AfterFunction: true
   AfterClass: true
   AfterStruct: true
   AfterUnion: true
+  AfterNamespace: true
+  AfterEnum: true
 IndentWidth: 2
 TabWidth: 2
 UseTab: Never

--- a/agents/issues/004-polar-dup-sketch-based-reference.md
+++ b/agents/issues/004-polar-dup-sketch-based-reference.md
@@ -1,0 +1,46 @@
+# [Draft] Polar duplicate: sketch-based reference when a sketch is available
+
+**Suggested labels:** `enhancement`, `sketch`, `ux`
+
+**Repo:** `trailcode/EzyCad`
+
+---
+
+## Title (GitHub)
+
+Polar duplicate: use sketch-based points/plane when a sketch is available
+
+## Body (GitHub)
+
+### Summary
+
+Polar duplicate today builds its polar arm and rotation using the **current sketch plane** and `Sketch_nodes::snap` for the first pick (see `Shp_polar_dup::move_point` / `add_point` in `src/shp_polar_dup.cpp`). There is a product gap: when a sketch exists, users expect polar array placement and reference geometry to feel **explicitly tied to sketch points, edges, or the sketch datum**, not only a bbox center plus plane snap.
+
+### Current behavior (for context)
+
+- Rotation axis uses `view().curr_sketch().get_plane()` and edge endpoints derived from the polar arm edge on that plane.
+- First drag uses `get_shape_bbox_center(m_shps[0]->Shape())` as one end of the arm (see TODO in code: "consider all shapes").
+- Successful `Dup` removes originals via `delete_operation_shps_()` (documented elsewhere; separate from sketch reference).
+
+### Desired direction (open for design)
+
+- When a **sketch is available** (e.g. current sketch has geometry or user is in a sketch-centric workflow), prefer:
+  - Snapping the polar **origin** or **arm endpoints** to sketch nodes / edges / meaningful sketch references where possible.
+  - Clear UX when no sketch is active (fallback to today or a world pick path).
+- Align with **Reader-first** / pragmatic DRY in `ezycad_code_style.md`: keep polar-dup interaction discoverable in one place (Options + mouse flow) without scattering sketch rules across unrelated tools.
+
+### Acceptance criteria (draft)
+
+- [ ] With an active sketch, polar duplicate picks can use sketch-backed snaps (exact rules TBD with design).
+- [ ] Without a sketch (or when explicitly in pure solid mode), behavior remains defined and documented (no silent failure).
+- [ ] Update in-app hints / tooltips if needed so users know plane and snap source.
+
+### Links / notes
+
+- Code entry points: `src/shp_polar_dup.cpp`, `Occt_view::on_mode` sketch visibility for `Mode::Shape_polar_duplicate` in `src/occt_view.cpp`.
+
+---
+
+## Metadata (do not paste into GitHub)
+
+- Draft path: `agents/issues/004-polar-dup-sketch-based-reference.md`

--- a/agents/prs/003-shape-polar-duplicate-sketch-node-visibility.md
+++ b/agents/prs/003-shape-polar-duplicate-sketch-node-visibility.md
@@ -1,0 +1,33 @@
+# PR - `Trailcode/ui_improvments2`
+
+## Title
+
+Shape polar duplicate: show permanent sketch nodes in inspection and polar-duplicate modes
+
+## Summary
+
+- Permanent "+" markers for user-placed sketch nodes (added via the Add Node tool) are now visible whenever a sketch is active in inspection mode or during Shape polar duplicate (which relies on sketch node snapping for the polar arm).
+- Previously, these nodes were only shown while actively using the Add Node tool (`Sketch_add_node`); they were hidden in `Sketch_inspection_mode` and `Shape_polar_duplicate`.
+- Changed the visibility condition in `sync_permanent_node_annos_()` from an explicit mode check to `is_sketch_mode(mode) || mode == Mode::Shape_polar_duplicate`.
+
+## Files Changed
+
+- `src/sketch.cpp`
+
+## Related
+
+- Compare: https://github.com/trailcode/EzyCad/compare/main...Trailcode/ui_improvments2
+- Enhancement issue (future sketch-based polar reference): https://github.com/trailcode/EzyCad/issues/102
+
+## Test Plan
+
+- [ ] Build `EzyCad_lib` in Release config.
+- [ ] Enter a sketch with existing permanent nodes (added via Add Node tool).
+- [ ] Switch to Sketch inspection mode and verify the "+" markers are visible and pickable.
+- [ ] Start Shape polar duplicate, select shapes, and verify sketch nodes remain visible for snapping the polar arm origin.
+- [ ] Verify nodes hide correctly when leaving all sketch/polar modes (e.g., back to Normal).
+- [ ] Confirm no regression in other sketch tools (line, circle, etc.).
+
+## Notes
+
+- Untracked workspace directory exists: `third_party/ImGuiColorTextEdit/`.

--- a/bugs.md
+++ b/bugs.md
@@ -12,4 +12,5 @@
 * For selection mode, not all of the current modes are useful.
 * Scale mode broken.
 * Add concept of dim or dimension, use with node, a measurement, but does not participate in generating faces.
+* Vendor and commit `third_party/ImGuiColorTextEdit/` into this repository; it has not been maintained upstream for a long time and we should pin a known-good copy.
 * ~~After an edge is split by its midpoint, the split edges do not have midpoints to snap to~~ - FIXED 

--- a/ezycad_code_style.md
+++ b/ezycad_code_style.md
@@ -15,6 +15,7 @@ Use this style when editing or adding C/C++ code in the EzyCad project (files un
 - **Classes / structs**: PascalCase with underscores, e.g. `Sketch_nodes`, `Shp`, `Sketch_AIS_edge`, `Occt_view`.
 - **Enums**: PascalCase; enum values either PascalCase or descriptive with underscores (e.g. `Full`, `Background`, `Sketch_add_node`, `_count` for sentinel).
 - **Member variables**: `m_` prefix (e.g. `m_nodes`, `m_view`). Static members: `s_` prefix (e.g. `s_snap_dist_pixels`).
+- Prefer clear domain prefixes for related member groups (e.g. `m_underlay_*`) instead of mixed short forms.
 - **Constants** (e.g. lookup arrays for enums): `c_` prefix (e.g. `c_mode_strs`, `c_chamfer_mode_strs`).
 - **Functions / methods**: snake_case (e.g. `add_new_node`, `get_node_exact`, `try_get_node_idx_snap`).
 - **Private methods**: snake_case with trailing underscore (e.g. `update_node_snap_anno_`, `try_snap_outside_`).
@@ -25,7 +26,7 @@ Use this style when editing or adding C/C++ code in the EzyCad project (files un
 
 - **Indentation**: 2 spaces (no tabs).
 - **Access specifiers**: ` public:` and ` private:` (one space before `public`/`private`/`protected`).
-- **Braces**: Opening brace for class/struct on the same line. For **control flow** (`if`, `for`, `while`, `switch`), put the opening brace on the **next line**. For functions, opening brace often on the next line; **short functions** (e.g. single return) may be on one line—`.clang-format` (AllowShortFunctionsOnASingleLine: All) does this automatically. `.clang-format` uses `BraceWrapping.AfterControlStatement: Always` to enforce control-statement brace placement.
+- **Braces**: Follow `.clang-format` (source of truth). With current settings, opening braces are on the **next line** for classes/structs/unions, functions, control statements, namespaces, and enums (`BreakBeforeBraces: Custom` with `BraceWrapping.After*` enabled). **Short functions** may still be kept on one line (`AllowShortFunctionsOnASingleLine: All`).
 - **Alignment**: Align member declarations in columns when it aids readability (type and name aligned across lines in the same block).
 - **Initialization**: Prefer brace-initialization for members (e.g. `bool is_midpoint {false};`, `size_t m_prev_num_nodes {0};`).
 - **Local declarations**: Prefer declaring locals close to first use for readability. For values shared by a render block, compute them once immediately before that block.

--- a/ezycad_code_style.md
+++ b/ezycad_code_style.md
@@ -50,9 +50,12 @@ Use this style when editing or adding C/C++ code in the EzyCad project (files un
 ## Don't Repeat Yourself (DRY)
 
 - DRY is important, but it is guidance, not a strict rule.
+- **Reader-first pairing**: Pragmatic DRY matches **Reader-first order** in **Code organization** above. Prefer a self-contained workflow or UI pane you can read top-to-bottom over distant abstractions whose only win is deleting a few repeated lines.
 - Avoid hasty abstractions: do not generalize too early before patterns are stable.
 - Too much DRY can increase coupling by forcing unrelated code through one shared abstraction.
 - Prefer readability over clever reuse when repetition is small and explicit code is clearer.
+- **When duplication is acceptable**: a few lines repeated across nearby UI or glue code can beat a shared helper if call sites are likely to diverge (different tooltips, widths, or disabled logic) or if extracting would scatter one screen across many symbols. Prefer **locality**: keep a small block self-contained so a reader does not jump to understand one pane.
+- **Rule of thumb**: extract when the behavior is **the same and stable** (or when a bug fix must touch N copies); wait when the pattern is still moving. If you extract, prefer a **narrow file-local helper** next to its users over a generic framework.
 - Context matters: stronger DRY is often good in monolith/shared-library code; some duplication can be healthier in fast-changing or separated systems.
 - Balance DRY with KISS, YAGNI, and overall cognitive load.
 

--- a/ezycad_code_style.md
+++ b/ezycad_code_style.md
@@ -113,4 +113,8 @@ Prefer **`CHK_RET(expr)`** when a callee returns `Status` or `Result<T>` and the
 - Prefer **`enum class`** for enumerations.
 - Use **`std::optional`** where a value may be absent.
 - Use **`const`** and **`const&`** for parameters and accessors where appropriate.
+- Prefer **glm vector types** (`glm::vec2/vec3/vec4`, `glm::dvec*`) for geometric/color-like grouped values
+  (positions, directions, extents, RGB/RGBA colors) instead of raw C arrays when storing or passing data in project
+  code. Use raw arrays only at API boundaries that require `float*`/`double*` (e.g. some ImGui or OCCT calls), and
+  convert at the boundary.
 - Keep consistent with existing file style (e.g. include order, brace placement) when editing.

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -962,11 +962,12 @@ void GUI::sketch_list_inspector_(Sketch& sketch, int index)
 
     if (ImGui::TreeNodeEx("Dimensions", flags, "Dimensions (%zu)", count))
     {
-      if (count > 0 && ImGui::BeginTable("sketch_dim_rows", 3, ImGuiTableFlags_SizingStretchProp))
+      if (count > 0 && ImGui::BeginTable("sketch_dim_rows", 3,
+                                        ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp))
       {
         ImGui::TableSetupColumn("show", ImGuiTableColumnFlags_WidthFixed, 28.f);
         ImGui::TableSetupColumn("dim", ImGuiTableColumnFlags_WidthStretch);
-        ImGui::TableSetupColumn("offset", ImGuiTableColumnFlags_WidthFixed, 132.f);
+        ImGui::TableSetupColumn("offset", ImGuiTableColumnFlags_WidthFixed, 120.f);
 
         for (size_t i = 0; i < count; ++i)
         {
@@ -985,6 +986,7 @@ void GUI::sketch_list_inspector_(Sketch& sketch, int index)
           std::string cur_name = sketch.dimension_name(i);
           strncpy(name_buf, cur_name.c_str(), sizeof(name_buf) - 1);
           name_buf[sizeof(name_buf) - 1] = '\0';
+          ImGui::SetNextItemWidth(-FLT_MIN);
           if (ImGui::InputText("##dim_name", name_buf, sizeof(name_buf)))
             sketch.set_dimension_name(i, std::string(name_buf));
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -981,8 +981,12 @@ void GUI::sketch_list_inspector_(Sketch& sketch, int index)
             sketch.set_dimension_visible(i, visible);
 
           ImGui::TableSetColumnIndex(1);
-          ImGui::AlignTextToFramePadding();
-          ImGui::TextUnformatted(labels[i].c_str());
+          char name_buf[128];
+          std::string cur_name = sketch.dimension_name(i);
+          strncpy(name_buf, cur_name.c_str(), sizeof(name_buf) - 1);
+          name_buf[sizeof(name_buf) - 1] = '\0';
+          if (ImGui::InputText("##dim_name", name_buf, sizeof(name_buf)))
+            sketch.set_dimension_name(i, std::string(name_buf));
 
           ImGui::TableSetColumnIndex(2);
           ImGui::SetNextItemWidth(86.f);
@@ -1001,6 +1005,7 @@ void GUI::sketch_list_inspector_(Sketch& sketch, int index)
     }
   }
 
+  draw_section("Nodes", sketch.inspector_node_labels());
   draw_section("Edges", sketch.inspector_edge_labels());
   draw_section("Faces", sketch.inspector_face_labels());
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -271,12 +271,8 @@ void GUI::menu_bar_()
 
     if (ImGui::MenuItem("Add box_prms"))
     {
-      m_add_box_origin_x   = 0;
-      m_add_box_origin_y   = 0;
-      m_add_box_origin_z   = 0;
-      m_add_box_width      = 1.0;
-      m_add_box_length     = 1.0;
-      m_add_box_height     = 1.0;
+      m_add_box_origin     = glm::dvec3(0.0, 0.0, 0.0);
+      m_add_box_size       = glm::dvec3(1.0, 1.0, 1.0);
       m_open_add_box_popup = true;
     }
 
@@ -288,9 +284,9 @@ void GUI::menu_bar_()
 
     if (ImGui::MenuItem("Add pyramid_prms"))
     {
-      m_add_pyramid_origin_x = m_add_pyramid_origin_y = m_add_pyramid_origin_z = 0;
-      m_add_pyramid_side                                                       = 1.0;
-      m_open_add_pyramid_popup                                                 = true;
+      m_add_pyramid_origin    = glm::dvec3(0.0, 0.0, 0.0);
+      m_add_pyramid_side      = 1.0;
+      m_open_add_pyramid_popup = true;
     }
 
     if (ImGui::MenuItem("Add sphere"))
@@ -301,9 +297,9 @@ void GUI::menu_bar_()
 
     if (ImGui::MenuItem("Add sphere_prms"))
     {
-      m_add_sphere_origin_x = m_add_sphere_origin_y = m_add_sphere_origin_z = 0;
-      m_add_sphere_radius                                                   = 1.0;
-      m_open_add_sphere_popup                                               = true;
+      m_add_sphere_origin    = glm::dvec3(0.0, 0.0, 0.0);
+      m_add_sphere_radius    = 1.0;
+      m_open_add_sphere_popup = true;
     }
 
     if (ImGui::MenuItem("Add cylinder"))
@@ -314,7 +310,7 @@ void GUI::menu_bar_()
 
     if (ImGui::MenuItem("Add cylinder_prms"))
     {
-      m_add_cylinder_origin_x = m_add_cylinder_origin_y = m_add_cylinder_origin_z = 0;
+      m_add_cylinder_origin = glm::dvec3(0.0, 0.0, 0.0);
       m_add_cylinder_radius = m_add_cylinder_height = 1.0;
       m_open_add_cylinder_popup                     = true;
     }
@@ -327,11 +323,11 @@ void GUI::menu_bar_()
 
     if (ImGui::MenuItem("Add cone_prms"))
     {
-      m_add_cone_origin_x = m_add_cone_origin_y = m_add_cone_origin_z = 0;
-      m_add_cone_R1                                                   = 1.0;
-      m_add_cone_R2                                                   = 0.0;
-      m_add_cone_height                                               = 1.0;
-      m_open_add_cone_popup                                           = true;
+      m_add_cone_origin    = glm::dvec3(0.0, 0.0, 0.0);
+      m_add_cone_R1        = 1.0;
+      m_add_cone_R2        = 0.0;
+      m_add_cone_height    = 1.0;
+      m_open_add_cone_popup = true;
     }
 
     if (ImGui::MenuItem("Add torus"))
@@ -342,10 +338,10 @@ void GUI::menu_bar_()
 
     if (ImGui::MenuItem("Add torus_prms"))
     {
-      m_add_torus_origin_x = m_add_torus_origin_y = m_add_torus_origin_z = 0;
-      m_add_torus_R1                                                     = 1.0;
-      m_add_torus_R2                                                     = 0.5;
-      m_open_add_torus_popup                                             = true;
+      m_add_torus_origin    = glm::dvec3(0.0, 0.0, 0.0);
+      m_add_torus_R1        = 1.0;
+      m_add_torus_R2        = 0.5;
+      m_open_add_torus_popup = true;
     }
 
     ImGui::EndMenu();
@@ -567,8 +563,8 @@ void GUI::ensure_about_assets_()
     std::string bytes((std::istreambuf_iterator<char>(fi)), std::istreambuf_iterator<char>());
     if (auto dec = decode_image_bytes(bytes))
     {
-      m_about_splash_w = std::get<1>(*dec);
-      m_about_splash_h = std::get<2>(*dec);
+      m_about_splash_size.x = std::get<1>(*dec);
+      m_about_splash_size.y = std::get<2>(*dec);
     }
     m_about_splash_gl = load_texture(p);
     break;
@@ -588,7 +584,7 @@ ImGui::MarkdownImageData GUI::about_markdown_image_(ImGui::MarkdownLinkCallbackD
   out.isValid         = true;
   out.useLinkCallback = false;
   out.user_texture_id = (ImTextureID) (intptr_t) m_about_splash_gl;
-  out.size            = ImVec2((float) m_about_splash_w, (float) m_about_splash_h);
+  out.size            = ImVec2((float) m_about_splash_size.x, (float) m_about_splash_size.y);
   ImVec2 const avail  = ImGui::GetContentRegionAvail();
   if (out.size.x > avail.x && avail.x > 1.0f)
   {
@@ -1090,7 +1086,7 @@ void GUI::sketch_list_()
       {
         sketch->underlay_set_visible(ul_vis);
         if (m_underlay_panel_sketch == sketch.get())
-          m_ul_vis = ul_vis;
+          m_underlay_vis = ul_vis;
       }
 
       if (!has_ul)
@@ -1219,27 +1215,30 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
     m_underlay_panel_sketch = sk.get();
     if (sk->has_underlay())
     {
-      sk->underlay_ui_params(m_ul_cx, m_ul_cy, m_ul_hw, m_ul_hh, m_ul_rot);
-      m_ul_opacity   = sk->underlay_opacity();
-      m_ul_vis       = sk->underlay_visible();
-      m_ul_key_white = sk->underlay_key_white_transparent();
-      m_ul_line_tint = sk->underlay_line_tint_enabled();
+      sk->underlay_ui_params(
+          m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y, m_underlay_rot);
+      m_underlay_opacity   = sk->underlay_opacity();
+      m_underlay_vis       = sk->underlay_visible();
+      m_underlay_key_white = sk->underlay_key_white_transparent();
+      m_underlay_line_tint = sk->underlay_line_tint_enabled();
       {
         uint8_t tr, tg, tb, ta;
         sk->underlay_line_tint_rgba(tr, tg, tb, ta);
-        m_ul_tint_col[0] = static_cast<float>(tr) / 255.f;
-        m_ul_tint_col[1] = static_cast<float>(tg) / 255.f;
-        m_ul_tint_col[2] = static_cast<float>(tb) / 255.f;
-        m_ul_tint_col[3] = static_cast<float>(ta) / 255.f;
+        m_underlay_tint_col[0] = static_cast<float>(tr) / 255.f;
+        m_underlay_tint_col[1] = static_cast<float>(tg) / 255.f;
+        m_underlay_tint_col[2] = static_cast<float>(tb) / 255.f;
+        m_underlay_tint_col[3] = static_cast<float>(ta) / 255.f;
       }
     } else
     {
-      m_ul_cx = m_ul_cy = m_ul_hw = m_ul_hh = m_ul_rot = 0.;
-      m_ul_opacity                                     = 0.88f;
-      m_ul_vis                                         = true;
-      m_ul_key_white                                   = true;
-      m_ul_line_tint                                   = true;
-      m_ul_tint_col                                    = glm::vec4(1.f, 0.863f, 0.f, 1.f);
+      m_underlay_center       = glm::dvec2(0.0, 0.0);
+      m_underlay_half_extents = glm::dvec2(0.0, 0.0);
+      m_underlay_rot          = 0.0;
+      m_underlay_opacity      = 0.88f;
+      m_underlay_vis          = true;
+      m_underlay_key_white    = true;
+      m_underlay_line_tint    = true;
+      m_underlay_tint_col     = glm::vec4(1.f, 0.863f, 0.f, 1.f);
     }
   }
 
@@ -1282,35 +1281,36 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
   if (!sk->has_underlay())
     return;
 
-  if (ImGui::Checkbox("White paper -> transparent", &m_ul_key_white))
-    sk->underlay_set_key_white_transparent(m_ul_key_white);
+  if (ImGui::Checkbox("White paper -> transparent", &m_underlay_key_white))
+    sk->underlay_set_key_white_transparent(m_underlay_key_white);
 
   if (m_show_tool_tips && ImGui::IsItemHovered())
     ImGui::SetTooltip(
         "Uses brightness: white background becomes clear; dark lines stay visible. "
         "Turn off for full-color photos. Inverting the image is not needed for typical scans.");
 
-  if (ImGui::Checkbox("Tint visible lines", &m_ul_line_tint))
-    sk->underlay_set_line_tint_enabled(m_ul_line_tint);
+  if (ImGui::Checkbox("Tint visible lines", &m_underlay_line_tint))
+    sk->underlay_set_line_tint_enabled(m_underlay_line_tint);
 
   if (m_show_tool_tips && ImGui::IsItemHovered())
     ImGui::SetTooltip(
         "Paints non-transparent pixels (after white key) with the line color. "
         "Default yellow reads well on dark backgrounds.");
 
-  if (m_ul_line_tint)
-    if (ImGui::ColorEdit4("Line color", &m_ul_tint_col[0]))
+  if (m_underlay_line_tint)
+    if (ImGui::ColorEdit4("Line color", &m_underlay_tint_col[0]))
     {
       const auto to_u8 = [](float c) -> uint8_t {
         const float x = std::clamp(c, 0.f, 1.f) * 255.f;
         return static_cast<uint8_t>(x + 0.5f);
       };
       sk->underlay_set_line_tint_rgba(
-          to_u8(m_ul_tint_col[0]), to_u8(m_ul_tint_col[1]), to_u8(m_ul_tint_col[2]), to_u8(m_ul_tint_col[3]));
+          to_u8(m_underlay_tint_col[0]), to_u8(m_underlay_tint_col[1]), to_u8(m_underlay_tint_col[2]),
+          to_u8(m_underlay_tint_col[3]));
     }
 
-  if (ImGui::SliderFloat("Opacity", &m_ul_opacity, 0.f, 1.f, "%.2f"))
-    sk->underlay_set_opacity(m_ul_opacity);
+  if (ImGui::SliderFloat("Opacity", &m_underlay_opacity, 0.f, 1.f, "%.2f"))
+    sk->underlay_set_opacity(m_underlay_opacity);
 
   if (m_show_tool_tips && ImGui::IsItemHovered())
     ImGui::SetTooltip("Overall opacity of the underlay image (0 = fully transparent, 1 = fully opaque).");
@@ -1416,11 +1416,11 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
     if (!have_view)
     {
       constexpr double k_fallback = 250.0;
-      // m_ul_cx / m_ul_cy stay sketch-plane gp_Pnt2d X / Y (same as underlay_ui_params).
-      min_u                       = m_ul_cx - k_fallback;
-      max_u                       = m_ul_cx + k_fallback;
-      min_v                       = m_ul_cy - k_fallback;
-      max_v                       = m_ul_cy + k_fallback;
+      // m_underlay_center stays sketch-plane gp_Pnt2d X / Y (same as underlay_ui_params).
+      min_u = m_underlay_center.x - k_fallback;
+      max_u = m_underlay_center.x + k_fallback;
+      min_v = m_underlay_center.y - k_fallback;
+      max_v = m_underlay_center.y + k_fallback;
     }
 
     const double     span_u      = std::max(max_u - min_u, 1e-6);
@@ -1438,7 +1438,9 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
       if (!sk->underlay_axes_orthogonal())
         return;
 
-      sk->underlay_set_center_extents_rotation(dvec2(m_ul_cx, m_ul_cy), dvec2(m_ul_hw, m_ul_hh), m_ul_rot);
+      sk->underlay_set_center_extents_rotation(
+          dvec2(m_underlay_center.x, m_underlay_center.y),
+          dvec2(m_underlay_half_extents.x, m_underlay_half_extents.y), m_underlay_rot);
     };
 
     auto transform_slider = [&](const char* label, ImGuiDataType type, void* p_data, const void* p_min,
@@ -1466,15 +1468,19 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
 
     ImGui::BeginDisabled(!ul_ortho);
     // Labels match typical sketch axes on screen: "Center X" drives plane Y (gp_Pnt2d::Y / view v), "Center Y" plane X (u).
-    transform_slider("Center X", ImGuiDataType_Double, &m_ul_cy, &min_v, &max_v, "%.4f", ImGuiSliderFlags_ClampOnInput);
-    transform_slider("Center Y", ImGuiDataType_Double, &m_ul_cx, &min_u, &max_u, "%.4f", ImGuiSliderFlags_ClampOnInput);
-    transform_slider("Half width", ImGuiDataType_Double, &m_ul_hw, &k_min_half, &max_half_w, "%.4f",
+    transform_slider(
+        "Center X", ImGuiDataType_Double, &m_underlay_center.y, &min_v, &max_v, "%.4f", ImGuiSliderFlags_ClampOnInput);
+    transform_slider(
+        "Center Y", ImGuiDataType_Double, &m_underlay_center.x, &min_u, &max_u, "%.4f", ImGuiSliderFlags_ClampOnInput);
+    transform_slider(
+        "Half width", ImGuiDataType_Double, &m_underlay_half_extents.x, &k_min_half, &max_half_w, "%.4f",
                      ImGuiSliderFlags_ClampOnInput | ImGuiSliderFlags_Logarithmic);
-    transform_slider("Half height", ImGuiDataType_Double, &m_ul_hh, &k_min_half, &max_half_h, "%.4f",
+    transform_slider("Half height", ImGuiDataType_Double, &m_underlay_half_extents.y, &k_min_half, &max_half_h,
+                     "%.4f",
                      ImGuiSliderFlags_ClampOnInput | ImGuiSliderFlags_Logarithmic);
-    transform_slider("Rotation (deg)", ImGuiDataType_Double, &m_ul_rot, &rot_min, &rot_max, "%.1f",
+    transform_slider("Rotation (deg)", ImGuiDataType_Double, &m_underlay_rot, &rot_min, &rot_max, "%.1f",
                      ImGuiSliderFlags_ClampOnInput);
-    transform_input_double("Rotation value (deg)", &m_ul_rot, rot_min, rot_max, "%.4f");
+    transform_input_double("Rotation value (deg)", &m_underlay_rot, rot_min, rot_max, "%.4f");
     ImGui::EndDisabled();
   }
 }
@@ -1499,7 +1505,8 @@ void GUI::begin_underlay_calib_set_x_(const Sketch::sptr& sk)
   }
 
   cancel_underlay_calib_();
-  sk->underlay_ui_params(m_ul_cx, m_ul_cy, m_ul_hw, m_ul_hh, m_ul_rot);
+  sk->underlay_ui_params(
+      m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y, m_underlay_rot);
   m_underlay_calib_sketch_wk = sk;
   m_underlay_calib_phase     = Underlay_calib_phase::PickX1;
   show_message(
@@ -1517,7 +1524,8 @@ void GUI::begin_underlay_calib_set_y_(const Sketch::sptr& sk)
   }
 
   cancel_underlay_calib_();
-  sk->underlay_ui_params(m_ul_cx, m_ul_cy, m_ul_hw, m_ul_hh, m_ul_rot);
+  sk->underlay_ui_params(
+      m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y, m_underlay_rot);
   m_underlay_calib_sketch_wk = sk;
   m_underlay_calib_phase     = Underlay_calib_phase::PickY1;
   show_message(
@@ -1535,7 +1543,8 @@ void GUI::begin_underlay_calib_define_datum_(const Sketch::sptr& sk)
   }
 
   cancel_underlay_calib_();
-  sk->underlay_ui_params(m_ul_cx, m_ul_cy, m_ul_hw, m_ul_hh, m_ul_rot);
+  sk->underlay_ui_params(
+      m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y, m_underlay_rot);
   m_underlay_calib_sketch_wk = sk;
   m_underlay_calib_phase     = Underlay_calib_phase::PickDatumO;
   show_message("Datum: click where bitmap corner (0,0) should lie on the sketch plane.");
@@ -1579,7 +1588,8 @@ void GUI::underlay_calib_prompt_x_distance_(const Sketch::sptr& sk)
     }
 
     m_underlay_calib_axis_u = s->underlay_axis_u_vec();
-    s->underlay_ui_params(m_ul_cx, m_ul_cy, m_ul_hw, m_ul_hh, m_ul_rot);
+    s->underlay_ui_params(
+        m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y, m_underlay_rot);
     m_underlay_panel_sketch = nullptr;
 
     m_dist_callback        = nullptr;
@@ -1630,7 +1640,8 @@ void GUI::underlay_calib_prompt_y_distance_(const Sketch::sptr& sk)
       return;
     }
 
-    s->underlay_ui_params(m_ul_cx, m_ul_cy, m_ul_hw, m_ul_hh, m_ul_rot);
+    s->underlay_ui_params(
+        m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y, m_underlay_rot);
     m_underlay_panel_sketch = nullptr;
 
     m_dist_callback = nullptr;
@@ -1736,7 +1747,8 @@ bool GUI::try_underlay_calib_click_(const ScreenCoords& screen_coords)
         return true;
       }
 
-      sk->underlay_ui_params(m_ul_cx, m_ul_cy, m_ul_hw, m_ul_hh, m_ul_rot);
+      sk->underlay_ui_params(
+          m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y, m_underlay_rot);
       m_underlay_panel_sketch = nullptr;
       cancel_underlay_calib_();
       show_message("Underlay datum set: origin at (0,0) and +U direction; half sizes unchanged.");

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -36,7 +36,6 @@
 using namespace glm;
 
 GUI* gui_instance = nullptr;
-
 GUI::GUI()
 {
   EZY_ASSERT(!gui_instance);
@@ -44,7 +43,6 @@ GUI::GUI()
   m_view       = std::make_unique<Occt_view>(*this);
   gui_instance = this;
 }
-
 ImFont* GUI::console_font() const
 {
   if (!m_console_font || !ImGui::GetCurrentContext())
@@ -60,12 +58,10 @@ ImFont* GUI::console_font() const
 
   return nullptr;
 }
-
 GUI::~GUI()
 {
   cleanup_log_redirection_();  // Clean up stream redirection
 }
-
 ImVec4 GUI::get_clear_color() const
 {
   if (m_dark_mode)
@@ -73,7 +69,6 @@ ImVec4 GUI::get_clear_color() const
 
   return ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
 }
-
 #ifdef __EMSCRIPTEN__
 GUI& GUI::instance()
 {
@@ -81,7 +76,6 @@ GUI& GUI::instance()
   return *gui_instance;
 }
 #endif
-
 void GUI::render_gui()
 {
   // Underlay transform sliders use sketch_plane_view_aabb_2d -> pt_on_plane -> view projection.
@@ -119,12 +113,10 @@ void GUI::render_gui()
   settings_();
   dbg_();
 }
-
 void GUI::render_occt()
 {
   m_view->do_frame();
 }
-
 // Initialize toolbar buttons
 void GUI::initialize_toolbar_()
 {
@@ -156,7 +148,6 @@ void GUI::initialize_toolbar_()
       {                    load_texture("res/icons/Part_Common.png"), false,                     "Shape common",                Command::Shape_common},
   };
 }
-
 void GUI::load_examples_list_()
 {
   m_example_files.clear();
@@ -182,10 +173,8 @@ void GUI::load_examples_list_()
     m_example_files.push_back(Example_file {std::move(label), std::move(path)});
   }
   std::sort(m_example_files.begin(), m_example_files.end(),
-            [](const Example_file& a, const Example_file& b)
-            { return a.label < b.label; });
+            [](const Example_file& a, const Example_file& b) { return a.label < b.label; });
 }
-
 void GUI::menu_bar_()
 {
   if (!ImGui::BeginMainMenuBar())
@@ -435,7 +424,6 @@ void GUI::menu_bar_()
 
   ImGui::EndMainMenuBar();
 }
-
 void GUI::about_dialog_()
 {
   if (m_open_about_popup)
@@ -476,7 +464,6 @@ void GUI::about_dialog_()
 
   ImGui::EndPopup();
 }
-
 std::string GUI::project_title_segment_() const
 {
   if (m_last_saved_path.empty() || m_last_saved_path == "(startup)")
@@ -495,7 +482,6 @@ std::string GUI::project_title_segment_() const
     return "untitled";
   }
 }
-
 void GUI::update_window_title_()
 {
   EZY_ASSERT(m_glfw_window != nullptr);
@@ -507,7 +493,6 @@ void GUI::update_window_title_()
   m_cached_window_title = title;
   glfwSetWindowTitle(m_glfw_window, m_cached_window_title.c_str());
 }
-
 void GUI::open_url_(const std::string& url)
 {
 #ifdef __EMSCRIPTEN__
@@ -538,7 +523,6 @@ void GUI::open_url_(const std::string& url)
   system(cmd.c_str());
 #endif
 }
-
 void GUI::ensure_about_assets_()
 {
   if (m_about_assets_loaded)
@@ -590,7 +574,6 @@ void GUI::ensure_about_assets_()
     break;
   }
 }
-
 ImGui::MarkdownImageData GUI::about_markdown_image_(ImGui::MarkdownLinkCallbackData data)
 {
   ImGui::MarkdownImageData out {};
@@ -615,7 +598,6 @@ ImGui::MarkdownImageData GUI::about_markdown_image_(ImGui::MarkdownLinkCallbackD
   }
   return out;
 }
-
 void GUI::about_markdown_link_cb_(ImGui::MarkdownLinkCallbackData data)
 {
   if (data.isImage || !data.userData)
@@ -624,7 +606,6 @@ void GUI::about_markdown_link_cb_(ImGui::MarkdownLinkCallbackData data)
   std::string url(data.link, data.linkLength);
   static_cast<GUI*>(data.userData)->open_url_(url);
 }
-
 ImGui::MarkdownImageData GUI::about_markdown_image_cb_(ImGui::MarkdownLinkCallbackData data)
 {
   if (!data.userData)
@@ -632,7 +613,6 @@ ImGui::MarkdownImageData GUI::about_markdown_image_cb_(ImGui::MarkdownLinkCallba
 
   return static_cast<GUI*>(data.userData)->about_markdown_image_(data);
 }
-
 // Render toolbar with ImGui
 void GUI::toolbar_()
 {
@@ -706,7 +686,6 @@ void GUI::toolbar_()
 
   ImGui::End();
 }
-
 // Distance edit related
 void GUI::set_dist_edit(float dist, std::function<void(float, bool)>&& callback, const std::optional<ScreenCoords> screen_coords)
 {
@@ -728,7 +707,6 @@ void GUI::set_dist_edit(float dist, std::function<void(float, bool)>&& callback,
   if (!already_editing)
     m_dist_edit_focus_pending = true;
 }
-
 void GUI::hide_dist_edit()
 {
   if (m_dist_callback)
@@ -744,7 +722,6 @@ void GUI::hide_dist_edit()
     callback(m_dist_val, true);
   }
 }
-
 void GUI::dist_edit_()
 {
   if (!m_dist_callback)
@@ -794,7 +771,6 @@ void GUI::dist_edit_()
 
   ImGui::End();
 }
-
 // Angle edit related
 void GUI::set_angle_edit(float angle, std::function<void(float, bool)>&& callback, const std::optional<ScreenCoords> screen_coords)
 {
@@ -814,7 +790,6 @@ void GUI::set_angle_edit(float angle, std::function<void(float, bool)>&& callbac
   if (!already_editing)
     m_angle_edit_focus_pending = true;
 }
-
 void GUI::hide_angle_edit()
 {
   if (m_angle_callback)
@@ -827,12 +802,10 @@ void GUI::hide_angle_edit()
     callback(m_angle_val, true);
   }
 }
-
 bool GUI::is_dist_or_angle_edit_active() const
 {
   return m_dist_callback != nullptr || m_angle_callback != nullptr;
 }
-
 void GUI::angle_edit_()
 {
   if (!m_angle_callback)
@@ -880,7 +853,6 @@ void GUI::angle_edit_()
 
   ImGui::End();
 }
-
 bool GUI::parse_dist_text_to_float_(const char* buf, float& out)
 {
   if (!buf)
@@ -905,20 +877,17 @@ bool GUI::parse_dist_text_to_float_(const char* buf, float& out)
   out = v;
   return true;
 }
-
 bool GUI::is_valid_project_json_(const std::string& s)
 {
   try
   {
     const nlohmann::json j = nlohmann::json::parse(s);
     return j.contains("sketches") && j["sketches"].is_array();
-  }
-  catch (...)
+  } catch (...)
   {
     return false;
   }
 }
-
 const std::vector<std::string>& GUI::occt_material_combo_labels_()
 {
   static std::vector<std::string> names;
@@ -931,14 +900,12 @@ const std::vector<std::string>& GUI::occt_material_combo_labels_()
 
   return names;
 }
-
 void GUI::sketch_list_inspector_(Sketch& sketch, int index)
 {
   ImGui::Indent();
   ImGui::PushID(index);
 
-  const auto draw_section = [](const char* title, const std::vector<std::string>& labels)
-  {
+  const auto draw_section = [](const char* title, const std::vector<std::string>& labels) {
     const size_t       count = labels.size();
     ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_SpanAvailWidth;
     if (count == 0)
@@ -963,7 +930,7 @@ void GUI::sketch_list_inspector_(Sketch& sketch, int index)
     if (ImGui::TreeNodeEx("Dimensions", flags, "Dimensions (%zu)", count))
     {
       if (count > 0 && ImGui::BeginTable("sketch_dim_rows", 3,
-                                        ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp))
+                                         ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp))
       {
         ImGui::TableSetupColumn("show", ImGuiTableColumnFlags_WidthFixed, 28.f);
         ImGui::TableSetupColumn("dim", ImGuiTableColumnFlags_WidthStretch);
@@ -982,7 +949,7 @@ void GUI::sketch_list_inspector_(Sketch& sketch, int index)
             sketch.set_dimension_visible(i, visible);
 
           ImGui::TableSetColumnIndex(1);
-          char name_buf[128];
+          char        name_buf[128];
           std::string cur_name = sketch.dimension_name(i);
           strncpy(name_buf, cur_name.c_str(), sizeof(name_buf) - 1);
           name_buf[sizeof(name_buf) - 1] = '\0';
@@ -1014,7 +981,6 @@ void GUI::sketch_list_inspector_(Sketch& sketch, int index)
   ImGui::PopID();
   ImGui::Unindent();
 }
-
 void GUI::sketch_list_()
 {
   if (!m_show_sketch_list)
@@ -1022,7 +988,7 @@ void GUI::sketch_list_()
 
   const ImGuiStyle& st              = ImGui::GetStyle();
   float             max_name_text_w = 0.f;
-  for (const std::shared_ptr<Sketch>& s : m_view->get_sketches())
+  for (const Sketch::sptr& s : m_view->get_sketches())
   {
     EZY_ASSERT(s);
     const std::string& nm = s->get_name();
@@ -1039,9 +1005,9 @@ void GUI::sketch_list_()
   ImGui::BeginChild("##sketch_list_scroll", ImVec2(0.f, 0.f), false, ImGuiWindowFlags_HorizontalScrollbar);
   const float name_field_w = list_name_field_width_(st, max_name_text_w);
 
-  int                     index = 0;
-  std::shared_ptr<Sketch> sketch_to_delete;
-  for (std::shared_ptr<Sketch>& sketch : m_view->get_sketches())
+  int          index = 0;
+  Sketch::sptr sketch_to_delete;
+  for (Sketch::sptr& sketch : m_view->get_sketches())
   {
     EZY_ASSERT(sketch);
 
@@ -1167,7 +1133,6 @@ void GUI::sketch_list_()
 
   ImGui::End();
 }
-
 void GUI::sketch_underlay_import_dialog_()
 {
 #ifndef __EMSCRIPTEN__
@@ -1198,10 +1163,9 @@ void GUI::sketch_underlay_import_dialog_()
   sketch_underlay_file_dialog_async();
 #endif
 }
-
 void GUI::on_sketch_underlay_file(const std::string& file_path, const std::string& file_bytes)
 {
-  std::shared_ptr<Sketch> sk = m_underlay_import_sketch_target.lock();
+  Sketch::sptr sk = m_underlay_import_sketch_target.lock();
   m_underlay_import_sketch_target.reset();
   if (!sk)
     sk = m_view->curr_sketch_shared();
@@ -1216,7 +1180,6 @@ void GUI::on_sketch_underlay_file(const std::string& file_path, const std::strin
   m_underlay_panel_sketch = nullptr;
   show_message("Underlay: " + std::filesystem::path(file_path).filename().string());
 }
-
 void GUI::sketch_properties_dialog_()
 {
   if (!m_sketch_properties_open)
@@ -1244,8 +1207,7 @@ void GUI::sketch_properties_dialog_()
   m_sketch_properties_open = open;
   ImGui::End();
 }
-
-void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
+void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
 {
   EZY_ASSERT(sk);
 
@@ -1258,8 +1220,8 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
     if (sk->has_underlay())
     {
       sk->underlay_ui_params(m_ul_cx, m_ul_cy, m_ul_hw, m_ul_hh, m_ul_rot);
-      m_ul_opacity     = sk->underlay_opacity();
-      m_ul_vis         = sk->underlay_visible();
+      m_ul_opacity   = sk->underlay_opacity();
+      m_ul_vis       = sk->underlay_visible();
       m_ul_key_white = sk->underlay_key_white_transparent();
       m_ul_line_tint = sk->underlay_line_tint_enabled();
       {
@@ -1270,8 +1232,7 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
         m_ul_tint_col[2] = static_cast<float>(tb) / 255.f;
         m_ul_tint_col[3] = static_cast<float>(ta) / 255.f;
       }
-    }
-    else
+    } else
     {
       m_ul_cx = m_ul_cy = m_ul_hw = m_ul_hh = m_ul_rot = 0.;
       m_ul_opacity                                     = 0.88f;
@@ -1340,8 +1301,7 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
   if (m_ul_line_tint)
     if (ImGui::ColorEdit4("Line color", &m_ul_tint_col[0]))
     {
-      const auto to_u8 = [](float c) -> uint8_t
-      {
+      const auto to_u8 = [](float c) -> uint8_t {
         const float x = std::clamp(c, 0.f, 1.f) * 255.f;
         return static_cast<uint8_t>(x + 0.5f);
       };
@@ -1474,8 +1434,7 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
     double           rot_min     = -180.0;
     double           rot_max     = 180.0;
 
-    auto apply_ul_xform = [&]()
-    {
+    auto apply_ul_xform = [&]() {
       if (!sk->underlay_axes_orthogonal())
         return;
 
@@ -1483,8 +1442,7 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
     };
 
     auto transform_slider = [&](const char* label, ImGuiDataType type, void* p_data, const void* p_min,
-                                const void* p_max, const char* format, ImGuiSliderFlags flags = 0)
-    {
+                                const void* p_max, const char* format, ImGuiSliderFlags flags = 0) {
       const bool changed = ImGui::SliderScalar(label, type, p_data, p_min, p_max, format, flags);
       if (ImGui::IsItemActivated())
         m_view->push_undo_snapshot();
@@ -1494,8 +1452,7 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
     };
 
     auto transform_input_double = [&](const char* label, double* p_data, double v_min, double v_max,
-                                      const char* format)
-    {
+                                      const char* format) {
       const bool changed = ImGui::InputDouble(label, p_data, 0.0, 0.0, format);
       if (ImGui::IsItemActivated())
         m_view->push_undo_snapshot();
@@ -1521,7 +1478,6 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
     ImGui::EndDisabled();
   }
 }
-
 void GUI::cancel_underlay_calib_()
 {
   m_dist_callback        = nullptr;
@@ -1531,8 +1487,7 @@ void GUI::cancel_underlay_calib_()
 
   m_underlay_calib_axis_u = gp_Vec2d(0., 0.);
 }
-
-void GUI::begin_underlay_calib_set_x_(const std::shared_ptr<Sketch>& sk)
+void GUI::begin_underlay_calib_set_x_(const Sketch::sptr& sk)
 {
   if (!sk || !sk->has_underlay())
     return;
@@ -1550,8 +1505,7 @@ void GUI::begin_underlay_calib_set_x_(const std::shared_ptr<Sketch>& sk)
   show_message(
       "Underlay X: uses the current transform. Click bitmap corner (0,0), then along +U; then enter the distance.");
 }
-
-void GUI::begin_underlay_calib_set_y_(const std::shared_ptr<Sketch>& sk)
+void GUI::begin_underlay_calib_set_y_(const Sketch::sptr& sk)
 {
   if (!sk || !sk->has_underlay())
     return;
@@ -1569,8 +1523,7 @@ void GUI::begin_underlay_calib_set_y_(const std::shared_ptr<Sketch>& sk)
   show_message(
       "Underlay Y: uses the current transform. Click two points along +V; then enter the drawing distance.");
 }
-
-void GUI::begin_underlay_calib_define_datum_(const std::shared_ptr<Sketch>& sk)
+void GUI::begin_underlay_calib_define_datum_(const Sketch::sptr& sk)
 {
   if (!sk || !sk->has_underlay())
     return;
@@ -1587,21 +1540,19 @@ void GUI::begin_underlay_calib_define_datum_(const std::shared_ptr<Sketch>& sk)
   m_underlay_calib_phase     = Underlay_calib_phase::PickDatumO;
   show_message("Datum: click where bitmap corner (0,0) should lie on the sketch plane.");
 }
-
-void GUI::underlay_calib_prompt_x_distance_(const std::shared_ptr<Sketch>& sk)
+void GUI::underlay_calib_prompt_x_distance_(const Sketch::sptr& sk)
 {
   m_underlay_calib_phase       = Underlay_calib_phase::AwaitDistX;
   const double       L_model   = m_underlay_calib_x0.Distance(m_underlay_calib_x1);
   const float        dist_show = static_cast<float>(L_model / m_view->get_dimension_scale());
   const ScreenCoords spos(dvec2(ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y));
 
-  std::weak_ptr<Sketch> wk      = sk;
-  auto                  on_dist = [this, wk](float new_dist, bool is_final)
-  {
+  Sketch::wptr wk      = sk;
+  auto         on_dist = [this, wk](float new_dist, bool is_final) {
     if (!is_final)
       return;
 
-    const std::shared_ptr<Sketch> s = wk.lock();
+    const Sketch::sptr s = wk.lock();
     if (!s || !s->has_underlay())
     {
       m_dist_callback = nullptr;
@@ -1635,26 +1586,24 @@ void GUI::underlay_calib_prompt_x_distance_(const std::shared_ptr<Sketch>& sk)
     m_underlay_calib_phase = Underlay_calib_phase::None;
     show_message(
         "X distance applied to the picked segment. Use Set Y from edge for the vertical span if needed, or adjust "
-        "transforms.");
+                "transforms.");
   };
 
   set_dist_edit(dist_show, std::move(on_dist), spos);
 }
-
-void GUI::underlay_calib_prompt_y_distance_(const std::shared_ptr<Sketch>& sk)
+void GUI::underlay_calib_prompt_y_distance_(const Sketch::sptr& sk)
 {
   m_underlay_calib_phase       = Underlay_calib_phase::AwaitDistY;
   const double       L_model   = m_underlay_calib_y0.Distance(m_underlay_calib_y1);
   const float        dist_show = static_cast<float>(L_model / m_view->get_dimension_scale());
   const ScreenCoords spos(dvec2(ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y));
 
-  std::weak_ptr<Sketch> wk      = sk;
-  auto                  on_dist = [this, wk](float new_dist, bool is_final)
-  {
+  Sketch::wptr wk      = sk;
+  auto         on_dist = [this, wk](float new_dist, bool is_final) {
     if (!is_final)
       return;
 
-    const std::shared_ptr<Sketch> s = wk.lock();
+    const Sketch::sptr s = wk.lock();
     if (!s || !s->has_underlay())
     {
       m_dist_callback = nullptr;
@@ -1688,12 +1637,11 @@ void GUI::underlay_calib_prompt_y_distance_(const std::shared_ptr<Sketch>& sk)
     cancel_underlay_calib_();
     show_message(
         "Y distance applied to the picked segment. Use Set X from edge for the horizontal span if needed, or adjust "
-        "transforms.");
+                "transforms.");
   };
 
   set_dist_edit(dist_show, std::move(on_dist), spos);
 }
-
 bool GUI::try_underlay_calib_click_(const ScreenCoords& screen_coords)
 {
   if (m_underlay_calib_phase == Underlay_calib_phase::None)
@@ -1703,8 +1651,8 @@ bool GUI::try_underlay_calib_click_(const ScreenCoords& screen_coords)
       m_underlay_calib_phase == Underlay_calib_phase::AwaitDistY)
     return true;
 
-  const std::shared_ptr<Sketch> sk     = m_underlay_calib_sketch_wk.lock();
-  const std::shared_ptr<Sketch> sk_cur = m_view->curr_sketch_shared();
+  const Sketch::sptr sk     = m_underlay_calib_sketch_wk.lock();
+  const Sketch::sptr sk_cur = m_view->curr_sketch_shared();
   if (!sk || !sk_cur || sk != sk_cur)
   {
     cancel_underlay_calib_();
@@ -1722,8 +1670,7 @@ bool GUI::try_underlay_calib_click_(const ScreenCoords& screen_coords)
   if (!pt)
     return true;
 
-  auto too_short = [](const gp_Pnt2d& a, const gp_Pnt2d& b)
-  {
+  auto too_short = [](const gp_Pnt2d& a, const gp_Pnt2d& b) {
     const double dx = b.X() - a.X();
     const double dy = b.Y() - a.Y();
     return dx * dx + dy * dy <= 1e-16;
@@ -1799,7 +1746,6 @@ bool GUI::try_underlay_calib_click_(const ScreenCoords& screen_coords)
       return false;
   }
 }
-
 void GUI::shape_list_()
 {
   if (!m_show_shape_list)
@@ -1894,8 +1840,7 @@ void GUI::shape_list_()
     if (mat_idx < 0 || mat_idx >= nmat)
       mat_idx = static_cast<int>(m_view->get_default_material().Name());
 
-    auto apply_shape_material = [&](int i)
-    {
+    auto apply_shape_material = [&](int i) {
       if (i < 0 || i >= nmat)
         return;
 
@@ -2002,7 +1947,6 @@ void GUI::shape_list_()
   ImGui::EndChild();
   ImGui::End();
 }
-
 float GUI::list_name_field_width_(const ImGuiStyle& st, const float max_name_text_w)
 {
   constexpr float k_name_field_cap   = 480.f;
@@ -2011,7 +1955,6 @@ float GUI::list_name_field_width_(const ImGuiStyle& st, const float max_name_tex
   const float     name_pad_x         = st.FramePadding.x * 2.0f;
   return std::clamp(max_name_text_w + name_pad_x, k_name_field_floor, k_name_field_cap);
 }
-
 #ifndef NDEBUG
 void GUI::dbg_()
 {
@@ -2046,14 +1989,12 @@ void GUI::dbg_()
 #else
 void GUI::dbg_() {}
 #endif
-
 void GUI::show_message(const std::string& message)
 {
   m_message            = message;
   m_message_visible    = true;
   m_message_start_time = std::chrono::steady_clock::now();
 }
-
 void GUI::message_status_window_()
 {
   if (!m_message_visible || m_message.empty())
@@ -2096,7 +2037,6 @@ void GUI::message_status_window_()
 
   ImGui::End();
 }
-
 // Log window implementation
 void GUI::log_message(const std::string& message)
 {
@@ -2104,15 +2044,13 @@ void GUI::log_message(const std::string& message)
   {
     m_log_buffer.pop_back();  // trailing '\0'
     m_log_buffer.push_back('\n');
-  }
-  else if (!m_log_buffer.empty())
+  } else if (!m_log_buffer.empty())
     m_log_buffer.pop_back();
 
   m_log_buffer.insert(m_log_buffer.end(), message.begin(), message.end());
   m_log_buffer.push_back('\0');
   m_log_scroll_to_bottom = true;
 }
-
 void GUI::log_window_()
 {
   if (!m_log_window_visible)
@@ -2139,7 +2077,6 @@ void GUI::log_window_()
   ImGui::EndChild();
   ImGui::End();
 }
-
 void GUI::lua_console_()
 {
   if (!m_show_lua_console)
@@ -2148,7 +2085,6 @@ void GUI::lua_console_()
     m_lua_console = std::make_unique<Lua_console>(this);
   m_lua_console->render(&m_show_lua_console);
 }
-
 void GUI::python_console_()
 {
   if (!m_show_python_console)
@@ -2158,14 +2094,12 @@ void GUI::python_console_()
     m_python_console = std::make_unique<Python_console>(this);
   m_python_console->render(&m_show_python_console);
 }
-
 void GUI::init(GLFWwindow* window, ImFont* console_font)
 {
   m_glfw_window  = window;
   m_console_font = console_font;
   initialize_toolbar_();
-  settings::set_log_callback([this](const std::string& m)
-                             { log_message(m); });
+  settings::set_log_callback([this](const std::string& m) { log_message(m); });
   setup_log_redirection_();  // Set up stream redirection
   log_message("EzyCad: initializing 3D view...");
   m_view->init_window(window);
@@ -2183,7 +2117,6 @@ void GUI::init(GLFWwindow* window, ImFont* console_font)
 
   load_default_project_();
 }
-
 void GUI::persist_last_opened_project_path_(const std::string& path)
 {
 #ifndef __EMSCRIPTEN__
@@ -2198,13 +2131,11 @@ void GUI::persist_last_opened_project_path_(const std::string& path)
 
     m_last_opened_project_path = p.generic_string();
     save_occt_view_settings();
-  }
-  catch (...)
+  } catch (...)
   {
   }
 #endif
 }
-
 void GUI::load_default_project_()
 {
   static constexpr char k_bundled_default[] = "res/default.ezy";
@@ -2233,11 +2164,9 @@ void GUI::load_default_project_()
           log_message("EzyCad: last opened project JSON is invalid; falling back to startup/default.");
           show_message("Last opened project file is invalid; loading startup/default.");
         }
-      }
-      else
+      } else
         log_message("EzyCad: last opened project path not found; falling back to startup/default.");
-    }
-    catch (...)
+    } catch (...)
     {
       log_message("EzyCad: could not load last opened project; falling back to startup/default.");
     }
@@ -2263,8 +2192,7 @@ void GUI::load_default_project_()
   {
     log_message("EzyCad: saved startup project is invalid or incomplete; falling back to install default.");
     show_message("Saved startup project is invalid; loading install default.");
-  }
-  else
+  } else
     log_message("EzyCad: no saved startup project; trying bundled default.");
 
   std::ifstream file(k_bundled_default, std::ios::binary);
@@ -2281,11 +2209,9 @@ void GUI::load_default_project_()
     on_file(k_bundled_default, json_str, false);
     m_last_saved_path.clear();
     log_message("EzyCad: startup document loaded (bundled default).");
-  }
-  else
+  } else
     log_message("EzyCad: bundled " + std::string(k_bundled_default) + " is invalid; keeping initial empty document.");
 }
-
 std::string GUI::serialized_project_json_() const
 {
   using namespace nlohmann;
@@ -2294,7 +2220,6 @@ std::string GUI::serialized_project_json_() const
   j["mode"]                = static_cast<int>(get_mode());
   return j.dump(2);
 }
-
 void GUI::save_startup_project_()
 {
   if (!settings::save_user_startup_project(serialized_project_json_()))
@@ -2310,13 +2235,11 @@ void GUI::save_startup_project_()
 #endif
   show_message("Startup project saved. It will load automatically the next time you start EzyCad.");
 }
-
 void GUI::clear_saved_startup_project_()
 {
   settings::clear_user_startup_project();
   show_message("Saved startup cleared. Next launch uses the install default (res/default.ezy).");
 }
-
 void GUI::on_mouse_pos(const ScreenCoords& screen_coords)
 {
   m_view->on_mouse_move(screen_coords);
@@ -2365,7 +2288,6 @@ void GUI::on_mouse_pos(const ScreenCoords& screen_coords)
       break;
   }
 }
-
 void GUI::on_mouse_button(int button, int action, int mods)
 {
   const ScreenCoords screen_coords(dvec2(ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y));
@@ -2443,7 +2365,6 @@ void GUI::on_mouse_button(int button, int action, int mods)
         break;
     }
 }
-
 void GUI::on_mouse_scroll(double xoffset, double yoffset)
 {
   EZY_ASSERT(m_glfw_window != nullptr);
@@ -2452,12 +2373,10 @@ void GUI::on_mouse_scroll(double xoffset, double yoffset)
 
   m_view->on_mouse_scroll(xoffset, yoffset, shift_finer);
 }
-
 void GUI::on_resize(int width, int height)
 {
   m_view->on_resize(width, height);
 }
-
 void GUI::setup_log_redirection_()
 {
   // Store original stream buffers
@@ -2472,7 +2391,6 @@ void GUI::setup_log_redirection_()
   std::cout.rdbuf(m_cout_log_buf);
   std::cerr.rdbuf(m_cerr_log_buf);
 }
-
 void GUI::cleanup_log_redirection_()
 {
   // Restore original stream buffers
@@ -2491,7 +2409,6 @@ void GUI::cleanup_log_redirection_()
   m_original_cout_buf = nullptr;
   m_original_cerr_buf = nullptr;
 }
-
 // Import/export related
 void GUI::export_file_dialog_(Export_format fmt)
 {
@@ -2574,7 +2491,6 @@ void GUI::export_file_dialog_(Export_format fmt)
   show_message("Exported: " + download_name);
 #endif
 }
-
 void GUI::import_file_dialog_()
 {
 #ifndef __EMSCRIPTEN__
@@ -2608,14 +2524,12 @@ void GUI::import_file_dialog_()
   import_file_dialog_async();
 #endif
 }
-
 // Open save related
 void GUI::new_project_()
 {
   m_last_saved_path.clear();
   m_view->new_file();
 }
-
 void GUI::open_file_dialog_()
 {
 #ifndef __EMSCRIPTEN__
@@ -2644,7 +2558,6 @@ void GUI::open_file_dialog_()
   open_file_dialog_async();
 #endif
 }
-
 void GUI::save_file_dialog_()
 {
   const std::string json_str = serialized_project_json_();
@@ -2672,18 +2585,15 @@ void GUI::save_file_dialog_()
       out.write(json_str.data(), json_str.size());
       out.close();
       show_message("Saved: " + std::filesystem::path(file).filename().string());
-    }
-    else
+    } else
       show_message("Failed to save: " + std::filesystem::path(file).filename().string());
-  }
-  else
+  } else
     show_message("Save canceled");
 #else
   std::string default_file = m_last_saved_path.empty() ? "project.ezy" : std::filesystem::path(m_last_saved_path).filename().string();
   save_file_dialog_async("Save EzyCad project", default_file, json_str);
 #endif
 }
-
 void GUI::on_file(const std::string& file_path, const std::string& json_str, bool announce_load)
 {
   using namespace nlohmann;
@@ -2706,7 +2616,6 @@ void GUI::on_file(const std::string& file_path, const std::string& json_str, boo
   if (announce_load)
     show_message("Opened: " + std::filesystem::path(file_path).filename().string());
 }
-
 void GUI::on_import_file(const std::string& file_path, const std::string& file_data)
 {
   std::string ext = std::filesystem::path(file_path).extension().string();
@@ -2727,7 +2636,6 @@ void GUI::on_import_file(const std::string& file_path, const std::string& file_d
   else
     show_message("Imported: " + std::filesystem::path(file_path).filename().string());
 }
-
 #ifdef __EMSCRIPTEN__
 void GUI::open_file_dialog_async()
 {
@@ -2762,7 +2670,6 @@ void GUI::open_file_dialog_async()
     input.click();
   });
 }
-
 void GUI::import_file_dialog_async()
 {
   EM_ASM({
@@ -2794,7 +2701,6 @@ void GUI::import_file_dialog_async()
     input.click();
   });
 }
-
 void GUI::sketch_underlay_file_dialog_async()
 {
   EM_ASM({
@@ -2826,7 +2732,6 @@ void GUI::sketch_underlay_file_dialog_async()
     input.click();
   });
 }
-
 void GUI::save_file_dialog_async(const char* title, const std::string& default_file, const std::string& json_str)
 {
   EM_ASM_ARGS({
@@ -2842,13 +2747,11 @@ void GUI::save_file_dialog_async(const char* title, const std::string& default_f
       URL.revokeObjectURL(url);
       Module.ccall('on_save_file_selected', null, ['string'], [UTF8ToString($2)]); }, json_str.data(), json_str.size(), default_file.c_str());
 }
-
 void GUI::note_saved_project_filename(const std::string& filename)
 {
   if (!filename.empty())
     m_last_saved_path = filename;
 }
-
 void GUI::download_blob_async(const std::string& default_filename, const std::string& data)
 {
   EM_ASM_ARGS({
@@ -2862,26 +2765,22 @@ void GUI::download_blob_async(const std::string& default_filename, const std::st
       document.body.removeChild(a);
       URL.revokeObjectURL(url); }, data.data(), data.size(), default_filename.c_str());
 }
-
 // C-style callback for Emscripten
 extern "C" void on_file_selected(const char* file_path, char* contents, int length)
 {
   const std::string json_str(contents, length);
   GUI::instance().on_file(file_path, json_str);
 }
-
 extern "C" void on_import_file_selected(const char* file_path, char* contents, int length)
 {
   const std::string file_bytes(contents, static_cast<size_t>(length));
   GUI::instance().on_import_file(file_path, file_bytes);
 }
-
 extern "C" void on_sketch_underlay_selected(const char* file_path, char* contents, int length)
 {
   const std::string file_bytes(contents, static_cast<size_t>(length));
   GUI::instance().on_sketch_underlay_file(file_path, file_bytes);
 }
-
 extern "C" void on_save_file_selected(const char* file_name)
 {
   GUI& g = GUI::instance();
@@ -2889,5 +2788,4 @@ extern "C" void on_save_file_selected(const char* file_name)
     g.note_saved_project_filename(file_name);
   g.show_message(std::string("Saved: ") + (file_name ? file_name : ""));
 }
-
 #endif

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1258,8 +1258,8 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
     if (sk->has_underlay())
     {
       sk->underlay_ui_params(m_ul_cx, m_ul_cy, m_ul_hw, m_ul_hh, m_ul_rot);
-      m_ul_opacity   = sk->underlay_opacity();
-      m_ul_vis       = sk->underlay_visible();
+      m_ul_opacity     = sk->underlay_opacity();
+      m_ul_vis         = sk->underlay_visible();
       m_ul_key_white = sk->underlay_key_white_transparent();
       m_ul_line_tint = sk->underlay_line_tint_enabled();
       {
@@ -1351,6 +1351,9 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
 
   if (ImGui::SliderFloat("Opacity", &m_ul_opacity, 0.f, 1.f, "%.2f"))
     sk->underlay_set_opacity(m_ul_opacity);
+
+  if (m_show_tool_tips && ImGui::IsItemHovered())
+    ImGui::SetTooltip("Overall opacity of the underlay image (0 = fully transparent, 1 = fully opaque).");
 
   ImGui::Separator();
   ImGui::TextUnformatted("Calibrate from sketch edges");

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1263,11 +1263,12 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
       m_ul_key_white = sk->underlay_key_white_transparent();
       m_ul_line_tint = sk->underlay_line_tint_enabled();
       {
-        uint8_t tr, tg, tb;
-        sk->underlay_line_tint_rgb(tr, tg, tb);
+        uint8_t tr, tg, tb, ta;
+        sk->underlay_line_tint_rgba(tr, tg, tb, ta);
         m_ul_tint_col[0] = static_cast<float>(tr) / 255.f;
         m_ul_tint_col[1] = static_cast<float>(tg) / 255.f;
         m_ul_tint_col[2] = static_cast<float>(tb) / 255.f;
+        m_ul_tint_col[3] = static_cast<float>(ta) / 255.f;
       }
     }
     else
@@ -1277,9 +1278,7 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
       m_ul_vis                                         = true;
       m_ul_key_white                                   = true;
       m_ul_line_tint                                   = true;
-      m_ul_tint_col[0]                                 = 1.f;
-      m_ul_tint_col[1]                                 = 0.863f;
-      m_ul_tint_col[2]                                 = 0.f;
+      m_ul_tint_col                                    = glm::vec4(1.f, 0.863f, 0.f, 1.f);
     }
   }
 
@@ -1339,14 +1338,15 @@ void GUI::sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk)
         "Default yellow reads well on dark backgrounds.");
 
   if (m_ul_line_tint)
-    if (ImGui::ColorEdit3("Line color", m_ul_tint_col))
+    if (ImGui::ColorEdit4("Line color", &m_ul_tint_col[0]))
     {
       const auto to_u8 = [](float c) -> uint8_t
       {
         const float x = std::clamp(c, 0.f, 1.f) * 255.f;
         return static_cast<uint8_t>(x + 0.5f);
       };
-      sk->underlay_set_line_tint_rgb(to_u8(m_ul_tint_col[0]), to_u8(m_ul_tint_col[1]), to_u8(m_ul_tint_col[2]));
+      sk->underlay_set_line_tint_rgba(
+          to_u8(m_ul_tint_col[0]), to_u8(m_ul_tint_col[1]), to_u8(m_ul_tint_col[2]), to_u8(m_ul_tint_col[3]));
     }
 
   if (ImGui::SliderFloat("Opacity", &m_ul_opacity, 0.f, 1.f, "%.2f"))

--- a/src/gui.h
+++ b/src/gui.h
@@ -17,15 +17,16 @@
 #include "imgui_markdown.h"
 #include "log.h"
 #include "modes.h"
+#include "occt_view.h"
 #include "types.h"
 
 class Lua_console;
 class Python_console;
-class Occt_view;
 class Sketch;
 struct GLFWwindow;
 
-enum class Command {
+enum class Command
+{
   Shape_cut,
   Shape_fuse,
   Shape_common,
@@ -33,7 +34,8 @@ enum class Command {
 };
 
 /// Two-segment picks for underlay X/Y calibration (Sketch properties pane).
-enum class Underlay_calib_phase : std::uint8_t {
+enum class Underlay_calib_phase : std::uint8_t
+{
   None,
   PickX1,
   PickX2,
@@ -141,7 +143,8 @@ class GUI
   /// Default RGBA (0-255) for sketch underlay line tint when importing a new image (see Settings).
   void       underlay_highlight_color_rgba(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a) const;
   /// For scripting (Lua console): access the 3D view.
-  Occt_view* get_view() {
+  Occt_view* get_view()
+  {
     return m_view.get();
   }
 
@@ -175,36 +178,39 @@ class GUI
   void options_shape_polar_duplicate_mode_();
   void options_rotate_mode_();
 
-  void                            dbg_();
-  void                            initialize_toolbar_();
-  void                            load_examples_list_();
-  void                            load_default_project_();
-  void                            menu_bar_();
-  void                            toolbar_();
-  void                            message_status_window_();
-  void                            add_box_dialog_();
-  void                            add_pyramid_dialog_();
-  void                            add_sphere_dialog_();
-  void                            add_cylinder_dialog_();
-  void                            add_cone_dialog_();
-  void                            add_torus_dialog_();
-  void                            about_dialog_();
-  void                            ensure_about_assets_();
+  void         dbg_();
+  void         initialize_toolbar_();
+  void         load_examples_list_();
+  void         load_default_project_();
+  void         menu_bar_();
+  void         toolbar_();
+  void         message_status_window_();
+  void         add_box_dialog_();
+  void         add_pyramid_dialog_();
+  void         add_sphere_dialog_();
+  void         add_cylinder_dialog_();
+  void         add_cone_dialog_();
+  void         add_torus_dialog_();
+  void         about_dialog_();
+  void         ensure_about_assets_();
+  static float list_name_field_width_(const ImGuiStyle& st, float max_name_text_w);
+  void         log_window_();
+  void         lua_console_();
+  void         python_console_();
+  void         settings_();
+  void         setup_log_redirection_();
+  void         cleanup_log_redirection_();
+
+  // About dialog markdown callbacks (for links and images in `about.md`).
   ImGui::MarkdownImageData        about_markdown_image_(ImGui::MarkdownLinkCallbackData data);
   static void                     about_markdown_link_cb_(ImGui::MarkdownLinkCallbackData data);
   static ImGui::MarkdownImageData about_markdown_image_cb_(ImGui::MarkdownLinkCallbackData data);
-  static float                    list_name_field_width_(const ImGuiStyle& st, float max_name_text_w);
-  void                            log_window_();
-  void                            lua_console_();
-  void                            python_console_();
-  void                            settings_();
-  void                            setup_log_redirection_();
-  void                            cleanup_log_redirection_();
 
   // Import/export related
   void import_file_dialog_();
   void export_file_dialog_(Export_format fmt);
 
+  // Sketch underlay related
   void sketch_underlay_import_dialog_();
   void sketch_underlay_panel_settings_(const std::shared_ptr<Sketch>& sk);
   void cancel_underlay_calib_();
@@ -223,18 +229,19 @@ class GUI
   void open_file_dialog_();
   void save_file_dialog_();
 
-  void                                   save_startup_project_();
-  void                                   clear_saved_startup_project_();
+  void                      save_startup_project_();
+  void                      clear_saved_startup_project_();
   /// Native only: store path in settings after a successful Open (for optional startup load).
-  void                                   persist_last_opened_project_path_(const std::string& path);
-  std::string                            serialized_project_json_() const;
-  void                                   open_url_(const std::string& url);
-  void                                   update_window_title_();
-  [[nodiscard]] std::string              project_title_segment_() const;
+  void                      persist_last_opened_project_path_(const std::string& path);
+  std::string               serialized_project_json_() const;
+  void                      open_url_(const std::string& url);
+  void                      update_window_title_();
+  [[nodiscard]] std::string project_title_segment_() const;
   /// Parses a float from manual dist/angle ImGui text fields (trimmed, full-string match).
-  static bool                            parse_dist_text_to_float_(const char* buf, float& out);
+  static bool               parse_dist_text_to_float_(const char* buf, float& out);
   /// True if JSON parses and looks like an EzyCad project document (`sketches` array).
-  static bool                            is_valid_project_json_(const std::string& s);
+  static bool               is_valid_project_json_(const std::string& s);
+
   /// OCCT standard material display names for ImGui combos (index matches \c Graphic3d_NameOfMaterial).
   static const std::vector<std::string>& occt_material_combo_labels_();
 
@@ -245,9 +252,9 @@ class GUI
   void apply_imgui_rounding_from_members_();
   void imgui_rounding_fallbacks_from_theme_(float& general, float& scroll, float& tabs) const;
 
-  std::unique_ptr<Occt_view> m_view;
-  GLFWwindow*                m_glfw_window {nullptr};
-  std::string                m_cached_window_title;
+  Occt_view::uptr m_view;
+  GLFWwindow*     m_glfw_window {nullptr};
+  std::string     m_cached_window_title;
 
   // Sketch segment manual length input related
   std::function<void(float, bool)> m_dist_callback;
@@ -299,43 +306,44 @@ class GUI
   using Example_file_list = std::vector<Example_file>;
   Example_file_list m_example_files;
 
-  bool                                    m_show_sketch_list {true};
   std::unordered_map<const Sketch*, bool> m_sketch_list_expanded;
-  bool                                    m_show_shape_list {true};
-  bool                                    m_show_options {true};
-  bool                                    m_show_settings_dialog {false};
-  bool                                    m_open_about_popup {false};
-  bool                                    m_about_popup_open {false};
-  std::string                             m_about_markdown;
-  uint32_t                                m_about_splash_gl {0};
-  int                                     m_about_splash_w {512};
-  int                                     m_about_splash_h {512};
-  bool                                    m_about_assets_loaded {false};
-  bool                                    m_open_add_box_popup {false};
-  double                                  m_add_box_origin_x {0};
-  double                                  m_add_box_origin_y {0};
-  double                                  m_add_box_origin_z {0};
-  double                                  m_add_box_width {1};
-  double                                  m_add_box_length {1};
-  double                                  m_add_box_height {1};
-  bool                                    m_open_add_pyramid_popup {false};
-  double                                  m_add_pyramid_origin_x {0}, m_add_pyramid_origin_y {0}, m_add_pyramid_origin_z {0};
-  double                                  m_add_pyramid_side {1};
-  bool                                    m_open_add_sphere_popup {false};
-  double                                  m_add_sphere_origin_x {0}, m_add_sphere_origin_y {0}, m_add_sphere_origin_z {0};
-  double                                  m_add_sphere_radius {1};
-  bool                                    m_open_add_cylinder_popup {false};
-  double                                  m_add_cylinder_origin_x {0}, m_add_cylinder_origin_y {0}, m_add_cylinder_origin_z {0};
-  double                                  m_add_cylinder_radius {1}, m_add_cylinder_height {1};
-  bool                                    m_open_add_cone_popup {false};
-  double                                  m_add_cone_origin_x {0}, m_add_cone_origin_y {0}, m_add_cone_origin_z {0};
-  double                                  m_add_cone_R1 {1}, m_add_cone_R2 {0}, m_add_cone_height {1};
-  bool                                    m_open_add_torus_popup {false};
-  double                                  m_add_torus_origin_x {0}, m_add_torus_origin_y {0}, m_add_torus_origin_z {0};
-  double                                  m_add_torus_R1 {1}, m_add_torus_R2 {0.5};
-  bool                                    m_hide_all_shapes {false};
-  bool                                    m_show_tool_tips {true};
-  bool                                    m_dark_mode {false};
+
+  bool        m_show_sketch_list {true};
+  bool        m_show_shape_list {true};
+  bool        m_show_options {true};
+  bool        m_show_settings_dialog {false};
+  bool        m_open_about_popup {false};
+  bool        m_about_popup_open {false};
+  std::string m_about_markdown;
+  uint32_t    m_about_splash_gl {0};
+  int         m_about_splash_w {512};
+  int         m_about_splash_h {512};
+  bool        m_about_assets_loaded {false};
+  bool        m_open_add_box_popup {false};
+  double      m_add_box_origin_x {0};
+  double      m_add_box_origin_y {0};
+  double      m_add_box_origin_z {0};
+  double      m_add_box_width {1};
+  double      m_add_box_length {1};
+  double      m_add_box_height {1};
+  bool        m_open_add_pyramid_popup {false};
+  double      m_add_pyramid_origin_x {0}, m_add_pyramid_origin_y {0}, m_add_pyramid_origin_z {0};
+  double      m_add_pyramid_side {1};
+  bool        m_open_add_sphere_popup {false};
+  double      m_add_sphere_origin_x {0}, m_add_sphere_origin_y {0}, m_add_sphere_origin_z {0};
+  double      m_add_sphere_radius {1};
+  bool        m_open_add_cylinder_popup {false};
+  double      m_add_cylinder_origin_x {0}, m_add_cylinder_origin_y {0}, m_add_cylinder_origin_z {0};
+  double      m_add_cylinder_radius {1}, m_add_cylinder_height {1};
+  bool        m_open_add_cone_popup {false};
+  double      m_add_cone_origin_x {0}, m_add_cone_origin_y {0}, m_add_cone_origin_z {0};
+  double      m_add_cone_R1 {1}, m_add_cone_R2 {0}, m_add_cone_height {1};
+  bool        m_open_add_torus_popup {false};
+  double      m_add_torus_origin_x {0}, m_add_torus_origin_y {0}, m_add_torus_origin_z {0};
+  double      m_add_torus_R1 {1}, m_add_torus_R2 {0.5};
+  bool        m_hide_all_shapes {false};
+  bool        m_show_tool_tips {true};
+  bool        m_dark_mode {false};
 #ifndef NDEBUG
   bool m_show_dbg {false};
 #endif

--- a/src/gui.h
+++ b/src/gui.h
@@ -316,30 +316,25 @@ class GUI
   bool        m_about_popup_open {false};
   std::string m_about_markdown;
   uint32_t    m_about_splash_gl {0};
-  int         m_about_splash_w {512};
-  int         m_about_splash_h {512};
+  glm::ivec2  m_about_splash_size {512, 512};
   bool        m_about_assets_loaded {false};
   bool        m_open_add_box_popup {false};
-  double      m_add_box_origin_x {0};
-  double      m_add_box_origin_y {0};
-  double      m_add_box_origin_z {0};
-  double      m_add_box_width {1};
-  double      m_add_box_length {1};
-  double      m_add_box_height {1};
+  glm::dvec3  m_add_box_origin {0.0, 0.0, 0.0};
+  glm::dvec3  m_add_box_size {1.0, 1.0, 1.0};
   bool        m_open_add_pyramid_popup {false};
-  double      m_add_pyramid_origin_x {0}, m_add_pyramid_origin_y {0}, m_add_pyramid_origin_z {0};
+  glm::dvec3  m_add_pyramid_origin {0.0, 0.0, 0.0};
   double      m_add_pyramid_side {1};
   bool        m_open_add_sphere_popup {false};
-  double      m_add_sphere_origin_x {0}, m_add_sphere_origin_y {0}, m_add_sphere_origin_z {0};
+  glm::dvec3  m_add_sphere_origin {0.0, 0.0, 0.0};
   double      m_add_sphere_radius {1};
   bool        m_open_add_cylinder_popup {false};
-  double      m_add_cylinder_origin_x {0}, m_add_cylinder_origin_y {0}, m_add_cylinder_origin_z {0};
+  glm::dvec3  m_add_cylinder_origin {0.0, 0.0, 0.0};
   double      m_add_cylinder_radius {1}, m_add_cylinder_height {1};
   bool        m_open_add_cone_popup {false};
-  double      m_add_cone_origin_x {0}, m_add_cone_origin_y {0}, m_add_cone_origin_z {0};
+  glm::dvec3  m_add_cone_origin {0.0, 0.0, 0.0};
   double      m_add_cone_R1 {1}, m_add_cone_R2 {0}, m_add_cone_height {1};
   bool        m_open_add_torus_popup {false};
-  double      m_add_torus_origin_x {0}, m_add_torus_origin_y {0}, m_add_torus_origin_z {0};
+  glm::dvec3  m_add_torus_origin {0.0, 0.0, 0.0};
   double      m_add_torus_R1 {1}, m_add_torus_R2 {0.5};
   bool        m_hide_all_shapes {false};
   bool        m_show_tool_tips {true};
@@ -352,6 +347,10 @@ class GUI
   float                 m_imgui_rounding_general {0.f};
   float                 m_imgui_rounding_scroll {0.f};
   float                 m_imgui_rounding_tabs {0.f};
+  bool                  m_sketch_properties_open {false};
+  std::weak_ptr<Sketch> m_sketch_properties_sketch;
+
+  // Sketch underlay related
   void*                 m_underlay_panel_sketch {nullptr};
   Underlay_calib_phase  m_underlay_calib_phase {Underlay_calib_phase::None};
   std::weak_ptr<Sketch> m_underlay_calib_sketch_wk {};
@@ -361,20 +360,16 @@ class GUI
   gp_Pnt2d              m_underlay_calib_y0 {};
   gp_Pnt2d              m_underlay_calib_y1 {};
   gp_Pnt2d              m_underlay_calib_datum_o {};
-  bool                  m_sketch_properties_open {false};
-  std::weak_ptr<Sketch> m_sketch_properties_sketch;
   /// If set, next underlay import (menu or async) applies to this sketch; otherwise current sketch.
   std::weak_ptr<Sketch> m_underlay_import_sketch_target;
-  double                m_ul_cx {};
-  double                m_ul_cy {};
-  double                m_ul_hw {};
-  double                m_ul_hh {};
-  double                m_ul_rot {};
-  float                 m_ul_opacity {0.88f};
-  bool                  m_ul_vis {true};
-  bool                  m_ul_key_white {true};
-  bool                  m_ul_line_tint {true};
-  glm::vec4             m_ul_tint_col {1.f, 220.f / 255.f, 0.f, 1.f};
+  glm::dvec2            m_underlay_center {};
+  glm::dvec2            m_underlay_half_extents {};
+  double                m_underlay_rot {};
+  float                 m_underlay_opacity {0.88f};
+  bool                  m_underlay_vis {true};
+  bool                  m_underlay_key_white {true};
+  bool                  m_underlay_line_tint {true};
+  glm::vec4             m_underlay_tint_col {1.f, 220.f / 255.f, 0.f, 1.f};
   /// Default underlay tint for new imports (0-1, persisted in ezycad_settings.json).
   glm::vec4             m_underlay_highlight_color {1.f, 220.f / 255.f, 0.f, 1.f};
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -25,8 +25,7 @@ class Occt_view;
 class Sketch;
 struct GLFWwindow;
 
-enum class Command
-{
+enum class Command {
   Shape_cut,
   Shape_fuse,
   Shape_common,
@@ -34,8 +33,7 @@ enum class Command
 };
 
 /// Two-segment picks for underlay X/Y calibration (Sketch properties pane).
-enum class Underlay_calib_phase : std::uint8_t
-{
+enum class Underlay_calib_phase : std::uint8_t {
   None,
   PickX1,
   PickX2,
@@ -47,14 +45,12 @@ enum class Underlay_calib_phase : std::uint8_t
   PickDatumO,
   PickDatumU
 };
-
 /// One entry under File > Examples (menu label + path to `.ezy` on disk).
 struct Example_file
 {
   std::string label;
   std::string path;
 };
-
 /// Default OCCT line-width scale for length dimensions when `edge_dim_line_width` is missing from settings JSON.
 inline constexpr float  k_gui_edge_dim_line_width_default    = 1.0f;
 /// Default OCCT arrow length for length dimensions when `edge_dim_arrow_size` is missing from settings JSON.
@@ -67,7 +63,6 @@ inline constexpr double k_gui_view_roll_step_deg_default     = 45.0;
 inline constexpr double k_gui_view_zoom_scroll_scale_min     = 0.25;
 inline constexpr double k_gui_view_zoom_scroll_scale_max     = 64.0;
 inline constexpr double k_gui_view_zoom_scroll_scale_default = 4.0;
-
 class GUI
 {
  public:
@@ -78,58 +73,50 @@ class GUI
   static GUI& instance();
 #endif
 
-  void init(GLFWwindow* window, ImFont* console_font);
-
+  void    init(GLFWwindow* window, ImFont* console_font);
   /// Monospace font for script console (normally set via init() from main after io.Fonts load).
-  void set_console_font(ImFont* font)
-  {
-    m_console_font = font;
-  }
-
+  void    set_console_font(ImFont* font) { m_console_font = font; }
   ImFont* console_font() const;
 
   void render_gui();
   void render_occt();
 
-  void on_key(int key, int scancode, int action, int mods);  // gui_mode.cpp
-  void on_mouse_pos(const ScreenCoords& screen_coords);
-  void on_mouse_button(int button, int action, int mods);
-  void on_mouse_scroll(double xoffset, double yoffset);
-  void on_resize(int width, int height);
-
-  // clang-format off
-  Mode get_mode() const { return m_mode; }
+  void         on_key(int key, int scancode, int action, int mods);  // gui_mode.cpp
+  void         on_mouse_pos(const ScreenCoords& screen_coords);
+  void         on_mouse_button(int button, int action, int mods);
+  void         on_mouse_scroll(double xoffset, double yoffset);
+  void         on_resize(int width, int height);
+  Mode         get_mode() const { return m_mode; }
   Chamfer_mode get_chamfer_mode() const { return m_chamfer_mode; }
-  Fillet_mode get_fillet_mode() const { return m_fillet_mode; }
+  Fillet_mode  get_fillet_mode() const { return m_fillet_mode; }
   /// Edge dimension value placement (Options panel, toggle-dimension tool): 0 first point, 1 second, 2 center, 3 auto.
-  int edge_dim_label_h() const { return m_edge_dim_label_h; }
+  int          edge_dim_label_h() const { return m_edge_dim_label_h; }
   /// OCCT scale factor for sketch/extrude length dimension lines (1.0 = default thickness).
-  float edge_dim_line_width() const { return m_edge_dim_line_width; }
+  float        edge_dim_line_width() const { return m_edge_dim_line_width; }
   /// OCCT arrow length for sketch/extrude length dimensions.
-  float edge_dim_arrow_size() const { return m_edge_dim_arrow_size; }
-  bool get_hide_all_shapes() const { return m_hide_all_shapes; }
-  void set_hide_all_shapes(bool hide) { m_hide_all_shapes = hide; }
-  bool get_dark_mode() const { return m_dark_mode; }
-  ImVec4 get_clear_color() const;
-  void set_mode(Mode mode);       // gui_mode.cpp
-  void set_parent_mode();        // gui_mode.cpp
-  void set_dist_edit(float dist, std::function<void(float, bool)>&& callback, const std::optional<ScreenCoords> screen_coords = std::nullopt);
-  void hide_dist_edit();
-  void set_angle_edit(float angle, std::function<void(float, bool)>&& callback, const std::optional<ScreenCoords> screen_coords = std::nullopt);
-  void hide_angle_edit();
+  float        edge_dim_arrow_size() const { return m_edge_dim_arrow_size; }
+  bool         get_hide_all_shapes() const { return m_hide_all_shapes; }
+  void         set_hide_all_shapes(bool hide) { m_hide_all_shapes = hide; }
+  bool         get_dark_mode() const { return m_dark_mode; }
+  ImVec4       get_clear_color() const;
+  void         set_mode(Mode mode);  // gui_mode.cpp
+  void         set_parent_mode();    // gui_mode.cpp
+  void         set_dist_edit(float dist, std::function<void(float, bool)>&& callback, const std::optional<ScreenCoords> screen_coords = std::nullopt);
+  void         hide_dist_edit();
+  void         set_angle_edit(float angle, std::function<void(float, bool)>&& callback, const std::optional<ScreenCoords> screen_coords = std::nullopt);
+  void         hide_angle_edit();
   /// True when dist or angle edit is visible; Tab should be routed to on_key() instead of ImGui.
-  bool is_dist_or_angle_edit_active() const;
-  void show_message(const std::string& message);
-  void log_message(const std::string& message);
-  void set_show_options(bool v) { m_show_options = v; }
-  void set_show_sketch_list(bool v) { m_show_sketch_list = v; }
-  void set_show_shape_list(bool v) { m_show_shape_list = v; }
-  void set_log_window_visible(bool v) { m_log_window_visible = v; }
-  void set_show_settings_dialog(bool v) { m_show_settings_dialog = v; }
+  bool         is_dist_or_angle_edit_active() const;
+  void         show_message(const std::string& message);
+  void         log_message(const std::string& message);
+  void         set_show_options(bool v) { m_show_options = v; }
+  void         set_show_sketch_list(bool v) { m_show_sketch_list = v; }
+  void         set_show_shape_list(bool v) { m_show_shape_list = v; }
+  void         set_log_window_visible(bool v) { m_log_window_visible = v; }
+  void         set_show_settings_dialog(bool v) { m_show_settings_dialog = v; }
 #ifndef NDEBUG
   void set_show_dbg(bool v) { m_show_dbg = v; }
 #endif
-  // clang-format on
 
 #ifdef __EMSCRIPTEN__
   void open_file_dialog_async();    // Emscripten: hidden <input type="file">; no custom title (browser UI)
@@ -151,18 +138,15 @@ class GUI
   /// `gui.edge_dim_arrow_size` (same keys as `ezycad_settings.json`). Asserts if the OCCT view is missing.
   [[nodiscard]] std::string occt_view_settings_json() const;
 
-  /// Default RGB (0-255) for sketch underlay line tint when importing a new image (see Settings).
-  void underlay_highlight_color_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const;
-
+  /// Default RGBA (0-255) for sketch underlay line tint when importing a new image (see Settings).
+  void       underlay_highlight_color_rgba(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a) const;
   /// For scripting (Lua console): access the 3D view.
-  Occt_view* get_view()
-  {
+  Occt_view* get_view() {
     return m_view.get();
   }
 
  private:
   friend class GUI_access;
-
   // Structure to hold button state and texture
   struct Toolbar_button
   {
@@ -171,7 +155,6 @@ class GUI
     const char*                 tooltip;
     std::variant<Mode, Command> data;
   };
-
   void dist_edit_();
   void angle_edit_();
   void sketch_list_();
@@ -383,9 +366,9 @@ class GUI
   bool                  m_ul_vis {true};
   bool                  m_ul_key_white {true};
   bool                  m_ul_line_tint {true};
-  float                 m_ul_tint_col[3] {1.f, 220.f / 255.f, 0.f};
+  glm::vec4             m_ul_tint_col {1.f, 220.f / 255.f, 0.f, 1.f};
   /// Default underlay tint for new imports (0-1, persisted in ezycad_settings.json).
-  float                 m_underlay_highlight_color[3] {1.f, 220.f / 255.f, 0.f};
+  glm::vec4             m_underlay_highlight_color {1.f, 220.f / 255.f, 0.f, 1.f};
 
   std::unique_ptr<Lua_console>    m_lua_console;
   bool                            m_show_python_console {false};

--- a/src/gui_add.cpp
+++ b/src/gui_add.cpp
@@ -22,42 +22,42 @@ void GUI::add_box_dialog_()
     ImGui::TextUnformatted("Origin X");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##box_origin_x", &m_add_box_origin_x, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##box_origin_x", &m_add_box_origin.x, 0.0, 0.0, "%.3f");
 
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Y");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##box_origin_y", &m_add_box_origin_y, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##box_origin_y", &m_add_box_origin.y, 0.0, 0.0, "%.3f");
 
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Z");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##box_origin_z", &m_add_box_origin_z, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##box_origin_z", &m_add_box_origin.z, 0.0, 0.0, "%.3f");
 
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Width (X)");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##box_width", &m_add_box_width, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##box_width", &m_add_box_size.x, 0.0, 0.0, "%.3f");
 
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Length (Y)");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##box_length", &m_add_box_length, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##box_length", &m_add_box_size.y, 0.0, 0.0, "%.3f");
 
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Height (Z)");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##box_height", &m_add_box_height, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##box_height", &m_add_box_size.z, 0.0, 0.0, "%.3f");
 
     ImGui::EndTable();
   }
@@ -65,12 +65,12 @@ void GUI::add_box_dialog_()
 
   if (ImGui::Button("Add"))
   {
-    if (m_add_box_width > 0 && m_add_box_length > 0 && m_add_box_height > 0)
+    if (m_add_box_size.x > 0 && m_add_box_size.y > 0 && m_add_box_size.z > 0)
     {
       const double scale = m_view->get_dimension_scale();
       m_view->add_box(
-          m_add_box_origin_x * scale, m_add_box_origin_y * scale, m_add_box_origin_z * scale,
-          m_add_box_width * scale, m_add_box_length * scale, m_add_box_height * scale);
+          m_add_box_origin.x * scale, m_add_box_origin.y * scale, m_add_box_origin.z * scale,
+          m_add_box_size.x * scale, m_add_box_size.y * scale, m_add_box_size.z * scale);
       ImGui::CloseCurrentPopup();
     }
   }
@@ -100,19 +100,19 @@ void GUI::add_pyramid_dialog_()
     ImGui::TextUnformatted("Origin X");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##pyramid_origin_x", &m_add_pyramid_origin_x, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##pyramid_origin_x", &m_add_pyramid_origin.x, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Y");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##pyramid_origin_y", &m_add_pyramid_origin_y, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##pyramid_origin_y", &m_add_pyramid_origin.y, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Z");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##pyramid_origin_z", &m_add_pyramid_origin_z, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##pyramid_origin_z", &m_add_pyramid_origin.z, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Side (base & height)");
@@ -125,7 +125,7 @@ void GUI::add_pyramid_dialog_()
   if (ImGui::Button("Add") && m_add_pyramid_side > 0)
   {
     const double scale = m_view->get_dimension_scale();
-    m_view->add_pyramid(m_add_pyramid_origin_x * scale, m_add_pyramid_origin_y * scale, m_add_pyramid_origin_z * scale, m_add_pyramid_side * scale);
+    m_view->add_pyramid(m_add_pyramid_origin.x * scale, m_add_pyramid_origin.y * scale, m_add_pyramid_origin.z * scale, m_add_pyramid_side * scale);
     ImGui::CloseCurrentPopup();
   }
   ImGui::SameLine();
@@ -154,19 +154,19 @@ void GUI::add_sphere_dialog_()
     ImGui::TextUnformatted("Origin X");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##sphere_origin_x", &m_add_sphere_origin_x, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##sphere_origin_x", &m_add_sphere_origin.x, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Y");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##sphere_origin_y", &m_add_sphere_origin_y, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##sphere_origin_y", &m_add_sphere_origin.y, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Z");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##sphere_origin_z", &m_add_sphere_origin_z, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##sphere_origin_z", &m_add_sphere_origin.z, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Radius");
@@ -180,7 +180,7 @@ void GUI::add_sphere_dialog_()
   if (ImGui::Button("Add") && m_add_sphere_radius > 0)
   {
     const double scale = m_view->get_dimension_scale();
-    m_view->add_sphere(m_add_sphere_origin_x * scale, m_add_sphere_origin_y * scale, m_add_sphere_origin_z * scale, m_add_sphere_radius * scale);
+    m_view->add_sphere(m_add_sphere_origin.x * scale, m_add_sphere_origin.y * scale, m_add_sphere_origin.z * scale, m_add_sphere_radius * scale);
     ImGui::CloseCurrentPopup();
   }
 
@@ -208,19 +208,19 @@ void GUI::add_cylinder_dialog_()
     ImGui::TextUnformatted("Origin X");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##cyl_origin_x", &m_add_cylinder_origin_x, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##cyl_origin_x", &m_add_cylinder_origin.x, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Y");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##cyl_origin_y", &m_add_cylinder_origin_y, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##cyl_origin_y", &m_add_cylinder_origin.y, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Z");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##cyl_origin_z", &m_add_cylinder_origin_z, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##cyl_origin_z", &m_add_cylinder_origin.z, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Radius");
@@ -239,7 +239,8 @@ void GUI::add_cylinder_dialog_()
   if (ImGui::Button("Add") && m_add_cylinder_radius > 0 && m_add_cylinder_height > 0)
   {
     const double scale = m_view->get_dimension_scale();
-    m_view->add_cylinder(m_add_cylinder_origin_x * scale, m_add_cylinder_origin_y * scale, m_add_cylinder_origin_z * scale, m_add_cylinder_radius * scale, m_add_cylinder_height * scale);
+    m_view->add_cylinder(m_add_cylinder_origin.x * scale, m_add_cylinder_origin.y * scale, m_add_cylinder_origin.z * scale,
+                         m_add_cylinder_radius * scale, m_add_cylinder_height * scale);
     ImGui::CloseCurrentPopup();
   }
   ImGui::SameLine();
@@ -266,19 +267,19 @@ void GUI::add_cone_dialog_()
     ImGui::TextUnformatted("Origin X");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##cone_origin_x", &m_add_cone_origin_x, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##cone_origin_x", &m_add_cone_origin.x, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Y");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##cone_origin_y", &m_add_cone_origin_y, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##cone_origin_y", &m_add_cone_origin.y, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Z");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##cone_origin_z", &m_add_cone_origin_z, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##cone_origin_z", &m_add_cone_origin.z, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Base radius (R1)");
@@ -303,7 +304,7 @@ void GUI::add_cone_dialog_()
   if (ImGui::Button("Add") && m_add_cone_R1 >= 0 && m_add_cone_R2 >= 0 && m_add_cone_height > 0)
   {
     const double scale = m_view->get_dimension_scale();
-    m_view->add_cone(m_add_cone_origin_x * scale, m_add_cone_origin_y * scale, m_add_cone_origin_z * scale, m_add_cone_R1 * scale, m_add_cone_R2 * scale, m_add_cone_height * scale);
+    m_view->add_cone(m_add_cone_origin.x * scale, m_add_cone_origin.y * scale, m_add_cone_origin.z * scale, m_add_cone_R1 * scale, m_add_cone_R2 * scale, m_add_cone_height * scale);
     ImGui::CloseCurrentPopup();
   }
   ImGui::SameLine();
@@ -330,19 +331,19 @@ void GUI::add_torus_dialog_()
     ImGui::TextUnformatted("Origin X");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##torus_origin_x", &m_add_torus_origin_x, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##torus_origin_x", &m_add_torus_origin.x, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Y");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##torus_origin_y", &m_add_torus_origin_y, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##torus_origin_y", &m_add_torus_origin.y, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Origin Z");
     ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(-1);
-    ImGui::InputDouble("##torus_origin_z", &m_add_torus_origin_z, 0.0, 0.0, "%.3f");
+    ImGui::InputDouble("##torus_origin_z", &m_add_torus_origin.z, 0.0, 0.0, "%.3f");
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
     ImGui::TextUnformatted("Major radius (R1)");
@@ -361,7 +362,7 @@ void GUI::add_torus_dialog_()
   if (ImGui::Button("Add") && m_add_torus_R1 > 0 && m_add_torus_R2 > 0)
   {
     const double scale = m_view->get_dimension_scale();
-    m_view->add_torus(m_add_torus_origin_x * scale, m_add_torus_origin_y * scale, m_add_torus_origin_z * scale, m_add_torus_R1 * scale, m_add_torus_R2 * scale);
+    m_view->add_torus(m_add_torus_origin.x * scale, m_add_torus_origin.y * scale, m_add_torus_origin.z * scale, m_add_torus_R1 * scale, m_add_torus_R2 * scale);
     ImGui::CloseCurrentPopup();
   }
   ImGui::SameLine();

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -382,6 +382,7 @@ void GUI::options_()
       };
 
       float label_col_w = ImGui::CalcTextSize("Snap dist").x;
+      label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Fullscreen snap guides").x);
       if (get_mode() == Mode::Sketch_dim_anno)
         label_col_w = std::max(label_col_w, ImGui::CalcTextSize("Length value placement").x);
       if (get_mode() == Mode::Sketch_face_extrude)
@@ -397,6 +398,17 @@ void GUI::options_()
       ImGui::SetNextItemWidth(140.0f);
       if (ImGui::InputFloat("##snap_dist", &snap_dist, 1.0f, 2.0f, "%.2f"))
         Sketch_nodes::set_snap_dist(snap_dist);
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      right_aligned_label("Fullscreen snap guides");
+      ImGui::TableSetColumnIndex(1);
+      bool show_fullscreen_guides = Sketch_nodes::get_show_fullscreen_snap_guides();
+      if (ImGui::Checkbox("##fullscreen_snap_guides", &show_fullscreen_guides))
+        Sketch_nodes::set_show_fullscreen_snap_guides(show_fullscreen_guides);
+      if (ImGui::IsItemHovered())
+        ImGui::SetTooltip(
+            "Show full-view snap guides: node snap shows full crosshair; axis-only snap shows a full X or Y guide line.");
 
       if (get_mode() == Mode::Sketch_dim_anno)
       {

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -347,8 +347,12 @@ void GUI::options_()
     if (current_item < 0 || current_item >= static_cast<int>(material_names.size()))
       current_item = 0;
 
-    if (ImGui::BeginCombo("Default Material##filter", material_names[static_cast<size_t>(current_item)].data(),
-                          ImGuiComboFlags_WidthFitPreview | ImGuiComboFlags_HeightSmall))
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Default Material");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(120.0f);
+    if (ImGui::BeginCombo("##default_material", material_names[static_cast<size_t>(current_item)].data(),
+                          ImGuiComboFlags_HeightSmall))
     {
       for (int i = 0; i < static_cast<int>(material_names.size()); i++)
         if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_item == i))
@@ -364,12 +368,35 @@ void GUI::options_()
   if (is_sketch_mode(get_mode()))
   {
     float snap_dist = float(Sketch_nodes::get_snap_dist());
-    if (ImGui::InputFloat("Snap dist##float_value", &snap_dist, 1.0f, 2.0f, "%.2f"))
-      Sketch_nodes::set_snap_dist(snap_dist);
-
-    switch (get_mode())
+    if (ImGui::BeginTable("options_sketch_rows", 2, ImGuiTableFlags_SizingStretchProp))
     {
-      case Mode::Sketch_dim_anno:
+      const auto right_aligned_label = [](const char* text)
+      {
+        ImGui::AlignTextToFramePadding();
+        const float text_w = ImGui::CalcTextSize(text).x;
+        const float col_w  = ImGui::GetColumnWidth();
+        const float x0     = ImGui::GetCursorPosX();
+        const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
+        ImGui::SetCursorPosX(right_x);
+        ImGui::TextUnformatted(text);
+      };
+
+      float label_col_w = ImGui::CalcTextSize("Snap dist").x;
+      if (get_mode() == Mode::Sketch_dim_anno)
+        label_col_w = std::max(label_col_w, ImGui::CalcTextSize("Length value placement").x);
+      label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+      ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
+      ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      right_aligned_label("Snap dist");
+      ImGui::TableSetColumnIndex(1);
+      ImGui::SetNextItemWidth(140.0f);
+      if (ImGui::InputFloat("##snap_dist", &snap_dist, 1.0f, 2.0f, "%.2f"))
+        Sketch_nodes::set_snap_dist(snap_dist);
+
+      if (get_mode() == Mode::Sketch_dim_anno)
       {
         constexpr std::array<const char*, 4> k_edge_dim_label_placement = {
             "Near first point",
@@ -378,11 +405,22 @@ void GUI::options_()
             "Automatic",
         };
         int h = m_edge_dim_label_h;
-        if (ImGui::Combo("Length value placement##edge_dim_h", &h, k_edge_dim_label_placement.data(),
-                         int(k_edge_dim_label_placement.size())))
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        right_aligned_label("Length value placement");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::SetNextItemWidth(170.0f);
+        if (ImGui::BeginCombo("##edge_dim_h", k_edge_dim_label_placement[static_cast<size_t>(h)],
+                              ImGuiComboFlags_HeightSmall))
         {
-          m_edge_dim_label_h = h;
-          save_occt_view_settings();
+          for (int i = 0; i < int(k_edge_dim_label_placement.size()); ++i)
+            if (ImGui::Selectable(k_edge_dim_label_placement[static_cast<size_t>(i)], i == h))
+            {
+              m_edge_dim_label_h = i;
+              save_occt_view_settings();
+            }
+          ImGui::EndCombo();
         }
         if (ImGui::IsItemHovered())
           ImGui::SetTooltip(
@@ -391,8 +429,15 @@ void GUI::options_()
               "When the sketch has filled faces, dimensions offset to the void side (point-in-face test).\n"
               "Otherwise the average node position is used as a rough inside reference.\n"
               "Dimension line width is in Settings -> Sketch.");
-        break;
       }
+
+      ImGui::EndTable();
+    }
+
+    switch (get_mode())
+    {
+      case Mode::Sketch_dim_anno:
+        break;
 
       case Mode::Sketch_face_extrude:
         default_material();
@@ -416,7 +461,7 @@ void GUI::options_()
         break;
     }
   }
-  else
+  else if (get_mode() != Mode::Normal)
     default_material();
 
   ImGui::End();
@@ -424,25 +469,74 @@ void GUI::options_()
 
 void GUI::options_normal_mode_()
 {
-  int current_item = static_cast<int>(m_view->get_shp_selection_mode());
-  if (ImGui::BeginCombo("Selection Mode##filter", c_names_TopAbs_ShapeEnum[current_item].data(),
-                        ImGuiComboFlags_WidthFitPreview | ImGuiComboFlags_HeightSmall))
+  if (ImGui::BeginTable("options_normal_rows", 2, ImGuiTableFlags_SizingStretchProp))
   {
-    for (int i = 0; i < static_cast<int>(c_names_TopAbs_ShapeEnum.size()); i++)
-      if (ImGui::Selectable(c_names_TopAbs_ShapeEnum[i].data(), current_item == i))
-        m_view->set_shp_selection_mode(static_cast<TopAbs_ShapeEnum>(i));
+    const auto right_aligned_label = [](const char* text)
+    {
+      ImGui::AlignTextToFramePadding();
+      const float text_w   = ImGui::CalcTextSize(text).x;
+      const float col_w    = ImGui::GetColumnWidth();
+      const float x0       = ImGui::GetCursorPosX();
+      const float right_x  = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
+      ImGui::SetCursorPosX(right_x);
+      ImGui::TextUnformatted(text);
+    };
 
-    ImGui::EndCombo();
-  }
-  ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
-  ImGui::TextDisabled("(?)");
-  if (ImGui::IsItemHovered())
-  {
-    ImGui::BeginTooltip();
-    ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-    ImGui::TextDisabled("Hotkeys: 1-9 (Normal mode) set filter when the 3D view has focus, not while typing in UI.");
-    ImGui::PopTextWrapPos();
-    ImGui::EndTooltip();
+    float label_col_w = std::max(ImGui::CalcTextSize("Selection Mode").x, ImGui::CalcTextSize("Default Material").x);
+    label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+    ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
+    ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
+
+    int current_item = static_cast<int>(m_view->get_shp_selection_mode());
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Selection Mode");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(120.0f);
+    if (ImGui::BeginCombo("##selection_mode", c_names_TopAbs_ShapeEnum[current_item].data(),
+                          ImGuiComboFlags_HeightSmall))
+    {
+      for (int i = 0; i < static_cast<int>(c_names_TopAbs_ShapeEnum.size()); i++)
+        if (ImGui::Selectable(c_names_TopAbs_ShapeEnum[i].data(), current_item == i))
+          m_view->set_shp_selection_mode(static_cast<TopAbs_ShapeEnum>(i));
+
+      ImGui::EndCombo();
+    }
+    ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+    ImGui::TextDisabled("(?)");
+    if (ImGui::IsItemHovered())
+    {
+      ImGui::BeginTooltip();
+      ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+      ImGui::TextDisabled(
+          "Hotkeys: 1-9 (Normal mode) set filter when the 3D view has focus, not while typing in UI.");
+      ImGui::PopTextWrapPos();
+      ImGui::EndTooltip();
+    }
+
+    const std::vector<std::string>& material_names = occt_material_combo_labels_();
+    int                             current_mat    = int(m_view->get_default_material().Name());
+    if (current_mat < 0 || current_mat >= static_cast<int>(material_names.size()))
+      current_mat = 0;
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Default Material");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(120.0f);
+    if (ImGui::BeginCombo("##default_material_normal", material_names[static_cast<size_t>(current_mat)].data(),
+                          ImGuiComboFlags_HeightSmall))
+    {
+      for (int i = 0; i < static_cast<int>(material_names.size()); i++)
+        if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_mat == i))
+        {
+          Graphic3d_MaterialAspect mat(static_cast<Graphic3d_NameOfMaterial>(i));
+          m_view->set_default_material(mat);
+        }
+      ImGui::EndCombo();
+    }
+
+    ImGui::EndTable();
   }
 }
 
@@ -506,7 +600,11 @@ void GUI::options_sketch_operation_axis_mode_()
 void GUI::options_shape_chamfer_mode_()
 {
   int current_mode = static_cast<int>(m_chamfer_mode);
-  if (ImGui::Combo("Chamfer Mode", &current_mode, c_chamfer_mode_strs.data(), (int) c_chamfer_mode_strs.size()))
+  ImGui::AlignTextToFramePadding();
+  ImGui::TextUnformatted("Chamfer Mode");
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(120.0f);
+  if (ImGui::Combo("##chamfer_mode", &current_mode, c_chamfer_mode_strs.data(), (int) c_chamfer_mode_strs.size()))
   {
     m_chamfer_mode = static_cast<Chamfer_mode>(current_mode);
     m_view->on_chamfer_mode();
@@ -522,6 +620,9 @@ void GUI::options_shape_chamfer_mode_()
   if (ctx && ctx->ActiveId != chamfer_input_id)
     format_double_trim_fraction(chamfer_buf, sizeof chamfer_buf, chamfer_dist, 6);
 
+  ImGui::AlignTextToFramePadding();
+  ImGui::TextUnformatted("Chamfer dist");
+  ImGui::SameLine();
   ImGui::SetNextItemWidth(100.0f);
   constexpr ImGuiInputTextFlags k_dim_flags =
       ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsScientific;
@@ -537,15 +638,17 @@ void GUI::options_shape_chamfer_mode_()
         m_view->shp_chamfer().set_chamfer_dist(p * scale);
     }
   }
-  ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
-  ImGui::TextUnformatted("Chamfer dist");
   ImGui::PopID();
 }
 
 void GUI::options_shape_fillet_mode_()
 {
   int current_mode = static_cast<int>(m_fillet_mode);
-  if (ImGui::Combo("Fillet Mode", &current_mode, c_fillet_mode_strs.data(), (int) c_fillet_mode_strs.size()))
+  ImGui::AlignTextToFramePadding();
+  ImGui::TextUnformatted("Fillet Mode");
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(120.0f);
+  if (ImGui::Combo("##fillet_mode", &current_mode, c_fillet_mode_strs.data(), (int) c_fillet_mode_strs.size()))
   {
     m_fillet_mode = static_cast<Fillet_mode>(current_mode);
     m_view->on_fillet_mode();
@@ -561,6 +664,9 @@ void GUI::options_shape_fillet_mode_()
   if (ctx && ctx->ActiveId != fillet_input_id)
     format_double_trim_fraction(fillet_buf, sizeof fillet_buf, fillet_radius, 6);
 
+  ImGui::AlignTextToFramePadding();
+  ImGui::TextUnformatted("Fillet radius");
+  ImGui::SameLine();
   ImGui::SetNextItemWidth(100.0f);
   constexpr ImGuiInputTextFlags k_dim_flags =
       ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsScientific;
@@ -576,8 +682,6 @@ void GUI::options_shape_fillet_mode_()
         m_view->shp_fillet().set_fillet_radius(p * scale);
     }
   }
-  ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
-  ImGui::TextUnformatted("Fillet radius");
   ImGui::PopID();
 }
 

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -382,7 +382,7 @@ void GUI::options_()
       };
 
       float label_col_w = ImGui::CalcTextSize("Snap dist").x;
-      label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Fullscreen snap guides").x);
+      label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Snap guide mode").x);
       if (get_mode() == Mode::Sketch_dim_anno)
         label_col_w = std::max(label_col_w, ImGui::CalcTextSize("Length value placement").x);
       if (get_mode() == Mode::Sketch_face_extrude)
@@ -401,14 +401,28 @@ void GUI::options_()
 
       ImGui::TableNextRow();
       ImGui::TableSetColumnIndex(0);
-      right_aligned_label("Fullscreen snap guides");
+      right_aligned_label("Snap guide mode");
       ImGui::TableSetColumnIndex(1);
-      bool show_fullscreen_guides = Sketch_nodes::get_show_fullscreen_snap_guides();
-      if (ImGui::Checkbox("##fullscreen_snap_guides", &show_fullscreen_guides))
-        Sketch_nodes::set_show_fullscreen_snap_guides(show_fullscreen_guides);
+      constexpr std::array<const char*, 3> k_snap_guide_mode_labels = {
+          "Traditional",
+          "Fullscreen",
+          "Both",
+      };
+      int snap_mode = static_cast<int>(Sketch_nodes::get_snap_guide_mode());
+      ImGui::SetNextItemWidth(140.0f);
+      if (ImGui::BeginCombo("##snap_guide_mode", k_snap_guide_mode_labels[static_cast<size_t>(snap_mode)],
+                            ImGuiComboFlags_HeightSmall))
+      {
+        for (int i = 0; i < static_cast<int>(k_snap_guide_mode_labels.size()); ++i)
+          if (ImGui::Selectable(k_snap_guide_mode_labels[static_cast<size_t>(i)], i == snap_mode))
+            Sketch_nodes::set_snap_guide_mode(static_cast<Sketch_nodes::Snap_guide_mode>(i));
+        ImGui::EndCombo();
+      }
       if (ImGui::IsItemHovered())
         ImGui::SetTooltip(
-            "Show full-view snap guides: node snap shows full crosshair; axis-only snap shows a full X or Y guide line.");
+            "Traditional: compact local snap marker.\n"
+            "Fullscreen: full-view crosshair/axis guides.\n"
+            "Both: show compact marker and fullscreen guides together.");
 
       if (get_mode() == Mode::Sketch_dim_anno)
       {

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -486,7 +486,7 @@ void GUI::options_()
         break;
     }
   }
-  else if (get_mode() != Mode::Normal)
+  else if (get_mode() != Mode::Normal && get_mode() != Mode::Shape_polar_duplicate)
     default_material();
 
   ImGui::End();
@@ -810,21 +810,88 @@ void GUI::options_shape_polar_duplicate_mode_()
   bool  rotate_dups  = polar_dup.get_rotate_dups();
   bool  combine_dups = polar_dup.get_combine_dups();
 
-  if (ImGui::InputFloat("Polar angle##float_value", &polar_angle, 0.0f, 0.0f, "%.2f"))
-    polar_dup.set_polar_angle(polar_angle);
+  if (ImGui::BeginTable("options_polar_dup_rows", 2, ImGuiTableFlags_SizingStretchProp))
+  {
+    const auto right_aligned_label = [](const char* text)
+    {
+      ImGui::AlignTextToFramePadding();
+      const float text_w  = ImGui::CalcTextSize(text).x;
+      const float col_w   = ImGui::GetColumnWidth();
+      const float x0      = ImGui::GetCursorPosX();
+      const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
+      ImGui::SetCursorPosX(right_x);
+      ImGui::TextUnformatted(text);
+    };
 
-  if (ImGui::InputInt("Num Elms##int_value", &num_elms))
-    polar_dup.set_num_elms(num_elms);
+    float label_col_w = ImGui::CalcTextSize("Polar angle").x;
+    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Num Elms").x);
+    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Rotate dups").x);
+    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Combine dups").x);
+    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Default Material").x);
+    label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+    ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
+    ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
 
-  if (ImGui::Checkbox("Rotate dups", &rotate_dups))
-    polar_dup.set_rotate_dups(rotate_dups);
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Polar angle");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(120.0f);
+    if (ImGui::InputFloat("##polar_angle", &polar_angle, 0.0f, 0.0f, "%.2f"))
+      polar_dup.set_polar_angle(polar_angle);
 
-  if (ImGui::Checkbox("Combine dups", &combine_dups))
-    polar_dup.set_combine_dups(combine_dups);
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Num Elms");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(120.0f);
+    if (ImGui::InputInt("##num_elms", &num_elms))
+      polar_dup.set_num_elms(num_elms);
 
-  if (ImGui::Button("Dup"))
-    if (Status s = polar_dup.dup(); !s.is_ok())
-      show_message(s.message());
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Rotate dups");
+    ImGui::TableSetColumnIndex(1);
+    if (ImGui::Checkbox("##rotate_dups", &rotate_dups))
+      polar_dup.set_rotate_dups(rotate_dups);
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Combine dups");
+    ImGui::TableSetColumnIndex(1);
+    if (ImGui::Checkbox("##combine_dups", &combine_dups))
+      polar_dup.set_combine_dups(combine_dups);
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(1);
+    if (ImGui::Button("Dup"))
+      if (Status s = polar_dup.dup(); !s.is_ok())
+        show_message(s.message());
+
+    const std::vector<std::string>& material_names = occt_material_combo_labels_();
+    int                             current_item   = int(m_view->get_default_material().Name());
+    if (current_item < 0 || current_item >= static_cast<int>(material_names.size()))
+      current_item = 0;
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Default Material");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(120.0f);
+    if (ImGui::BeginCombo("##default_material_polar_dup", material_names[static_cast<size_t>(current_item)].data(),
+                          ImGuiComboFlags_HeightSmall))
+    {
+      for (int i = 0; i < static_cast<int>(material_names.size()); i++)
+        if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_item == i))
+        {
+          Graphic3d_MaterialAspect mat(static_cast<Graphic3d_NameOfMaterial>(i));
+          m_view->set_default_material(mat);
+        }
+      ImGui::EndCombo();
+    }
+
+    ImGui::EndTable();
+  }
 }
 
 void GUI::on_key_rotate_mode_(int key)

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -385,8 +385,13 @@ void GUI::options_()
       label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Snap guide mode").x);
       if (get_mode() == Mode::Sketch_dim_anno)
         label_col_w = std::max(label_col_w, ImGui::CalcTextSize("Length value placement").x);
+
       if (get_mode() == Mode::Sketch_face_extrude)
-        label_col_w = std::max(label_col_w, ImGui::CalcTextSize("Default Material").x);
+      {
+        const float extrude_label_w = std::max(ImGui::CalcTextSize("Both sides").x, ImGui::CalcTextSize("Default Material").x);
+        label_col_w                 = std::max(label_col_w, extrude_label_w);
+      }
+
       label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
       ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
       ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
@@ -460,6 +465,14 @@ void GUI::options_()
       }
       else if (get_mode() == Mode::Sketch_face_extrude)
       {
+        bool extrude_both_sides = m_view->shp_extrude().get_both_sides();
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        right_aligned_label("Both sides");
+        ImGui::TableSetColumnIndex(1);
+        if (ImGui::Checkbox("##extrude_both_sides", &extrude_both_sides))
+          m_view->shp_extrude().set_both_sides(extrude_both_sides);
+
         const std::vector<std::string>& material_names = occt_material_combo_labels_();
         int                             current_item   = int(m_view->get_default_material().Name());
         if (current_item < 0 || current_item >= static_cast<int>(material_names.size()))

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -384,6 +384,8 @@ void GUI::options_()
       float label_col_w = ImGui::CalcTextSize("Snap dist").x;
       if (get_mode() == Mode::Sketch_dim_anno)
         label_col_w = std::max(label_col_w, ImGui::CalcTextSize("Length value placement").x);
+      if (get_mode() == Mode::Sketch_face_extrude)
+        label_col_w = std::max(label_col_w, ImGui::CalcTextSize("Default Material").x);
       label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
       ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
       ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
@@ -430,6 +432,30 @@ void GUI::options_()
               "Otherwise the average node position is used as a rough inside reference.\n"
               "Dimension line width is in Settings -> Sketch.");
       }
+      else if (get_mode() == Mode::Sketch_face_extrude)
+      {
+        const std::vector<std::string>& material_names = occt_material_combo_labels_();
+        int                             current_item   = int(m_view->get_default_material().Name());
+        if (current_item < 0 || current_item >= static_cast<int>(material_names.size()))
+          current_item = 0;
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        right_aligned_label("Default Material");
+        ImGui::TableSetColumnIndex(1);
+        ImGui::SetNextItemWidth(120.0f);
+        if (ImGui::BeginCombo("##default_material_sketch_extrude",
+                              material_names[static_cast<size_t>(current_item)].data(), ImGuiComboFlags_HeightSmall))
+        {
+          for (int i = 0; i < static_cast<int>(material_names.size()); i++)
+            if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_item == i))
+            {
+              Graphic3d_MaterialAspect mat(static_cast<Graphic3d_NameOfMaterial>(i));
+              m_view->set_default_material(mat);
+            }
+          ImGui::EndCombo();
+        }
+      }
 
       ImGui::EndTable();
     }
@@ -440,7 +466,6 @@ void GUI::options_()
         break;
 
       case Mode::Sketch_face_extrude:
-        default_material();
         break;
 
       case Mode::Sketch_add_edge:
@@ -599,90 +624,182 @@ void GUI::options_sketch_operation_axis_mode_()
 
 void GUI::options_shape_chamfer_mode_()
 {
-  int current_mode = static_cast<int>(m_chamfer_mode);
-  ImGui::AlignTextToFramePadding();
-  ImGui::TextUnformatted("Chamfer Mode");
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(120.0f);
-  if (ImGui::Combo("##chamfer_mode", &current_mode, c_chamfer_mode_strs.data(), (int) c_chamfer_mode_strs.size()))
+  if (ImGui::BeginTable("options_chamfer_rows", 2, ImGuiTableFlags_SizingStretchProp))
   {
-    m_chamfer_mode = static_cast<Chamfer_mode>(current_mode);
-    m_view->on_chamfer_mode();
-  }
-
-  static char  chamfer_buf[64];
-  const double scale        = m_view->get_dimension_scale();
-  const double chamfer_dist = m_view->shp_chamfer().get_chamfer_dist() / scale;
-
-  ImGui::PushID("chamfer_dist_micron");
-  const ImGuiID chamfer_input_id = ImGui::GetID("##micron");
-  ImGuiContext* ctx              = ImGui::GetCurrentContext();
-  if (ctx && ctx->ActiveId != chamfer_input_id)
-    format_double_trim_fraction(chamfer_buf, sizeof chamfer_buf, chamfer_dist, 6);
-
-  ImGui::AlignTextToFramePadding();
-  ImGui::TextUnformatted("Chamfer dist");
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(100.0f);
-  constexpr ImGuiInputTextFlags k_dim_flags =
-      ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsScientific;
-  if (ImGui::InputText("##micron", chamfer_buf, sizeof chamfer_buf, k_dim_flags))
-  {
-    char*        end = nullptr;
-    const double p   = std::strtod(chamfer_buf, &end);
-    if (end != chamfer_buf)
+    const auto right_aligned_label = [](const char* text)
     {
-      while (*end == ' ' || *end == '\t')
-        ++end;
-      if (*end == '\0')
-        m_view->shp_chamfer().set_chamfer_dist(p * scale);
+      ImGui::AlignTextToFramePadding();
+      const float text_w  = ImGui::CalcTextSize(text).x;
+      const float col_w   = ImGui::GetColumnWidth();
+      const float x0      = ImGui::GetCursorPosX();
+      const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
+      ImGui::SetCursorPosX(right_x);
+      ImGui::TextUnformatted(text);
+    };
+
+    float label_col_w = std::max(ImGui::CalcTextSize("Chamfer Mode").x, ImGui::CalcTextSize("Chamfer dist").x);
+    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Default Material").x);
+    label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+    ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
+    ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
+
+    int current_mode = static_cast<int>(m_chamfer_mode);
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Chamfer Mode");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(120.0f);
+    if (ImGui::Combo("##chamfer_mode", &current_mode, c_chamfer_mode_strs.data(), (int) c_chamfer_mode_strs.size()))
+    {
+      m_chamfer_mode = static_cast<Chamfer_mode>(current_mode);
+      m_view->on_chamfer_mode();
     }
+
+    static char  chamfer_buf[64];
+    const double scale        = m_view->get_dimension_scale();
+    const double chamfer_dist = m_view->shp_chamfer().get_chamfer_dist() / scale;
+
+    ImGui::PushID("chamfer_dist_micron");
+    const ImGuiID chamfer_input_id = ImGui::GetID("##micron");
+    ImGuiContext* ctx              = ImGui::GetCurrentContext();
+    if (ctx && ctx->ActiveId != chamfer_input_id)
+      format_double_trim_fraction(chamfer_buf, sizeof chamfer_buf, chamfer_dist, 6);
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Chamfer dist");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(100.0f);
+    constexpr ImGuiInputTextFlags k_dim_flags =
+        ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsScientific;
+    if (ImGui::InputText("##micron", chamfer_buf, sizeof chamfer_buf, k_dim_flags))
+    {
+      char*        end = nullptr;
+      const double p   = std::strtod(chamfer_buf, &end);
+      if (end != chamfer_buf)
+      {
+        while (*end == ' ' || *end == '\t')
+          ++end;
+        if (*end == '\0')
+          m_view->shp_chamfer().set_chamfer_dist(p * scale);
+      }
+    }
+    ImGui::PopID();
+
+    const std::vector<std::string>& material_names = occt_material_combo_labels_();
+    int                             current_item   = int(m_view->get_default_material().Name());
+    if (current_item < 0 || current_item >= static_cast<int>(material_names.size()))
+      current_item = 0;
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Default Material");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(120.0f);
+    if (ImGui::BeginCombo("##default_material_chamfer", material_names[static_cast<size_t>(current_item)].data(),
+                          ImGuiComboFlags_HeightSmall))
+    {
+      for (int i = 0; i < static_cast<int>(material_names.size()); i++)
+        if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_item == i))
+        {
+          Graphic3d_MaterialAspect mat(static_cast<Graphic3d_NameOfMaterial>(i));
+          m_view->set_default_material(mat);
+        }
+      ImGui::EndCombo();
+    }
+
+    ImGui::EndTable();
   }
-  ImGui::PopID();
 }
 
 void GUI::options_shape_fillet_mode_()
 {
-  int current_mode = static_cast<int>(m_fillet_mode);
-  ImGui::AlignTextToFramePadding();
-  ImGui::TextUnformatted("Fillet Mode");
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(120.0f);
-  if (ImGui::Combo("##fillet_mode", &current_mode, c_fillet_mode_strs.data(), (int) c_fillet_mode_strs.size()))
+  if (ImGui::BeginTable("options_fillet_rows", 2, ImGuiTableFlags_SizingStretchProp))
   {
-    m_fillet_mode = static_cast<Fillet_mode>(current_mode);
-    m_view->on_fillet_mode();
-  }
-
-  static char  fillet_buf[64];
-  const double scale         = m_view->get_dimension_scale();
-  const double fillet_radius = m_view->shp_fillet().get_fillet_radius() / scale;
-
-  ImGui::PushID("fillet_rad_micron");
-  const ImGuiID fillet_input_id = ImGui::GetID("##micron");
-  ImGuiContext* ctx             = ImGui::GetCurrentContext();
-  if (ctx && ctx->ActiveId != fillet_input_id)
-    format_double_trim_fraction(fillet_buf, sizeof fillet_buf, fillet_radius, 6);
-
-  ImGui::AlignTextToFramePadding();
-  ImGui::TextUnformatted("Fillet radius");
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(100.0f);
-  constexpr ImGuiInputTextFlags k_dim_flags =
-      ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsScientific;
-  if (ImGui::InputText("##micron", fillet_buf, sizeof fillet_buf, k_dim_flags))
-  {
-    char*        end = nullptr;
-    const double p   = std::strtod(fillet_buf, &end);
-    if (end != fillet_buf)
+    const auto right_aligned_label = [](const char* text)
     {
-      while (*end == ' ' || *end == '\t')
-        ++end;
-      if (*end == '\0')
-        m_view->shp_fillet().set_fillet_radius(p * scale);
+      ImGui::AlignTextToFramePadding();
+      const float text_w  = ImGui::CalcTextSize(text).x;
+      const float col_w   = ImGui::GetColumnWidth();
+      const float x0      = ImGui::GetCursorPosX();
+      const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
+      ImGui::SetCursorPosX(right_x);
+      ImGui::TextUnformatted(text);
+    };
+
+    float label_col_w = std::max(ImGui::CalcTextSize("Fillet Mode").x, ImGui::CalcTextSize("Fillet radius").x);
+    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Default Material").x);
+    label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+    ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
+    ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
+
+    int current_mode = static_cast<int>(m_fillet_mode);
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Fillet Mode");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(120.0f);
+    if (ImGui::Combo("##fillet_mode", &current_mode, c_fillet_mode_strs.data(), (int) c_fillet_mode_strs.size()))
+    {
+      m_fillet_mode = static_cast<Fillet_mode>(current_mode);
+      m_view->on_fillet_mode();
     }
+
+    static char  fillet_buf[64];
+    const double scale         = m_view->get_dimension_scale();
+    const double fillet_radius = m_view->shp_fillet().get_fillet_radius() / scale;
+
+    ImGui::PushID("fillet_rad_micron");
+    const ImGuiID fillet_input_id = ImGui::GetID("##micron");
+    ImGuiContext* ctx             = ImGui::GetCurrentContext();
+    if (ctx && ctx->ActiveId != fillet_input_id)
+      format_double_trim_fraction(fillet_buf, sizeof fillet_buf, fillet_radius, 6);
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Fillet radius");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(100.0f);
+    constexpr ImGuiInputTextFlags k_dim_flags =
+        ImGuiInputTextFlags_CharsDecimal | ImGuiInputTextFlags_CharsScientific;
+    if (ImGui::InputText("##micron", fillet_buf, sizeof fillet_buf, k_dim_flags))
+    {
+      char*        end = nullptr;
+      const double p   = std::strtod(fillet_buf, &end);
+      if (end != fillet_buf)
+      {
+        while (*end == ' ' || *end == '\t')
+          ++end;
+        if (*end == '\0')
+          m_view->shp_fillet().set_fillet_radius(p * scale);
+      }
+    }
+    ImGui::PopID();
+
+    const std::vector<std::string>& material_names = occt_material_combo_labels_();
+    int                             current_item   = int(m_view->get_default_material().Name());
+    if (current_item < 0 || current_item >= static_cast<int>(material_names.size()))
+      current_item = 0;
+
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Default Material");
+    ImGui::TableSetColumnIndex(1);
+    ImGui::SetNextItemWidth(120.0f);
+    if (ImGui::BeginCombo("##default_material_fillet", material_names[static_cast<size_t>(current_item)].data(),
+                          ImGuiComboFlags_HeightSmall))
+    {
+      for (int i = 0; i < static_cast<int>(material_names.size()); i++)
+        if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_item == i))
+        {
+          Graphic3d_MaterialAspect mat(static_cast<Graphic3d_NameOfMaterial>(i));
+          m_view->set_default_material(mat);
+        }
+      ImGui::EndCombo();
+    }
+
+    ImGui::EndTable();
   }
-  ImGui::PopID();
 }
 
 void GUI::options_shape_polar_duplicate_mode_()

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -340,19 +340,15 @@ void GUI::options_()
   }
   // clang-format on
 
-  auto default_material = [&]()
+  auto material_combo_only_ = [&](const char* combo_id)
   {
     const std::vector<std::string>& material_names = occt_material_combo_labels_();
     int                             current_item   = int(m_view->get_default_material().Name());
     if (current_item < 0 || current_item >= static_cast<int>(material_names.size()))
       current_item = 0;
 
-    ImGui::AlignTextToFramePadding();
-    ImGui::TextUnformatted("Default Material");
-    ImGui::SameLine();
-    ImGui::SetNextItemWidth(120.0f);
-    if (ImGui::BeginCombo("##default_material", material_names[static_cast<size_t>(current_item)].data(),
-                          ImGuiComboFlags_HeightSmall))
+    ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+    if (ImGui::BeginCombo(combo_id, material_names[static_cast<size_t>(current_item)].data(), ImGuiComboFlags_HeightSmall))
     {
       for (int i = 0; i < static_cast<int>(material_names.size()); i++)
         if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_item == i))
@@ -367,33 +363,34 @@ void GUI::options_()
 
   if (is_sketch_mode(get_mode()))
   {
-    float snap_dist = float(Sketch_nodes::get_snap_dist());
-    if (ImGui::BeginTable("options_sketch_rows", 2, ImGuiTableFlags_SizingStretchProp))
+    const auto right_aligned_label = [](const char* text)
     {
-      const auto right_aligned_label = [](const char* text)
-      {
-        ImGui::AlignTextToFramePadding();
-        const float text_w = ImGui::CalcTextSize(text).x;
-        const float col_w  = ImGui::GetColumnWidth();
-        const float x0     = ImGui::GetCursorPosX();
-        const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
-        ImGui::SetCursorPosX(right_x);
-        ImGui::TextUnformatted(text);
-      };
+      ImGui::AlignTextToFramePadding();
+      const float text_w  = ImGui::CalcTextSize(text).x;
+      const float col_w   = ImGui::GetColumnWidth();
+      const float x0      = ImGui::GetCursorPosX();
+      const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
+      ImGui::SetCursorPosX(right_x);
+      ImGui::TextUnformatted(text);
+    };
 
-      float label_col_w = ImGui::CalcTextSize("Snap dist").x;
-      label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Snap guide mode").x);
-      if (get_mode() == Mode::Sketch_dim_anno)
-        label_col_w = std::max(label_col_w, ImGui::CalcTextSize("Length value placement").x);
+    float snap_dist = float(Sketch_nodes::get_snap_dist());
 
-      if (get_mode() == Mode::Sketch_face_extrude)
-      {
-        const float extrude_label_w = std::max(ImGui::CalcTextSize("Both sides").x, ImGui::CalcTextSize("Default Material").x);
-        label_col_w                 = std::max(label_col_w, extrude_label_w);
-      }
+    float sketch_label_col_w = ImGui::CalcTextSize("Snap dist").x;
+    sketch_label_col_w       = std::max(sketch_label_col_w, ImGui::CalcTextSize("Snap guide mode").x);
+    if (get_mode() == Mode::Sketch_dim_anno)
+      sketch_label_col_w = std::max(sketch_label_col_w, ImGui::CalcTextSize("Length value placement").x);
+    if (get_mode() == Mode::Sketch_face_extrude)
+    {
+      sketch_label_col_w = std::max(sketch_label_col_w, ImGui::CalcTextSize("Both sides").x);
+      sketch_label_col_w = std::max(sketch_label_col_w, ImGui::CalcTextSize("Material").x);
+    }
+    sketch_label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
 
-      label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
-      ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
+    ImGui::TextUnformatted("Sketch options");
+    if (ImGui::BeginTable("options_sketch_sketch", 2, ImGuiTableFlags_SizingStretchProp))
+    {
+      ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, sketch_label_col_w);
       ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
 
       ImGui::TableNextRow();
@@ -463,8 +460,19 @@ void GUI::options_()
               "Otherwise the average node position is used as a rough inside reference.\n"
               "Dimension line width is in Settings -> Sketch.");
       }
-      else if (get_mode() == Mode::Sketch_face_extrude)
+
+      ImGui::EndTable();
+    }
+
+    if (get_mode() == Mode::Sketch_face_extrude)
+    {
+      ImGui::Separator();
+      ImGui::TextUnformatted("Extrude");
+      if (ImGui::BeginTable("options_sketch_extrude", 2, ImGuiTableFlags_SizingStretchProp))
       {
+        ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, sketch_label_col_w);
+        ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
+
         bool extrude_both_sides = m_view->shp_extrude().get_both_sides();
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex(0);
@@ -480,7 +488,7 @@ void GUI::options_()
 
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex(0);
-        right_aligned_label("Default Material");
+        right_aligned_label("Material");
         ImGui::TableSetColumnIndex(1);
         ImGui::SetNextItemWidth(120.0f);
         if (ImGui::BeginCombo("##default_material_sketch_extrude",
@@ -494,9 +502,9 @@ void GUI::options_()
             }
           ImGui::EndCombo();
         }
-      }
 
-      ImGui::EndTable();
+        ImGui::EndTable();
+      }
     }
 
     switch (get_mode())
@@ -510,11 +518,13 @@ void GUI::options_()
       case Mode::Sketch_add_edge:
       case Mode::Sketch_add_multi_edges:
         ImGui::Separator();
+        ImGui::TextUnformatted("Shortcuts");
         ImGui::TextWrapped("TAB: type edge length. Shift+TAB: type angle (degrees, CCW from +X).");
         break;
 
       case Mode::Sketch_add_node:
         ImGui::Separator();
+        ImGui::TextUnformatted("Shortcuts");
         ImGui::TextWrapped("TAB: type length along the rubber band. Shift+TAB: type angle (degrees, CCW from +X).");
         ImGui::TextWrapped(
             "Snap the first click to an existing sketch point to start a rubber band, then click to place the node "
@@ -525,29 +535,37 @@ void GUI::options_()
         break;
     }
   }
-  else if (get_mode() != Mode::Normal && get_mode() != Mode::Shape_polar_duplicate)
-    default_material();
+  else if (get_mode() != Mode::Normal && get_mode() != Mode::Shape_polar_duplicate && get_mode() != Mode::Shape_chamfer
+           && get_mode() != Mode::Shape_fillet && get_mode() != Mode::Move && get_mode() != Mode::Rotate
+           && get_mode() != Mode::Scale)
+  {
+    ImGui::Separator();
+    ImGui::TextUnformatted("Material");
+    material_combo_only_("##default_material");
+  }
 
   ImGui::End();
 }
 
 void GUI::options_normal_mode_()
 {
-  if (ImGui::BeginTable("options_normal_rows", 2, ImGuiTableFlags_SizingStretchProp))
+  const auto right_aligned_label = [](const char* text)
   {
-    const auto right_aligned_label = [](const char* text)
-    {
-      ImGui::AlignTextToFramePadding();
-      const float text_w   = ImGui::CalcTextSize(text).x;
-      const float col_w    = ImGui::GetColumnWidth();
-      const float x0       = ImGui::GetCursorPosX();
-      const float right_x  = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
-      ImGui::SetCursorPosX(right_x);
-      ImGui::TextUnformatted(text);
-    };
+    ImGui::AlignTextToFramePadding();
+    const float text_w  = ImGui::CalcTextSize(text).x;
+    const float col_w   = ImGui::GetColumnWidth();
+    const float x0      = ImGui::GetCursorPosX();
+    const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
+    ImGui::SetCursorPosX(right_x);
+    ImGui::TextUnformatted(text);
+  };
 
-    float label_col_w = std::max(ImGui::CalcTextSize("Selection Mode").x, ImGui::CalcTextSize("Default Material").x);
-    label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+  float label_col_w = ImGui::CalcTextSize("Selection Mode").x;
+  label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+
+  ImGui::TextUnformatted("Selection");
+  if (ImGui::BeginTable("options_normal_selection", 2, ImGuiTableFlags_SizingStretchProp))
+  {
     ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
     ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
 
@@ -578,34 +596,33 @@ void GUI::options_normal_mode_()
       ImGui::EndTooltip();
     }
 
-    const std::vector<std::string>& material_names = occt_material_combo_labels_();
-    int                             current_mat    = int(m_view->get_default_material().Name());
-    if (current_mat < 0 || current_mat >= static_cast<int>(material_names.size()))
-      current_mat = 0;
-
-    ImGui::TableNextRow();
-    ImGui::TableSetColumnIndex(0);
-    right_aligned_label("Default Material");
-    ImGui::TableSetColumnIndex(1);
-    ImGui::SetNextItemWidth(120.0f);
-    if (ImGui::BeginCombo("##default_material_normal", material_names[static_cast<size_t>(current_mat)].data(),
-                          ImGuiComboFlags_HeightSmall))
-    {
-      for (int i = 0; i < static_cast<int>(material_names.size()); i++)
-        if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_mat == i))
-        {
-          Graphic3d_MaterialAspect mat(static_cast<Graphic3d_NameOfMaterial>(i));
-          m_view->set_default_material(mat);
-        }
-      ImGui::EndCombo();
-    }
-
     ImGui::EndTable();
+  }
+
+  ImGui::Separator();
+  ImGui::TextUnformatted("Material");
+  const std::vector<std::string>& material_names = occt_material_combo_labels_();
+  int                             current_mat    = int(m_view->get_default_material().Name());
+  if (current_mat < 0 || current_mat >= static_cast<int>(material_names.size()))
+    current_mat = 0;
+  ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+  if (ImGui::BeginCombo("##default_material_normal", material_names[static_cast<size_t>(current_mat)].data(),
+                        ImGuiComboFlags_HeightSmall))
+  {
+    for (int i = 0; i < static_cast<int>(material_names.size()); i++)
+      if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_mat == i))
+      {
+        Graphic3d_MaterialAspect mat(static_cast<Graphic3d_NameOfMaterial>(i));
+        m_view->set_default_material(mat);
+      }
+    ImGui::EndCombo();
   }
 }
 
 void GUI::options_move_mode_()
 {
+  ImGui::TextUnformatted("Move");
+  ImGui::Separator();
   ImGui::TextUnformatted("Move constrain axis:");
 
   Move_options& opts = m_view->shp_move().get_opts();
@@ -623,7 +640,7 @@ void GUI::options_scale_mode_()
 
 void GUI::options_rotate_mode_()
 {
-  ImGui::Text("Rotation Options");
+  ImGui::TextUnformatted("Rotation");
   ImGui::Separator();
 
   int selected_axis = static_cast<int>(m_view->shp_rotate().get_rotation_axis());
@@ -642,6 +659,9 @@ void GUI::options_rotate_mode_()
 
 void GUI::options_sketch_operation_axis_mode_()
 {
+  ImGui::TextUnformatted("Sketch operation");
+  ImGui::Separator();
+
   if (m_view->curr_sketch().has_operation_axis())
   {
     if (ImGui::Button("Mirror"))
@@ -663,22 +683,23 @@ void GUI::options_sketch_operation_axis_mode_()
 
 void GUI::options_shape_chamfer_mode_()
 {
-  if (ImGui::BeginTable("options_chamfer_rows", 2, ImGuiTableFlags_SizingStretchProp))
+  const auto right_aligned_label = [](const char* text)
   {
-    const auto right_aligned_label = [](const char* text)
-    {
-      ImGui::AlignTextToFramePadding();
-      const float text_w  = ImGui::CalcTextSize(text).x;
-      const float col_w   = ImGui::GetColumnWidth();
-      const float x0      = ImGui::GetCursorPosX();
-      const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
-      ImGui::SetCursorPosX(right_x);
-      ImGui::TextUnformatted(text);
-    };
+    ImGui::AlignTextToFramePadding();
+    const float text_w  = ImGui::CalcTextSize(text).x;
+    const float col_w   = ImGui::GetColumnWidth();
+    const float x0      = ImGui::GetCursorPosX();
+    const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
+    ImGui::SetCursorPosX(right_x);
+    ImGui::TextUnformatted(text);
+  };
 
-    float label_col_w = std::max(ImGui::CalcTextSize("Chamfer Mode").x, ImGui::CalcTextSize("Chamfer dist").x);
-    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Default Material").x);
-    label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+  float label_col_w = std::max(ImGui::CalcTextSize("Chamfer Mode").x, ImGui::CalcTextSize("Chamfer dist").x);
+  label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+
+  ImGui::TextUnformatted("Chamfer");
+  if (ImGui::BeginTable("options_chamfer_tool", 2, ImGuiTableFlags_SizingStretchProp))
+  {
     ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
     ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
 
@@ -725,50 +746,29 @@ void GUI::options_shape_chamfer_mode_()
     }
     ImGui::PopID();
 
-    const std::vector<std::string>& material_names = occt_material_combo_labels_();
-    int                             current_item   = int(m_view->get_default_material().Name());
-    if (current_item < 0 || current_item >= static_cast<int>(material_names.size()))
-      current_item = 0;
-
-    ImGui::TableNextRow();
-    ImGui::TableSetColumnIndex(0);
-    right_aligned_label("Default Material");
-    ImGui::TableSetColumnIndex(1);
-    ImGui::SetNextItemWidth(120.0f);
-    if (ImGui::BeginCombo("##default_material_chamfer", material_names[static_cast<size_t>(current_item)].data(),
-                          ImGuiComboFlags_HeightSmall))
-    {
-      for (int i = 0; i < static_cast<int>(material_names.size()); i++)
-        if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_item == i))
-        {
-          Graphic3d_MaterialAspect mat(static_cast<Graphic3d_NameOfMaterial>(i));
-          m_view->set_default_material(mat);
-        }
-      ImGui::EndCombo();
-    }
-
     ImGui::EndTable();
   }
 }
 
 void GUI::options_shape_fillet_mode_()
 {
-  if (ImGui::BeginTable("options_fillet_rows", 2, ImGuiTableFlags_SizingStretchProp))
+  const auto right_aligned_label = [](const char* text)
   {
-    const auto right_aligned_label = [](const char* text)
-    {
-      ImGui::AlignTextToFramePadding();
-      const float text_w  = ImGui::CalcTextSize(text).x;
-      const float col_w   = ImGui::GetColumnWidth();
-      const float x0      = ImGui::GetCursorPosX();
-      const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
-      ImGui::SetCursorPosX(right_x);
-      ImGui::TextUnformatted(text);
-    };
+    ImGui::AlignTextToFramePadding();
+    const float text_w  = ImGui::CalcTextSize(text).x;
+    const float col_w   = ImGui::GetColumnWidth();
+    const float x0      = ImGui::GetCursorPosX();
+    const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
+    ImGui::SetCursorPosX(right_x);
+    ImGui::TextUnformatted(text);
+  };
 
-    float label_col_w = std::max(ImGui::CalcTextSize("Fillet Mode").x, ImGui::CalcTextSize("Fillet radius").x);
-    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Default Material").x);
-    label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+  float label_col_w = std::max(ImGui::CalcTextSize("Fillet Mode").x, ImGui::CalcTextSize("Fillet radius").x);
+  label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+
+  ImGui::TextUnformatted("Fillet");
+  if (ImGui::BeginTable("options_fillet_tool", 2, ImGuiTableFlags_SizingStretchProp))
+  {
     ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
     ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
 
@@ -815,28 +815,6 @@ void GUI::options_shape_fillet_mode_()
     }
     ImGui::PopID();
 
-    const std::vector<std::string>& material_names = occt_material_combo_labels_();
-    int                             current_item   = int(m_view->get_default_material().Name());
-    if (current_item < 0 || current_item >= static_cast<int>(material_names.size()))
-      current_item = 0;
-
-    ImGui::TableNextRow();
-    ImGui::TableSetColumnIndex(0);
-    right_aligned_label("Default Material");
-    ImGui::TableSetColumnIndex(1);
-    ImGui::SetNextItemWidth(120.0f);
-    if (ImGui::BeginCombo("##default_material_fillet", material_names[static_cast<size_t>(current_item)].data(),
-                          ImGuiComboFlags_HeightSmall))
-    {
-      for (int i = 0; i < static_cast<int>(material_names.size()); i++)
-        if (ImGui::Selectable(material_names[static_cast<size_t>(i)].data(), current_item == i))
-        {
-          Graphic3d_MaterialAspect mat(static_cast<Graphic3d_NameOfMaterial>(i));
-          m_view->set_default_material(mat);
-        }
-      ImGui::EndCombo();
-    }
-
     ImGui::EndTable();
   }
 }
@@ -849,25 +827,27 @@ void GUI::options_shape_polar_duplicate_mode_()
   bool  rotate_dups  = polar_dup.get_rotate_dups();
   bool  combine_dups = polar_dup.get_combine_dups();
 
-  if (ImGui::BeginTable("options_polar_dup_rows", 2, ImGuiTableFlags_SizingStretchProp))
+  const auto right_aligned_label = [](const char* text)
   {
-    const auto right_aligned_label = [](const char* text)
-    {
-      ImGui::AlignTextToFramePadding();
-      const float text_w  = ImGui::CalcTextSize(text).x;
-      const float col_w   = ImGui::GetColumnWidth();
-      const float x0      = ImGui::GetCursorPosX();
-      const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
-      ImGui::SetCursorPosX(right_x);
-      ImGui::TextUnformatted(text);
-    };
+    ImGui::AlignTextToFramePadding();
+    const float text_w  = ImGui::CalcTextSize(text).x;
+    const float col_w   = ImGui::GetColumnWidth();
+    const float x0      = ImGui::GetCursorPosX();
+    const float right_x = x0 + std::max(0.0f, col_w - text_w - ImGui::GetStyle().CellPadding.x * 2.0f);
+    ImGui::SetCursorPosX(right_x);
+    ImGui::TextUnformatted(text);
+  };
 
-    float label_col_w = ImGui::CalcTextSize("Polar angle").x;
-    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Num Elms").x);
-    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Rotate dups").x);
-    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Combine dups").x);
-    label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Default Material").x);
-    label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+  float label_col_w = ImGui::CalcTextSize("Polar angle").x;
+  label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Num Elms").x);
+  label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Rotate dups").x);
+  label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Combine dups").x);
+  label_col_w       = std::max(label_col_w, ImGui::CalcTextSize("Material").x);
+  label_col_w += ImGui::GetStyle().CellPadding.x * 2.0f + 8.0f;
+
+  ImGui::TextUnformatted("Polar duplicate");
+  if (ImGui::BeginTable("options_polar_dup_tool", 2, ImGuiTableFlags_SizingStretchProp))
+  {
     ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, label_col_w);
     ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
 
@@ -907,15 +887,14 @@ void GUI::options_shape_polar_duplicate_mode_()
       if (Status s = polar_dup.dup(); !s.is_ok())
         show_message(s.message());
 
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+    right_aligned_label("Material");
+    ImGui::TableSetColumnIndex(1);
     const std::vector<std::string>& material_names = occt_material_combo_labels_();
     int                             current_item   = int(m_view->get_default_material().Name());
     if (current_item < 0 || current_item >= static_cast<int>(material_names.size()))
       current_item = 0;
-
-    ImGui::TableNextRow();
-    ImGui::TableSetColumnIndex(0);
-    right_aligned_label("Default Material");
-    ImGui::TableSetColumnIndex(1);
     ImGui::SetNextItemWidth(120.0f);
     if (ImGui::BeginCombo("##default_material_polar_dup", material_names[static_cast<size_t>(current_item)].data(),
                           ImGuiComboFlags_HeightSmall))

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -735,7 +735,7 @@ void GUI::settings_()
     {
       uint8_t hr, hg, hb, ha;
       underlay_highlight_color_rgba(hr, hg, hb, ha);
-      for (const std::shared_ptr<Sketch>& sk : m_view->get_sketches())
+      for (const Sketch::sptr& sk : m_view->get_sketches())
       {
         EZY_ASSERT(sk);
         if (sk->has_underlay())

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -1,6 +1,7 @@
 // Settings dialog, JSON load/save, and OCCT view appearance from ezycad_settings.json.
 
 #include <algorithm>
+#include <array>
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
@@ -11,6 +12,7 @@
 #include "occt_view.h"
 #include "settings.h"
 #include "sketch.h"
+#include "sketch_nodes.h"
 
 namespace
 {
@@ -45,6 +47,14 @@ std::string GUI::occt_view_settings_json() const
       {   "edge_dim_arrow_size",    m_edge_dim_arrow_size},
       {    "view_roll_step_deg",     m_view_roll_step_deg},
       {"view_zoom_scroll_scale", m_view_zoom_scroll_scale},
+      {"snap_guide_color",
+       [&]()
+       {
+         float r {}, g {}, b {};
+         Sketch_nodes::get_snap_guide_color(r, g, b);
+         return nlohmann::json::array({r, g, b});
+       }()},
+      {"snap_guide_mode", static_cast<int>(Sketch_nodes::get_snap_guide_mode())},
   };
   return j.dump(2);
 }
@@ -85,6 +95,14 @@ void GUI::save_occt_view_settings()
       {        "imgui_rounding_tabs",                                          m_imgui_rounding_tabs},
       {         "view_roll_step_deg",                                           m_view_roll_step_deg},
       {     "view_zoom_scroll_scale",                                       m_view_zoom_scroll_scale},
+      {           "snap_guide_color",
+       [&]()
+       {
+         float r {}, g {}, b {};
+         Sketch_nodes::get_snap_guide_color(r, g, b);
+         return nlohmann::json::array({r, g, b});
+       }()},
+      {"snap_guide_mode", static_cast<int>(Sketch_nodes::get_snap_guide_mode())},
 #ifndef NDEBUG
       {                   "show_dbg",                                                     m_show_dbg},
 #endif
@@ -239,6 +257,27 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
     }
     if (m_view)
       m_view->set_zoom_scroll_scale(m_view_zoom_scroll_scale);
+
+    // Default snap-guide color is green unless overridden by settings JSON.
+    Sketch_nodes::set_snap_guide_color(0.0f, 1.0f, 0.0f);
+    if (g.contains("snap_guide_color") && g["snap_guide_color"].is_array() && g["snap_guide_color"].size() >= 3)
+    {
+      const json& a = g["snap_guide_color"];
+      float       c[3] {0.0f, 1.0f, 0.0f};
+      for (size_t i = 0; i < 3; ++i)
+        if (a[static_cast<json::size_type>(i)].is_number())
+          c[i] = std::clamp(a[static_cast<json::size_type>(i)].get<float>(), 0.f, 1.f);
+      Sketch_nodes::set_snap_guide_color(c[0], c[1], c[2]);
+    }
+
+    Sketch_nodes::set_snap_guide_mode(Sketch_nodes::Snap_guide_mode::Traditional);
+    if (g.contains("snap_guide_mode") && g["snap_guide_mode"].is_number_integer())
+    {
+      const int mode = g["snap_guide_mode"].get<int>();
+      if (mode >= static_cast<int>(Sketch_nodes::Snap_guide_mode::Traditional) &&
+          mode <= static_cast<int>(Sketch_nodes::Snap_guide_mode::Both))
+        Sketch_nodes::set_snap_guide_mode(static_cast<Sketch_nodes::Snap_guide_mode>(mode));
+    }
 
     if (g.contains("underlay_highlight_color") && g["underlay_highlight_color"].is_array() && g["underlay_highlight_color"].size() >= 3)
     {
@@ -619,6 +658,58 @@ void GUI::settings_()
             "Per-sketch overrides in Sketch List if needed.");
         ImGui::PopTextWrapPos();
         ImGui::EndTooltip();
+      }
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::AlignTextToFramePadding();
+      ImGui::TextUnformatted("Snap guide color");
+      ImGui::TableSetColumnIndex(1);
+      {
+        float snap_col[3];
+        Sketch_nodes::get_snap_guide_color(snap_col[0], snap_col[1], snap_col[2]);
+        if (ImGui::ColorEdit3("##snap_guide_color", snap_col, ImGuiColorEditFlags_Float))
+        {
+          Sketch_nodes::set_snap_guide_color(snap_col[0], snap_col[1], snap_col[2]);
+          save_occt_view_settings();
+        }
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+        ImGui::TextDisabled("(?)");
+        if (ImGui::IsItemHovered())
+        {
+          ImGui::BeginTooltip();
+          ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+          ImGui::TextDisabled(
+              "Color used by fullscreen snap guides and snap markers in sketch mode.");
+          ImGui::PopTextWrapPos();
+          ImGui::EndTooltip();
+        }
+      }
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::AlignTextToFramePadding();
+      ImGui::TextUnformatted("Snap guide mode");
+      ImGui::TableSetColumnIndex(1);
+      {
+        constexpr std::array<const char*, 3> k_snap_guide_mode_labels = {
+            "Traditional",
+            "Fullscreen",
+            "Both",
+        };
+        int mode = static_cast<int>(Sketch_nodes::get_snap_guide_mode());
+        ImGui::SetNextItemWidth(160.0f);
+        if (ImGui::BeginCombo("##settings_snap_guide_mode", k_snap_guide_mode_labels[static_cast<size_t>(mode)],
+                              ImGuiComboFlags_HeightSmall))
+        {
+          for (int i = 0; i < static_cast<int>(k_snap_guide_mode_labels.size()); ++i)
+            if (ImGui::Selectable(k_snap_guide_mode_labels[static_cast<size_t>(i)], i == mode))
+            {
+              Sketch_nodes::set_snap_guide_mode(static_cast<Sketch_nodes::Snap_guide_mode>(i));
+              save_occt_view_settings();
+            }
+          ImGui::EndCombo();
+        }
       }
 
       ImGui::EndTable();

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -107,7 +107,8 @@ void GUI::save_occt_view_settings()
       {                   "show_dbg",                                                     m_show_dbg},
 #endif
       {   "underlay_highlight_color",
-       {m_underlay_highlight_color[0], m_underlay_highlight_color[1], m_underlay_highlight_color[2]}},
+       {m_underlay_highlight_color[0], m_underlay_highlight_color[1], m_underlay_highlight_color[2],
+        m_underlay_highlight_color[3]}},
   };
   j["version"]          = k_settings_version;
   const char* imgui_ini = ImGui::SaveIniSettingsToMemory(nullptr);
@@ -263,10 +264,11 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
     if (g.contains("snap_guide_color") && g["snap_guide_color"].is_array() && g["snap_guide_color"].size() >= 3)
     {
       const json& a = g["snap_guide_color"];
-      float       c[3] {0.0f, 1.0f, 0.0f};
+      glm::vec3   c(0.0f, 1.0f, 0.0f);
       for (size_t i = 0; i < 3; ++i)
         if (a[static_cast<json::size_type>(i)].is_number())
-          c[i] = std::clamp(a[static_cast<json::size_type>(i)].get<float>(), 0.f, 1.f);
+          c[static_cast<glm::vec3::length_type>(i)] =
+              std::clamp(a[static_cast<json::size_type>(i)].get<float>(), 0.f, 1.f);
       Sketch_nodes::set_snap_guide_color(c[0], c[1], c[2]);
     }
 
@@ -282,10 +284,13 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
     if (g.contains("underlay_highlight_color") && g["underlay_highlight_color"].is_array() && g["underlay_highlight_color"].size() >= 3)
     {
       const json& a = g["underlay_highlight_color"];
-      for (size_t i = 0; i < 3; ++i)
+      for (int i = 0; i < 3; ++i)
         if (a[static_cast<json::size_type>(i)].is_number())
-          m_underlay_highlight_color[i] =
+          m_underlay_highlight_color[static_cast<glm::vec4::length_type>(i)] =
               std::clamp(a[static_cast<json::size_type>(i)].get<float>(), 0.f, 1.f);
+      m_underlay_highlight_color[3] = 1.f;
+      if (a.size() >= 4 && a[3].is_number())
+        m_underlay_highlight_color[3] = std::clamp(a[3].get<float>(), 0.f, 1.f);
     }
 
 #ifndef NDEBUG
@@ -646,7 +651,7 @@ void GUI::settings_()
       ImGui::AlignTextToFramePadding();
       ImGui::TextUnformatted("Underlay highlight color");
       ImGui::TableSetColumnIndex(1);
-      ul_changed |= ImGui::ColorEdit3("##underlay_hi", m_underlay_highlight_color, ImGuiColorEditFlags_Float);
+      ul_changed |= ImGui::ColorEdit4("##underlay_hi", &m_underlay_highlight_color[0], ImGuiColorEditFlags_Float);
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       ImGui::TextDisabled("(?)");
       if (ImGui::IsItemHovered())
@@ -666,9 +671,9 @@ void GUI::settings_()
       ImGui::TextUnformatted("Snap guide color");
       ImGui::TableSetColumnIndex(1);
       {
-        float snap_col[3];
+        glm::vec3 snap_col;
         Sketch_nodes::get_snap_guide_color(snap_col[0], snap_col[1], snap_col[2]);
-        if (ImGui::ColorEdit3("##snap_guide_color", snap_col, ImGuiColorEditFlags_Float))
+        if (ImGui::ColorEdit3("##snap_guide_color", &snap_col[0], ImGuiColorEditFlags_Float))
         {
           Sketch_nodes::set_snap_guide_color(snap_col[0], snap_col[1], snap_col[2]);
           save_occt_view_settings();
@@ -728,13 +733,13 @@ void GUI::settings_()
     }
     if (ul_changed)
     {
-      uint8_t hr, hg, hb;
-      underlay_highlight_color_rgb(hr, hg, hb);
+      uint8_t hr, hg, hb, ha;
+      underlay_highlight_color_rgba(hr, hg, hb, ha);
       for (const std::shared_ptr<Sketch>& sk : m_view->get_sketches())
       {
         EZY_ASSERT(sk);
         if (sk->has_underlay())
-          sk->underlay_set_line_tint_rgb(hr, hg, hb);
+          sk->underlay_set_line_tint_rgba(hr, hg, hb, ha);
       }
       m_underlay_panel_sketch = nullptr;
       save_occt_view_settings();
@@ -828,7 +833,7 @@ void GUI::settings_()
   ImGui::End();
 }
 
-void GUI::underlay_highlight_color_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const
+void GUI::underlay_highlight_color_rgba(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a) const
 {
   const auto to_u8 = [](float c) -> uint8_t
   {
@@ -838,6 +843,7 @@ void GUI::underlay_highlight_color_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const
   r = to_u8(m_underlay_highlight_color[0]);
   g = to_u8(m_underlay_highlight_color[1]);
   b = to_u8(m_underlay_highlight_color[2]);
+  a = to_u8(m_underlay_highlight_color[3]);
 }
 
 void GUI::imgui_rounding_fallbacks_from_theme_(float& general, float& scroll, float& tabs) const

--- a/src/occt_view.cpp
+++ b/src/occt_view.cpp
@@ -256,19 +256,11 @@ void Occt_view::init_viewer()
   m_ctx->UpdateCurrentViewer();
 
   // Set initial colors to match what OCCT renders (light gradient + grid)
-  m_bg_color1[0]       = 0.85f;
-  m_bg_color1[1]       = 0.88f;
-  m_bg_color1[2]       = 0.90f;
-  m_bg_color2[0]       = 0.45f;
-  m_bg_color2[1]       = 0.55f;
-  m_bg_color2[2]       = 0.60f;
+  m_bg_color1          = glm::vec3(0.85f, 0.88f, 0.90f);
+  m_bg_color2          = glm::vec3(0.45f, 0.55f, 0.60f);
   m_bg_gradient_method = 1;  // Vertical
-  m_grid_color1[0]     = 0.1f;
-  m_grid_color1[1]     = 0.1f;
-  m_grid_color1[2]     = 0.1f;
-  m_grid_color2[0]     = 0.1f;
-  m_grid_color2[1]     = 0.1f;
-  m_grid_color2[2]     = 0.3f;
+  m_grid_color1        = glm::vec3(0.1f, 0.1f, 0.1f);
+  m_grid_color2        = glm::vec3(0.1f, 0.1f, 0.3f);
   update_view_background_();
 
   Handle(AIS_ViewCube) myViewCube = new AIS_ViewCube();
@@ -1194,16 +1186,16 @@ void Occt_view::update_view_background_()
     return;
 
   m_view->SetBgGradientColors(
-      Quantity_Color(m_bg_color1[0], m_bg_color1[1], m_bg_color1[2], Quantity_TOC_RGB),
-      Quantity_Color(m_bg_color2[0], m_bg_color2[1], m_bg_color2[2], Quantity_TOC_RGB),
+      Quantity_Color(m_bg_color1.x, m_bg_color1.y, m_bg_color1.z, Quantity_TOC_RGB),
+      Quantity_Color(m_bg_color2.x, m_bg_color2.y, m_bg_color2.z, Quantity_TOC_RGB),
       gradient_method_from_int(m_bg_gradient_method),
       Standard_True);
 
   Handle(V3d_Viewer) viewer = m_view->Viewer();
   if (!viewer.IsNull() && !viewer->Grid().IsNull())
   {
-    Quantity_Color cc(m_grid_color1[0], m_grid_color1[1], m_grid_color1[2], Quantity_TOC_RGB);
-    Quantity_Color cd(m_grid_color2[0], m_grid_color2[1], m_grid_color2[2], Quantity_TOC_RGB);
+    Quantity_Color cc(m_grid_color1.x, m_grid_color1.y, m_grid_color1.z, Quantity_TOC_RGB);
+    Quantity_Color cd(m_grid_color2.x, m_grid_color2.y, m_grid_color2.z, Quantity_TOC_RGB);
     viewer->Grid()->SetColors(cc, cd);
   }
 }
@@ -1219,12 +1211,8 @@ void Occt_view::get_bg_gradient_colors(float color1[3], float color2[3]) const
 
 void Occt_view::set_bg_gradient_colors(float r1, float g1, float b1, float r2, float g2, float b2)
 {
-  m_bg_color1[0] = r1;
-  m_bg_color1[1] = g1;
-  m_bg_color1[2] = b1;
-  m_bg_color2[0] = r2;
-  m_bg_color2[1] = g2;
-  m_bg_color2[2] = b2;
+  m_bg_color1 = glm::vec3(r1, g1, b1);
+  m_bg_color2 = glm::vec3(r2, g2, b2);
   update_view_background_();
 }
 
@@ -1250,12 +1238,8 @@ void Occt_view::get_grid_colors(float color1[3], float color2[3]) const
 
 void Occt_view::set_grid_colors(float r1, float g1, float b1, float r2, float g2, float b2)
 {
-  m_grid_color1[0] = r1;
-  m_grid_color1[1] = g1;
-  m_grid_color1[2] = b1;
-  m_grid_color2[0] = r2;
-  m_grid_color2[1] = g2;
-  m_grid_color2[2] = b2;
+  m_grid_color1 = glm::vec3(r1, g1, b1);
+  m_grid_color2 = glm::vec3(r2, g2, b2);
   update_view_background_();
 }
 

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -52,6 +52,7 @@ enum class Set_parent_mode
 class Occt_view : protected AIS_ViewController
 {
  public:
+  DECL_PTR(Occt_view);
   using Sketch_ptr  = std::shared_ptr<Sketch>;
   using Sketch_list = std::list<Sketch_ptr>;
 

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -4,6 +4,7 @@
 #include <AIS_Shape.hxx>
 #include <AIS_ViewController.hxx>
 #include <Graphic3d_MaterialAspect.hxx>
+#include <glm/glm.hpp>
 #include <list>
 #include <memory>
 #include <optional>
@@ -288,11 +289,11 @@ class Occt_view : protected AIS_ViewController
   /// True when LMB press was handled by planar-face sketch creation without AIS_ViewController::PressMouseButton (pair with release skip).
   bool                     m_planar_face_lmb_skipped_view_controller {false};
   // OCCT view colors; defaults match what we render (set explicitly in init_viewer())
-  float                    m_bg_color1[3] {0.85f, 0.88f, 0.90f};
-  float                    m_bg_color2[3] {0.45f, 0.55f, 0.60f};
+  glm::vec3                m_bg_color1 {0.85f, 0.88f, 0.90f};
+  glm::vec3                m_bg_color2 {0.45f, 0.55f, 0.60f};
   int                      m_bg_gradient_method {1};  // 0=HOR, 1=VER, 2=DIAG1, ...
-  float                    m_grid_color1[3] {0.1f, 0.1f, 0.1f};
-  float                    m_grid_color2[3] {0.1f, 0.1f, 0.3f};
+  glm::vec3                m_grid_color1 {0.1f, 0.1f, 0.1f};
+  glm::vec3                m_grid_color2 {0.1f, 0.1f, 0.3f};
   /// User setting: same role as former literal in `UpdateZoom(Aspect_ScrollDelta(..., int(y * scale)))`.
   double                   m_zoom_scroll_scale {4.0};
   // --------------------------------------------------------------------

--- a/src/shp_chamfer.cpp
+++ b/src/shp_chamfer.cpp
@@ -95,6 +95,7 @@ Status Shp_chamfer::add_chamfer(const ScreenCoords& screen_coords, const Chamfer
     view().m_shps.remove(chamfer_src_shp);
     chamfer_shp->set_name("Chamfered shape");
     add_shp_(chamfer_shp);
+    copy_shape_material_from_(chamfer_shp, chamfer_src_shp);
   }
   catch (const Standard_Failure& e)
   {

--- a/src/shp_extrude.cpp
+++ b/src/shp_extrude.cpp
@@ -1,5 +1,6 @@
 #include "shp_extrude.h"
 
+#include <BRepBuilderAPI_Transform.hxx>
 #include <BRepPrimAPI_MakePrism.hxx>
 #include <Precision.hxx>
 #include <TopoDS.hxx>
@@ -86,6 +87,16 @@ bool Shp_extrude::has_active_extrusion() const
   return !m_extruded.IsNull();
 }
 
+bool Shp_extrude::get_both_sides() const
+{
+  return m_extrude_both_sides;
+}
+
+void Shp_extrude::set_both_sides(const bool both_sides)
+{
+  m_extrude_both_sides = both_sides;
+}
+
 void Shp_extrude::set_curr_view_pln(const gp_Pln& pln)
 {
   m_curr_view_pln = pln;
@@ -138,15 +149,17 @@ void Shp_extrude::_update_extrude_preview_(const double extrude_dist, const Plan
 
   EZY_ASSERT(side != Plane_side::On);
 
-  auto extrude_vec = gp_Vec(m_to_extrude_pln.Axis().Direction());
-  if (side == Plane_side::Front)
-    extrude_vec *= extrude_dist;
-  else
-    extrude_vec *= -extrude_dist;
+  const gp_Vec normal_dir(m_to_extrude_pln.Axis().Direction());
+  const double side_sign = (side == Plane_side::Front) ? 1.0 : -1.0;
+  const gp_Vec extrude_vec = normal_dir * (side_sign * extrude_dist);
+  gp_Vec       face_offset(0.0, 0.0, 0.0);
+
+  if (m_extrude_both_sides)
+    face_offset = normal_dir * (-side_sign * (extrude_dist * 0.5));
 
   ctx().Remove(m_tmp_dim, false);
-  m_tmp_dim = create_distance_annotation(gp_Pnt(m_to_extrude_pt->XYZ() + extrude_vec.XYZ()),
-                                         *m_to_extrude_pt,
+  m_tmp_dim = create_distance_annotation(gp_Pnt(m_to_extrude_pt->XYZ() + face_offset.XYZ() + extrude_vec.XYZ()),
+                                         gp_Pnt(m_to_extrude_pt->XYZ() + face_offset.XYZ()),
                                          m_curr_view_pln,
                                          Prs3d_DTHP_Fit,
                                          std::nullopt,
@@ -158,8 +171,16 @@ void Shp_extrude::_update_extrude_preview_(const double extrude_dist, const Plan
 
   ctx().Display(m_tmp_dim, false);
 
-  const TopoDS_Face& face = TopoDS::Face(m_to_extrude->Shape());
-  TopoDS_Shape       body = BRepPrimAPI_MakePrism(face, extrude_vec);
+  TopoDS_Face face = TopoDS::Face(m_to_extrude->Shape());
+  if (m_extrude_both_sides)
+  {
+    gp_Trsf trsf;
+    trsf.SetTranslation(face_offset);
+    TopoDS_Shape shifted_face = BRepBuilderAPI_Transform(face, trsf, true).Shape();
+    face = TopoDS::Face(shifted_face);
+  }
+
+  TopoDS_Shape body = BRepPrimAPI_MakePrism(face, extrude_vec);
   if (!m_extruded)
   {
     m_extruded = new Shp(ctx(), body);

--- a/src/shp_extrude.h
+++ b/src/shp_extrude.h
@@ -20,6 +20,8 @@ class Shp_extrude : private Shp_operation_base
   void finalize();
   bool cancel();
   bool has_active_extrusion() const;
+  bool get_both_sides() const;
+  void set_both_sides(bool both_sides);
 
   // For testing
   void set_curr_view_pln(const gp_Pln& pln);
@@ -35,4 +37,5 @@ class Shp_extrude : private Shp_operation_base
   gp_Pln                     m_curr_view_pln;
   PrsDim_LengthDimension_ptr m_tmp_dim;
   Plane_side                 m_extrude_side;
+  bool                       m_extrude_both_sides {false};
 };

--- a/src/shp_fillet.cpp
+++ b/src/shp_fillet.cpp
@@ -91,6 +91,7 @@ Status Shp_fillet::add_fillet(const ScreenCoords& screen_coords, const Fillet_mo
     view().m_shps.remove(fillet_src_shp);
     fillet_shp->set_name("Filleted shape");
     add_shp_(fillet_shp);
+    copy_shape_material_from_(fillet_shp, fillet_src_shp);
   }
   catch (const Standard_Failure& e)
   {

--- a/src/shp_operation.cpp
+++ b/src/shp_operation.cpp
@@ -1,5 +1,7 @@
 #include "shp_operation.h"
 
+#include <Graphic3d_MaterialAspect.hxx>
+
 #include "occt_view.h"
 
 Shp_operation_base::Shp_operation_base(Occt_view& view)
@@ -105,6 +107,19 @@ const TopoDS_Edge* Shp_operation_base::get_edge_(const ScreenCoords& screen_coor
 void Shp_operation_base::add_shp_(Shp_ptr& shp)
 {
   m_view.add_shp_(shp);
+}
+
+void Shp_operation_base::copy_shape_material_from_(Shp_ptr& dest, const Shp_ptr& src)
+{
+  if (dest.IsNull() || src.IsNull())
+    return;
+  const int        nmat    = Graphic3d_MaterialAspect::NumberOfMaterials();
+  Standard_Integer mat_idx = src->Material();
+  if (mat_idx < 0 || mat_idx >= nmat)
+    return;
+  dest->SetMaterial(Graphic3d_MaterialAspect(static_cast<Graphic3d_NameOfMaterial>(mat_idx)));
+  ctx().Redisplay(dest, true);
+  ctx().UpdateCurrentViewer();
 }
 
 void Shp_operation_base::redisplay_operation_shps_after_transform_()

--- a/src/shp_operation.h
+++ b/src/shp_operation.h
@@ -32,6 +32,9 @@ class Shp_operation_base
 
   void add_shp_(Shp_ptr& shp);
 
+  /// Replace `dest` presentation material with `src` (used after add_shp_, which applies the view default).
+  void copy_shape_material_from_(Shp_ptr& dest, const Shp_ptr& src);
+
   /// After transform-only changes on `m_shps`, refresh presentations once (avoids N x viewer updates per frame).
   void redisplay_operation_shps_after_transform_();
 

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -2713,9 +2713,9 @@ bool Sketch::load_underlay_image(const std::string& file_bytes)
     m_underlay = std::make_unique<Sketch_underlay>();
   if (!m_underlay->set_image_rgba(std::move(rgba), w, h))
     return false;
-  uint8_t hr, hg, hb;
-  m_view.gui().underlay_highlight_color_rgb(hr, hg, hb);
-  m_underlay->set_line_tint_rgb(hr, hg, hb);
+  uint8_t hr, hg, hb, ha;
+  m_view.gui().underlay_highlight_color_rgba(hr, hg, hb, ha);
+  m_underlay->set_line_tint_rgba(hr, hg, hb, ha);
   if (m_visible)
     m_underlay->rebuild_and_display(m_pln, m_ctx);
   m_ctx.UpdateCurrentViewer();
@@ -2942,6 +2942,14 @@ void Sketch::underlay_set_line_tint_rgb(uint8_t r, uint8_t g, uint8_t b)
   underlay_rebuild_display();
 }
 
+void Sketch::underlay_set_line_tint_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+  if (!m_underlay)
+    return;
+  m_underlay->set_line_tint_rgba(r, g, b, a);
+  underlay_rebuild_display();
+}
+
 bool Sketch::underlay_line_tint_enabled() const
 {
   return m_underlay ? m_underlay->line_tint_enabled() : true;
@@ -2956,6 +2964,19 @@ void Sketch::underlay_line_tint_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const
     r = 255;
     g = 220;
     b = 0;
+  }
+}
+
+void Sketch::underlay_line_tint_rgba(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a) const
+{
+  if (m_underlay)
+    m_underlay->line_tint_rgba(r, g, b, a);
+  else
+  {
+    r = 255;
+    g = 220;
+    b = 0;
+    a = 255;
   }
 }
 

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -1482,7 +1482,8 @@ void Sketch::add_or_toggle_length_dim_between_node_indices_(size_t node_a, size_
 void Sketch::json_add_length_dimension_(size_t                      node_a,
                                         size_t                      node_b,
                                         const bool                  visible,
-                                        const std::optional<double> flyout_offset)
+                                        const std::optional<double> flyout_offset,
+                                        const std::string&          name)
 {
   const size_t lo = std::min(node_a, node_b);
   const size_t hi = std::max(node_a, node_b);
@@ -1496,6 +1497,7 @@ void Sketch::json_add_length_dimension_(size_t                      node_a,
   d.node_idx_hi   = hi;
   d.visible       = visible;
   d.flyout_offset = flyout_offset;
+  d.name          = name;
   m_length_dimensions.push_back(std::move(d));
   rebuild_length_dimension_display_(m_length_dimensions.back());
 }
@@ -2485,6 +2487,22 @@ void Sketch::set_dimension_offset(size_t dim_index, const double offset)
   rebuild_length_dimension_display_(d);
 }
 
+std::string Sketch::dimension_name(size_t dim_index) const
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  return m_length_dimensions[dim_index].name;
+}
+
+void Sketch::set_dimension_name(size_t dim_index, const std::string& name)
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  Length_dimension& d = m_length_dimensions[dim_index];
+  if (d.name == name)
+    return;
+  d.name = name;
+  // name is only used in Sketch List inspector; no 3D annotation update needed
+}
+
 void Sketch::refresh_edge_dimension_line_widths(const double line_width)
 {
   for (Length_dimension& ld : m_length_dimensions)
@@ -2620,23 +2638,7 @@ std::vector<std::string> Sketch::inspector_edge_labels() const
   size_t idx = 0;
   for (const Edge& e : m_edges)
   {
-    std::string lbl = "E" + std::to_string(idx) + ": ";
-    if (e.circle_arc)
-      lbl += "Circle arc";
-    else if (e.node_idx_arc.has_value())
-      lbl += "3pt arc";
-    else
-      lbl += "Line";
-
-    lbl += " n" + std::to_string(e.node_idx_a) + "->";
-    if (e.node_idx_b.has_value())
-      lbl += "n" + std::to_string(*e.node_idx_b);
-    else
-      lbl += "?";
-
-    if (e.node_idx_arc.has_value())
-      lbl += " (arc n" + std::to_string(*e.node_idx_arc) + ")";
-
+    std::string lbl = e.name.empty() ? ("E" + std::to_string(idx)) : e.name;
     labels.push_back(std::move(lbl));
     ++idx;
   }
@@ -2649,10 +2651,9 @@ std::vector<std::string> Sketch::inspector_face_labels() const
   labels.reserve(m_faces.size());
   for (size_t i = 0; i < m_faces.size(); ++i)
   {
-    const Sketch_face_shp_ptr& f    = m_faces[i];
-    const size_t               nv   = f ? f->verts_3d.size() : 0;
-    const std::string          text = "F" + std::to_string(i) + ": " + std::to_string(nv) + " verts";
-    labels.push_back(text);
+    const Sketch_face_shp_ptr& f   = m_faces[i];
+    std::string                lbl = (f && !f->name.empty()) ? f->name : ("F" + std::to_string(i));
+    labels.push_back(std::move(lbl));
   }
   return labels;
 }
@@ -2663,9 +2664,24 @@ std::vector<std::string> Sketch::inspector_dimension_labels() const
   labels.reserve(m_length_dimensions.size());
   for (size_t i = 0; i < m_length_dimensions.size(); ++i)
   {
-    const Length_dimension& d = m_length_dimensions[i];
-    labels.push_back("D" + std::to_string(i) + ": n" + std::to_string(d.node_idx_lo) + "<->n" +
-                     std::to_string(d.node_idx_hi));
+    const Length_dimension& d   = m_length_dimensions[i];
+    std::string             lbl = d.name.empty() ? ("D" + std::to_string(i)) : d.name;
+    labels.push_back(std::move(lbl));
+  }
+  return labels;
+}
+
+std::vector<std::string> Sketch::inspector_node_labels() const
+{
+  std::vector<std::string> labels;
+  for (size_t i = 0; i < m_nodes.size(); ++i)
+  {
+    const Sketch_nodes::Node& n = m_nodes[i];
+    if (n.permanent && !n.deleted)
+    {
+      std::string lbl = n.name.empty() ? ("N" + std::to_string(i)) : n.name;
+      labels.push_back(std::move(lbl));
+    }
   }
   return labels;
 }

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -2890,6 +2890,7 @@ void Sketch::underlay_set_opacity(float opaque01)
   if (!m_underlay)
     return;
   m_underlay->set_opacity(opaque01);
+  m_underlay->redisplay(m_ctx);
   m_ctx.UpdateCurrentViewer();
 }
 

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -222,9 +222,9 @@ void Sketch::sync_permanent_node_annos_()
   const double half_arm =
       std::max(plane_pick_snap_radius_world_() * 0.45, Precision::Confusion() * 50.0);
 
-  const Mode mode                 = get_mode();
-  // Show "+" markers only while placing nodes; hide in inspection and all other modes (including other sketch tools).
-  const bool show_permanent_marks = mode == Mode::Sketch_add_node;
+  const Mode mode = get_mode();
+  // Show "+" markers for permanent user nodes in sketch modes and polar duplicate (which snaps to sketch nodes).
+  const bool show_permanent_marks = is_sketch_mode(mode) || mode == Mode::Shape_polar_duplicate;
 
   for (size_t i = 0, n = m_nodes.size(); i < n; ++i)
   {

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -59,7 +59,8 @@ using Sketch_face_shp_ptr      = opencascade::handle<Sketch_face_shp>;
 class Sketch
 {
  public:
-  using Sketch_ptr = std::shared_ptr<Sketch>;
+  DECL_PTR(Sketch);
+  using Sketch_ptr = sptr;  // Compatibility alias for existing code.
 
   // `view` must exist for the lifetime of this `Sketch`
   Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln);

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -86,17 +86,17 @@ class Sketch
   void on_enter();  // For finalizing manual distance input.
 
   // Visibility related
-  void   set_visible(bool state);
-  bool   is_visible() const;
-  void   set_show_faces(bool show);
-  void   set_show_edges(bool show);
-  void   set_show_dims(bool show);
-  bool   dimension_visible(size_t dim_index) const;
-  void   set_dimension_visible(size_t dim_index, bool visible);
-  double dimension_offset(size_t dim_index) const;
-  void   set_dimension_offset(size_t dim_index, double offset);
+  void        set_visible(bool state);
+  bool        is_visible() const;
+  void        set_show_faces(bool show);
+  void        set_show_edges(bool show);
+  void        set_show_dims(bool show);
+  bool        dimension_visible(size_t dim_index) const;
+  void        set_dimension_visible(size_t dim_index, bool visible);
+  double      dimension_offset(size_t dim_index) const;
+  void        set_dimension_offset(size_t dim_index, double offset);
   std::string dimension_name(size_t dim_index) const;
-  void   set_dimension_name(size_t dim_index, const std::string& name);
+  void        set_dimension_name(size_t dim_index, const std::string& name);
 
   /// Apply global dimension line width to edge annotations and in-progress rubber-band dim.
   void refresh_edge_dimension_line_widths(double line_width);

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -45,6 +45,7 @@ struct Sketch_face_shp : public AIS_Shape
   Sketch&             owner_sketch;
   std::vector<gp_Pnt> verts_3d;  // Used for extruding the face
   std::vector<size_t> vert_idxs;
+  std::string         name;
 };
 
 using Sketch_AIS_edge_ptr      = opencascade::handle<Sketch_AIS_edge>;
@@ -94,6 +95,8 @@ class Sketch
   void   set_dimension_visible(size_t dim_index, bool visible);
   double dimension_offset(size_t dim_index) const;
   void   set_dimension_offset(size_t dim_index, double offset);
+  std::string dimension_name(size_t dim_index) const;
+  void   set_dimension_name(size_t dim_index, const std::string& name);
 
   /// Apply global dimension line width to edge annotations and in-progress rubber-band dim.
   void refresh_edge_dimension_line_widths(double line_width);
@@ -131,6 +134,7 @@ class Sketch
   std::vector<std::string> inspector_edge_labels() const;
   std::vector<std::string> inspector_face_labels() const;
   std::vector<std::string> inspector_dimension_labels() const;
+  std::vector<std::string> inspector_node_labels() const;
 
   void          on_mode();
   Mode          get_mode() const;
@@ -183,6 +187,7 @@ class Sketch
     PrsDim_LengthDimension_ptr dim;
     bool                       visible {true};
     std::optional<double>      flyout_offset;
+    std::string                name;
   };
 
   struct Edge
@@ -195,6 +200,8 @@ class Sketch
     //  Used to identify the two `Edges` defining a circle arc.
     Geom_TrimmedCurve_ptr circle_arc;
     Sketch_AIS_edge_ptr   shp;  // Current edge annotation.
+
+    std::string name;
 
     bool reversed(size_t idx_a, size_t idx_b) const;
   };
@@ -319,7 +326,8 @@ class Sketch
   void json_add_length_dimension_(size_t                node_a,
                                   size_t                node_b,
                                   bool                  visible       = true,
-                                  std::optional<double> flyout_offset = std::nullopt);
+                                  std::optional<double> flyout_offset = std::nullopt,
+                                  const std::string&    name          = {});
 
   /// Average of non-deleted node positions (3D on sketch plane); used to place edge dimensions outside loops.
   std::optional<gp_Pnt> approx_sketch_interior_ref_3d_() const;

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -155,8 +155,10 @@ class Sketch
   [[nodiscard]] bool  underlay_key_white_transparent() const;
   void                underlay_set_line_tint_enabled(bool on);
   void                underlay_set_line_tint_rgb(uint8_t r, uint8_t g, uint8_t b);
+  void                underlay_set_line_tint_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
   [[nodiscard]] bool  underlay_line_tint_enabled() const;
   void                underlay_line_tint_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const;
+  void                underlay_line_tint_rgba(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a) const;
   void                underlay_ui_params(double& cx, double& cy, double& half_w, double& half_h, double& rot_deg) const;
   /// True when texture U and V directions are perpendicular (no shear). Orthogonal UI assumes this.
   [[nodiscard]] bool  underlay_axes_orthogonal() const;

--- a/src/sketch_json.cpp
+++ b/src/sketch_json.cpp
@@ -224,14 +224,14 @@ nlohmann::json Sketch_json::to_json(const Sketch& sketch)
   return j;
 }
 
-std::shared_ptr<Sketch> Sketch_json::from_json(Occt_view& view, const nlohmann::json& j)
+Sketch::sptr Sketch_json::from_json(Occt_view& view, const nlohmann::json& j)
 {
   EZY_ASSERT(j.contains("name") && j["name"].is_string());
   EZY_ASSERT(j.contains("edges") && j["edges"].is_array());
   EZY_ASSERT(j.contains("plane") && j["plane"].is_object());
   EZY_ASSERT(j.contains("isCurrent") && j["isCurrent"].is_boolean());
 
-  std::shared_ptr<Sketch> ret;
+  Sketch::sptr ret;
 
   if (j.contains("originating_face"))
   {

--- a/src/sketch_json.cpp
+++ b/src/sketch_json.cpp
@@ -41,6 +41,9 @@ json node_to_json_(const Sketch_nodes::Node& nd)
   if (nd.permanent)
     o["permanent"] = true;
 
+  if (!nd.name.empty())
+    o["name"] = nd.name;
+
   return o;
 }
 
@@ -55,7 +58,7 @@ void Sketch_json::load_nodes_(Sketch& sketch, const json& nodes_json)
     const json& el = nodes_json[i];
     if (el.is_null())
     {
-      sketch.get_nodes().json_set_node(i, gp_Pnt2d(0., 0.), true, false, false);
+      sketch.get_nodes().json_set_node(i, gp_Pnt2d(0., 0.), true, false, false, "");
       continue;
     }
     EZY_ASSERT(el.is_object());
@@ -64,7 +67,7 @@ void Sketch_json::load_nodes_(Sketch& sketch, const json& nodes_json)
         el.contains("midpoint") && el["midpoint"].is_boolean() && el["midpoint"].get<bool>();
     const bool permanent =
         el.contains("permanent") && el["permanent"].is_boolean() && el["permanent"].get<bool>();
-    sketch.get_nodes().json_set_node(i, pt, false, midpoint, permanent);
+    sketch.get_nodes().json_set_node(i, pt, false, midpoint, permanent, el.contains("name") && el["name"].is_string() ? el["name"].get<std::string>() : "");
   }
 }
 
@@ -210,6 +213,8 @@ nlohmann::json Sketch_json::to_json(const Sketch& sketch)
     json e = json::array({remap(ld.node_idx_lo), remap(ld.node_idx_hi), ld.visible});
     if (ld.flyout_offset.has_value())
       e.push_back(*ld.flyout_offset);
+    if (!ld.name.empty())
+      e.push_back(ld.name);
     len_dims_json.push_back(std::move(e));
   }
 
@@ -256,22 +261,30 @@ std::shared_ptr<Sketch> Sketch_json::from_json(Occt_view& view, const nlohmann::
   ret->update_faces_();
 
   for (const auto& ab : legacy_length_dim_endpoints)
-    ret->json_add_length_dimension_(ab.first, ab.second);
+    ret->json_add_length_dimension_(ab.first, ab.second, true, std::nullopt, "");
 
   if (j.contains("length_dimensions") && j["length_dimensions"].is_array())
     for (const auto& pair_json : j["length_dimensions"])
     {
-      EZY_ASSERT(pair_json.is_array() && (pair_json.size() == 2 || pair_json.size() == 3 || pair_json.size() == 4));
+      EZY_ASSERT(pair_json.is_array() && (pair_json.size() >= 2 && pair_json.size() <= 5));
       const bool visible = pair_json.size() >= 3 ? pair_json[2].get<bool>() : true;
       std::optional<double> flyout_offset;
-      if (pair_json.size() == 4)
+      std::string           dim_name;
+      if (pair_json.size() >= 4)
       {
-        const double v = pair_json[3].get<double>();
-        if (v > 0.0)
-          flyout_offset = v;
+        if (pair_json[3].is_number())
+        {
+          const double v = pair_json[3].get<double>();
+          if (v > 0.0)
+            flyout_offset = v;
+        }
+        else if (pair_json[3].is_string())
+          dim_name = pair_json[3].get<std::string>();
       }
+      if (pair_json.size() == 5 && pair_json[4].is_string())
+        dim_name = pair_json[4].get<std::string>();
       ret->json_add_length_dimension_(pair_json[0].get<std::size_t>(), pair_json[1].get<std::size_t>(), visible,
-                                      flyout_offset);
+                                      flyout_offset, dim_name);
     }
 
   if (j.contains("underlay") && j["underlay"].is_object())

--- a/src/sketch_nodes.cpp
+++ b/src/sketch_nodes.cpp
@@ -327,7 +327,7 @@ void Sketch_nodes::update_node_snap_anno_(const gp_Pnt2d& pt, const double snap_
     m_snap_anno = new AIS_Shape(anno_shape);
     m_snap_anno->SetWidth(3.0);
     m_snap_anno->SetColor(
-        Quantity_Color(s_snap_guide_color[0], s_snap_guide_color[1], s_snap_guide_color[2], Quantity_TOC_RGB));
+        Quantity_Color(s_snap_guide_color.x, s_snap_guide_color.y, s_snap_guide_color.z, Quantity_TOC_RGB));
     m_ctx.Display(m_snap_anno, true);
   }
   else
@@ -387,7 +387,7 @@ void Sketch_nodes::update_axis_snap_anno_(int axis_index, const gp_Pnt2d& axis_p
     m_snap_anno_axis[axis_index] = new AIS_Shape(anno_shape);
     m_snap_anno_axis[axis_index]->SetWidth(3.0);
     m_snap_anno_axis[axis_index]->SetColor(
-        Quantity_Color(s_snap_guide_color[0], s_snap_guide_color[1], s_snap_guide_color[2], Quantity_TOC_RGB));
+        Quantity_Color(s_snap_guide_color.x, s_snap_guide_color.y, s_snap_guide_color.z, Quantity_TOC_RGB));
     m_ctx.Display(m_snap_anno_axis[axis_index], true);
   }
   else
@@ -497,7 +497,7 @@ void Sketch_nodes::add_outside_snap_pnt(const gp_Pnt& pt3d)
 // Snap distance related
 double                        Sketch_nodes::s_snap_dist_pixels = 35.0;
 Sketch_nodes::Snap_guide_mode Sketch_nodes::s_snap_guide_mode  = Snap_guide_mode::Traditional;
-float                         Sketch_nodes::s_snap_guide_color[3] = {0.0f, 1.0f, 0.0f};
+glm::vec3                     Sketch_nodes::s_snap_guide_color {0.0f, 1.0f, 0.0f};
 
 void Sketch_nodes::set_snap_dist(double snap_dist_pixels)
 {
@@ -521,15 +521,15 @@ Sketch_nodes::Snap_guide_mode Sketch_nodes::get_snap_guide_mode()
 
 void Sketch_nodes::set_snap_guide_color(float r, float g, float b)
 {
-  s_snap_guide_color[0] = std::clamp(r, 0.0f, 1.0f);
-  s_snap_guide_color[1] = std::clamp(g, 0.0f, 1.0f);
-  s_snap_guide_color[2] = std::clamp(b, 0.0f, 1.0f);
+  s_snap_guide_color.x = std::clamp(r, 0.0f, 1.0f);
+  s_snap_guide_color.y = std::clamp(g, 0.0f, 1.0f);
+  s_snap_guide_color.z = std::clamp(b, 0.0f, 1.0f);
 }
 
 void Sketch_nodes::get_snap_guide_color(float& r, float& g, float& b)
 {
-  r = s_snap_guide_color[0];
-  g = s_snap_guide_color[1];
-  b = s_snap_guide_color[2];
+  r = s_snap_guide_color.x;
+  g = s_snap_guide_color.y;
+  b = s_snap_guide_color.z;
 }
 

--- a/src/sketch_nodes.cpp
+++ b/src/sketch_nodes.cpp
@@ -4,6 +4,7 @@
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <TopoDS_Compound.hxx>
 #include <TopoDS_Wire.hxx>
+#include <algorithm>
 #include <limits>
 
 #include "dbg.h"
@@ -280,8 +281,13 @@ void Sketch_nodes::update_node_snap_anno_(const gp_Pnt2d& pt, const double snap_
 
   m_last_snap_pt = pt;
 
-  TopoDS_Shape anno_shape;
-  if (s_show_fullscreen_snap_guides)
+  const bool show_traditional =
+      s_snap_guide_mode == Snap_guide_mode::Traditional || s_snap_guide_mode == Snap_guide_mode::Both;
+  const bool show_fullscreen =
+      s_snap_guide_mode == Snap_guide_mode::Fullscreen || s_snap_guide_mode == Snap_guide_mode::Both;
+
+  TopoDS_Shape fullscreen_shape;
+  if (show_fullscreen)
   {
     double min_u {}, min_v {}, max_u {}, max_v {};
     if (view_bounds_2d_(min_u, min_v, max_u, max_v))
@@ -296,18 +302,32 @@ void Sketch_nodes::update_node_snap_anno_(const gp_Pnt2d& pt, const double snap_
       const gp_Pnt p_v1 = to_3d(m_pln, gp_Pnt2d(pt.X(), max_v));
       builder.Add(comp, BRepBuilderAPI_MakeEdge(p_h0, p_h1).Edge());
       builder.Add(comp, BRepBuilderAPI_MakeEdge(p_v0, p_v1).Edge());
-      anno_shape = comp;
+      fullscreen_shape = comp;
     }
   }
 
-  if (anno_shape.IsNull())
-    anno_shape = create_wire_box(m_pln, to_3d(m_pln, pt), snap_dist, snap_dist);
+  TopoDS_Shape anno_shape;
+  const TopoDS_Shape traditional_shape = create_wire_box(m_pln, to_3d(m_pln, pt), snap_dist, snap_dist);
+  if (show_traditional && !fullscreen_shape.IsNull())
+  {
+    BRep_Builder    builder;
+    TopoDS_Compound comp;
+    builder.MakeCompound(comp);
+    builder.Add(comp, fullscreen_shape);
+    builder.Add(comp, traditional_shape);
+    anno_shape = comp;
+  }
+  else if (!fullscreen_shape.IsNull())
+    anno_shape = fullscreen_shape;
+  else
+    anno_shape = traditional_shape;
 
   if (m_snap_anno.IsNull())
   {
     m_snap_anno = new AIS_Shape(anno_shape);
     m_snap_anno->SetWidth(3.0);
-    m_snap_anno->SetColor(Quantity_Color(0, 0.5, 0.7, Quantity_TOC_RGB));
+    m_snap_anno->SetColor(
+        Quantity_Color(s_snap_guide_color[0], s_snap_guide_color[1], s_snap_guide_color[2], Quantity_TOC_RGB));
     m_ctx.Display(m_snap_anno, true);
   }
   else
@@ -319,8 +339,13 @@ void Sketch_nodes::update_node_snap_anno_(const gp_Pnt2d& pt, const double snap_
 
 void Sketch_nodes::update_axis_snap_anno_(int axis_index, const gp_Pnt2d& axis_pt, double snap_dist)
 {
-  TopoDS_Shape anno_shape;
-  if (s_show_fullscreen_snap_guides)
+  const bool show_traditional =
+      s_snap_guide_mode == Snap_guide_mode::Traditional || s_snap_guide_mode == Snap_guide_mode::Both;
+  const bool show_fullscreen =
+      s_snap_guide_mode == Snap_guide_mode::Fullscreen || s_snap_guide_mode == Snap_guide_mode::Both;
+
+  TopoDS_Shape fullscreen_shape;
+  if (show_fullscreen)
   {
     double min_u {}, min_v {}, max_u {}, max_v {};
     if (view_bounds_2d_(min_u, min_v, max_u, max_v))
@@ -329,25 +354,40 @@ void Sketch_nodes::update_axis_snap_anno_(int axis_index, const gp_Pnt2d& axis_p
       {
         const gp_Pnt p0 = to_3d(m_pln, gp_Pnt2d(axis_pt.X(), min_v));
         const gp_Pnt p1 = to_3d(m_pln, gp_Pnt2d(axis_pt.X(), max_v));
-        anno_shape       = BRepBuilderAPI_MakeEdge(p0, p1).Edge();
+        fullscreen_shape = BRepBuilderAPI_MakeEdge(p0, p1).Edge();
       }
       else
       {
         const gp_Pnt p0 = to_3d(m_pln, gp_Pnt2d(min_u, axis_pt.Y()));
         const gp_Pnt p1 = to_3d(m_pln, gp_Pnt2d(max_u, axis_pt.Y()));
-        anno_shape       = BRepBuilderAPI_MakeEdge(p0, p1).Edge();
+        fullscreen_shape = BRepBuilderAPI_MakeEdge(p0, p1).Edge();
       }
     }
   }
 
-  if (anno_shape.IsNull())
-    anno_shape = create_wire_box(m_pln, to_3d(m_pln, axis_pt), snap_dist * 0.5, snap_dist * 0.5);
+  TopoDS_Shape anno_shape;
+  const TopoDS_Shape traditional_shape =
+      create_wire_box(m_pln, to_3d(m_pln, axis_pt), snap_dist * 0.5, snap_dist * 0.5);
+  if (show_traditional && !fullscreen_shape.IsNull())
+  {
+    BRep_Builder    builder;
+    TopoDS_Compound comp;
+    builder.MakeCompound(comp);
+    builder.Add(comp, fullscreen_shape);
+    builder.Add(comp, traditional_shape);
+    anno_shape = comp;
+  }
+  else if (!fullscreen_shape.IsNull())
+    anno_shape = fullscreen_shape;
+  else
+    anno_shape = traditional_shape;
 
   if (m_snap_anno_axis[axis_index].IsNull())
   {
     m_snap_anno_axis[axis_index] = new AIS_Shape(anno_shape);
     m_snap_anno_axis[axis_index]->SetWidth(3.0);
-    m_snap_anno_axis[axis_index]->SetColor(Quantity_Color(1, 0.5, 0.7, Quantity_TOC_RGB));
+    m_snap_anno_axis[axis_index]->SetColor(
+        Quantity_Color(s_snap_guide_color[0], s_snap_guide_color[1], s_snap_guide_color[2], Quantity_TOC_RGB));
     m_ctx.Display(m_snap_anno_axis[axis_index], true);
   }
   else
@@ -455,8 +495,9 @@ void Sketch_nodes::add_outside_snap_pnt(const gp_Pnt& pt3d)
 }
 
 // Snap distance related
-double Sketch_nodes::s_snap_dist_pixels = 35.0;
-bool   Sketch_nodes::s_show_fullscreen_snap_guides = false;
+double                        Sketch_nodes::s_snap_dist_pixels = 35.0;
+Sketch_nodes::Snap_guide_mode Sketch_nodes::s_snap_guide_mode  = Snap_guide_mode::Traditional;
+float                         Sketch_nodes::s_snap_guide_color[3] = {0.0f, 1.0f, 0.0f};
 
 void Sketch_nodes::set_snap_dist(double snap_dist_pixels)
 {
@@ -468,13 +509,27 @@ double Sketch_nodes::get_snap_dist()
   return s_snap_dist_pixels;
 }
 
-void Sketch_nodes::set_show_fullscreen_snap_guides(bool on)
+void Sketch_nodes::set_snap_guide_mode(Snap_guide_mode mode)
 {
-  s_show_fullscreen_snap_guides = on;
+  s_snap_guide_mode = mode;
 }
 
-bool Sketch_nodes::get_show_fullscreen_snap_guides()
+Sketch_nodes::Snap_guide_mode Sketch_nodes::get_snap_guide_mode()
 {
-  return s_show_fullscreen_snap_guides;
+  return s_snap_guide_mode;
+}
+
+void Sketch_nodes::set_snap_guide_color(float r, float g, float b)
+{
+  s_snap_guide_color[0] = std::clamp(r, 0.0f, 1.0f);
+  s_snap_guide_color[1] = std::clamp(g, 0.0f, 1.0f);
+  s_snap_guide_color[2] = std::clamp(b, 0.0f, 1.0f);
+}
+
+void Sketch_nodes::get_snap_guide_color(float& r, float& g, float& b)
+{
+  r = s_snap_guide_color[0];
+  g = s_snap_guide_color[1];
+  b = s_snap_guide_color[2];
 }
 

--- a/src/sketch_nodes.cpp
+++ b/src/sketch_nodes.cpp
@@ -28,9 +28,33 @@ std::optional<gp_Pnt2d> Sketch_nodes::snap(const ScreenCoords& screen_coords)
 
 size_t Sketch_nodes::get_node_exact(const gp_Pnt2d& pt, bool permanent_for_new)
 {
+  std::optional<size_t> deleted_match;
   for (size_t idx = 0, num = m_nodes.size(); idx < num; ++idx)
     if (equal(pt, gp_Pnt2d(m_nodes[idx])))
+    {
+      Node& n = m_nodes[idx];
+      // Never bind to tombstoned nodes while searching for an exact live match.
+      if (n.deleted)
+      {
+        if (!deleted_match.has_value())
+          deleted_match = idx;
+        continue;
+      }
+      // If caller requests permanence (e.g. add-node tool), preserve/promote it.
+      if (permanent_for_new)
+        n.permanent = true;
       return idx;
+    }
+
+  // If only a deleted exact match exists, revive it instead of appending a duplicate index.
+  if (deleted_match.has_value())
+  {
+    Node& n = m_nodes[*deleted_match];
+    n.deleted = false;
+    if (permanent_for_new)
+      n.permanent = true;
+    return *deleted_match;
+  }
 
   Node n(pt);
   n.permanent = permanent_for_new;

--- a/src/sketch_nodes.cpp
+++ b/src/sketch_nodes.cpp
@@ -1,10 +1,14 @@
 #include "sketch_nodes.h"
 
+#include <BRep_Builder.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <TopoDS_Compound.hxx>
 #include <TopoDS_Wire.hxx>
 #include <limits>
 
 #include "dbg.h"
 #include "geom.h"
+#include "imgui.h"
 #include "occt_view.h"
 
 Sketch_nodes::Sketch_nodes(Occt_view& view, const gp_Pln& pln)
@@ -96,6 +100,16 @@ double Sketch_nodes::snap_radius_world_(const gp_Pnt2d& pt) const
     return 5.0;
   }
   return s_snap_dist_pixels;
+}
+
+bool Sketch_nodes::view_bounds_2d_(double& min_u, double& min_v, double& max_u, double& max_v) const
+{
+  if (m_view.is_headless())
+    return false;
+
+  const ImGuiIO& io = ImGui::GetIO();
+  return m_view.sketch_plane_view_aabb_2d(m_pln, static_cast<double>(io.DisplaySize.x),
+                                          static_cast<double>(io.DisplaySize.y), min_u, min_v, max_u, max_v);
 }
 
 std::optional<size_t> Sketch_nodes::try_pick_existing_node(const ScreenCoords& screen_coords)
@@ -215,27 +229,9 @@ std::optional<size_t> Sketch_nodes::try_get_node_idx_snap(
       try_nd_pt(nd_pt);
 
     if (snap_axis_point)
-    {
-      // create_wire_box and update_node_snap_anno_ expect linear distances.
-      TopoDS_Wire box = create_wire_box(m_pln, to_3d(m_pln, *snap_axis_point), sqrt(snap_dist) * 0.5, sqrt(snap_dist) * 0.5);
-      if (m_snap_anno_axis[i].IsNull())
-      {
-        m_snap_anno_axis[i] = new AIS_Shape(box);
-        m_snap_anno_axis[i]->SetWidth(3.0);
-        m_snap_anno_axis[i]->SetColor(Quantity_Color(1, 0.5, 0.7, Quantity_TOC_RGB));
-        m_ctx.Display(m_snap_anno_axis[i], true);
-      }
-      else
-      {
-        m_snap_anno_axis[i]->Set(box);
-        m_ctx.Redisplay(m_snap_anno_axis[i], true);
-      }
-    }
-    else
-    {
-      if (!m_snap_anno_axis[i].IsNull())
-        m_ctx.Erase(m_snap_anno_axis[i], true);
-    }
+      update_axis_snap_anno_(i, *snap_axis_point, sqrt(snap_dist));
+    else if (!m_snap_anno_axis[i].IsNull())
+      m_ctx.Erase(m_snap_anno_axis[i], true);
   }
 
   return {};
@@ -284,19 +280,80 @@ void Sketch_nodes::update_node_snap_anno_(const gp_Pnt2d& pt, const double snap_
 
   m_last_snap_pt = pt;
 
-  TopoDS_Wire box = create_wire_box(m_pln, to_3d(m_pln, pt), snap_dist, snap_dist);
+  TopoDS_Shape anno_shape;
+  if (s_show_fullscreen_snap_guides)
+  {
+    double min_u {}, min_v {}, max_u {}, max_v {};
+    if (view_bounds_2d_(min_u, min_v, max_u, max_v))
+    {
+      BRep_Builder    builder;
+      TopoDS_Compound comp;
+      builder.MakeCompound(comp);
+
+      const gp_Pnt p_h0 = to_3d(m_pln, gp_Pnt2d(min_u, pt.Y()));
+      const gp_Pnt p_h1 = to_3d(m_pln, gp_Pnt2d(max_u, pt.Y()));
+      const gp_Pnt p_v0 = to_3d(m_pln, gp_Pnt2d(pt.X(), min_v));
+      const gp_Pnt p_v1 = to_3d(m_pln, gp_Pnt2d(pt.X(), max_v));
+      builder.Add(comp, BRepBuilderAPI_MakeEdge(p_h0, p_h1).Edge());
+      builder.Add(comp, BRepBuilderAPI_MakeEdge(p_v0, p_v1).Edge());
+      anno_shape = comp;
+    }
+  }
+
+  if (anno_shape.IsNull())
+    anno_shape = create_wire_box(m_pln, to_3d(m_pln, pt), snap_dist, snap_dist);
 
   if (m_snap_anno.IsNull())
   {
-    m_snap_anno = new AIS_Shape(box);
+    m_snap_anno = new AIS_Shape(anno_shape);
     m_snap_anno->SetWidth(3.0);
     m_snap_anno->SetColor(Quantity_Color(0, 0.5, 0.7, Quantity_TOC_RGB));
     m_ctx.Display(m_snap_anno, true);
   }
   else
   {
-    m_snap_anno->Set(box);
+    m_snap_anno->Set(anno_shape);
     m_ctx.Redisplay(m_snap_anno, true);
+  }
+}
+
+void Sketch_nodes::update_axis_snap_anno_(int axis_index, const gp_Pnt2d& axis_pt, double snap_dist)
+{
+  TopoDS_Shape anno_shape;
+  if (s_show_fullscreen_snap_guides)
+  {
+    double min_u {}, min_v {}, max_u {}, max_v {};
+    if (view_bounds_2d_(min_u, min_v, max_u, max_v))
+    {
+      if (axis_index == 0)
+      {
+        const gp_Pnt p0 = to_3d(m_pln, gp_Pnt2d(axis_pt.X(), min_v));
+        const gp_Pnt p1 = to_3d(m_pln, gp_Pnt2d(axis_pt.X(), max_v));
+        anno_shape       = BRepBuilderAPI_MakeEdge(p0, p1).Edge();
+      }
+      else
+      {
+        const gp_Pnt p0 = to_3d(m_pln, gp_Pnt2d(min_u, axis_pt.Y()));
+        const gp_Pnt p1 = to_3d(m_pln, gp_Pnt2d(max_u, axis_pt.Y()));
+        anno_shape       = BRepBuilderAPI_MakeEdge(p0, p1).Edge();
+      }
+    }
+  }
+
+  if (anno_shape.IsNull())
+    anno_shape = create_wire_box(m_pln, to_3d(m_pln, axis_pt), snap_dist * 0.5, snap_dist * 0.5);
+
+  if (m_snap_anno_axis[axis_index].IsNull())
+  {
+    m_snap_anno_axis[axis_index] = new AIS_Shape(anno_shape);
+    m_snap_anno_axis[axis_index]->SetWidth(3.0);
+    m_snap_anno_axis[axis_index]->SetColor(Quantity_Color(1, 0.5, 0.7, Quantity_TOC_RGB));
+    m_ctx.Display(m_snap_anno_axis[axis_index], true);
+  }
+  else
+  {
+    m_snap_anno_axis[axis_index]->Set(anno_shape);
+    m_ctx.Redisplay(m_snap_anno_axis[axis_index], true);
   }
 }
 
@@ -399,6 +456,7 @@ void Sketch_nodes::add_outside_snap_pnt(const gp_Pnt& pt3d)
 
 // Snap distance related
 double Sketch_nodes::s_snap_dist_pixels = 35.0;
+bool   Sketch_nodes::s_show_fullscreen_snap_guides = false;
 
 void Sketch_nodes::set_snap_dist(double snap_dist_pixels)
 {
@@ -408,5 +466,15 @@ void Sketch_nodes::set_snap_dist(double snap_dist_pixels)
 double Sketch_nodes::get_snap_dist()
 {
   return s_snap_dist_pixels;
+}
+
+void Sketch_nodes::set_show_fullscreen_snap_guides(bool on)
+{
+  s_show_fullscreen_snap_guides = on;
+}
+
+bool Sketch_nodes::get_show_fullscreen_snap_guides()
+{
+  return s_show_fullscreen_snap_guides;
 }
 

--- a/src/sketch_nodes.cpp
+++ b/src/sketch_nodes.cpp
@@ -341,15 +341,16 @@ void Sketch_nodes::json_resize(size_t count)
   m_nodes.assign(count, Node {});
 }
 
-void Sketch_nodes::json_set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent)
+void Sketch_nodes::json_set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent, const std::string& name)
 {
   EZY_ASSERT(idx < m_nodes.size());
   Node& n = m_nodes[idx];
   n.SetX(pt.X());
   n.SetY(pt.Y());
-  n.deleted     = deleted;
-  n.midpoint    = midpoint;
-  n.permanent   = permanent;
+  n.deleted   = deleted;
+  n.midpoint  = midpoint;
+  n.permanent = permanent;
+  n.name      = name;
 }
 
 void Sketch_nodes::finalize()

--- a/src/sketch_nodes.h
+++ b/src/sketch_nodes.h
@@ -2,6 +2,7 @@
 
 #include <gp_Pln.hxx>
 #include <gp_Pnt2d.hxx>
+#include <glm/glm.hpp>
 #include <optional>
 #include <set>
 #include <string>
@@ -99,7 +100,7 @@ class Sketch_nodes
   std::vector<Node>       m_nodes;
   static double           s_snap_dist_pixels;  // Global to all sketches
   static Snap_guide_mode  s_snap_guide_mode;
-  static float            s_snap_guide_color[3];
+  static glm::vec3        s_snap_guide_color;
   std::set<gp_Pnt2d>      m_outside_snap_pts;  // Projected snap points from other sketches.
   AIS_Shape_ptr           m_snap_anno_axis[2];
   std::optional<gp_Pnt2d> m_last_snap_pt;  // Used for snap annotation

--- a/src/sketch_nodes.h
+++ b/src/sketch_nodes.h
@@ -4,6 +4,7 @@
 #include <gp_Pnt2d.hxx>
 #include <optional>
 #include <set>
+#include <string>
 
 #include "types.h"
 
@@ -18,9 +19,10 @@ class Sketch_nodes
  public:
   struct Node : public gp_Pnt2d
   {
-    bool midpoint = false;
-    bool deleted     = false;
-    bool permanent   = false;
+    bool        midpoint = false;
+    bool        deleted  = false;
+    bool        permanent = false;
+    std::string name;
   };
 
   // `view` must exist for the lifetime of this object
@@ -74,7 +76,7 @@ class Sketch_nodes
   /// Resize storage so indices `0..count-1` exist (JSON load).
   void json_resize(size_t count);
   /// Assign slot `idx` (used after `json_resize`).
-  void json_set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent);
+  void json_set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent, const std::string& name = {});
 
   void update_node_snap_anno_(const gp_Pnt2d& pt, const double snap_dist);
   /// World-space snap radius at `pt` (same convention as `try_get_node_idx_snap` / `try_pick_existing_node`).

--- a/src/sketch_nodes.h
+++ b/src/sketch_nodes.h
@@ -59,6 +59,8 @@ class Sketch_nodes
   // Snap distance related
   static void   set_snap_dist(double snap_dist_pixels);
   static double get_snap_dist();
+  static void   set_show_fullscreen_snap_guides(bool on);
+  static bool   get_show_fullscreen_snap_guides();
 
   // Methods for range-based for loop support
   // clang-format off
@@ -79,12 +81,15 @@ class Sketch_nodes
   void json_set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent, const std::string& name = {});
 
   void update_node_snap_anno_(const gp_Pnt2d& pt, const double snap_dist);
+  void update_axis_snap_anno_(int axis_index, const gp_Pnt2d& axis_pt, double snap_dist);
   /// World-space snap radius at `pt` (same convention as `try_get_node_idx_snap` / `try_pick_existing_node`).
   double snap_radius_world_(const gp_Pnt2d& pt) const;
+  bool   view_bounds_2d_(double& min_u, double& min_v, double& max_u, double& max_v) const;
   bool try_snap_outside_(gp_Pnt2d& pt, const double snap_dist);  // Use points in `m_outside_snap_pts` `pt` will be modified if snapped.
 
   std::vector<Node>       m_nodes;
   static double           s_snap_dist_pixels;  // Global to all sketches
+  static bool             s_show_fullscreen_snap_guides;
   std::set<gp_Pnt2d>      m_outside_snap_pts;  // Projected snap points from other sketches.
   AIS_Shape_ptr           m_snap_anno_axis[2];
   std::optional<gp_Pnt2d> m_last_snap_pt;  // Used for snap annotation

--- a/src/sketch_nodes.h
+++ b/src/sketch_nodes.h
@@ -17,6 +17,13 @@ class Sketch_json;
 class Sketch_nodes
 {
  public:
+  enum class Snap_guide_mode : int
+  {
+    Traditional = 0,
+    Fullscreen  = 1,
+    Both        = 2
+  };
+
   struct Node : public gp_Pnt2d
   {
     bool        midpoint = false;
@@ -59,8 +66,10 @@ class Sketch_nodes
   // Snap distance related
   static void   set_snap_dist(double snap_dist_pixels);
   static double get_snap_dist();
-  static void   set_show_fullscreen_snap_guides(bool on);
-  static bool   get_show_fullscreen_snap_guides();
+  static void   set_snap_guide_mode(Snap_guide_mode mode);
+  static Snap_guide_mode get_snap_guide_mode();
+  static void   set_snap_guide_color(float r, float g, float b);
+  static void   get_snap_guide_color(float& r, float& g, float& b);
 
   // Methods for range-based for loop support
   // clang-format off
@@ -89,7 +98,8 @@ class Sketch_nodes
 
   std::vector<Node>       m_nodes;
   static double           s_snap_dist_pixels;  // Global to all sketches
-  static bool             s_show_fullscreen_snap_guides;
+  static Snap_guide_mode  s_snap_guide_mode;
+  static float            s_snap_guide_color[3];
   std::set<gp_Pnt2d>      m_outside_snap_pts;  // Projected snap points from other sketches.
   AIS_Shape_ptr           m_snap_anno_axis[2];
   std::optional<gp_Pnt2d> m_last_snap_pt;  // Used for snap annotation

--- a/src/sketch_underlay.cpp
+++ b/src/sketch_underlay.cpp
@@ -500,6 +500,12 @@ void Sketch_underlay::sync_visibility(const gp_Pln& pln, AIS_InteractiveContext&
     remove_ais_(ctx);
 }
 
+void Sketch_underlay::redisplay(AIS_InteractiveContext& ctx)
+{
+  if (!m_ais.IsNull())
+    ctx.Redisplay(m_ais, true);
+}
+
 nlohmann::json Sketch_underlay::to_json() const
 {
   using nlohmann::json;
@@ -572,7 +578,6 @@ bool Sketch_underlay::from_json(const nlohmann::json& j)
     m_opacity = 0.f;
   if (m_opacity > 1.f)
     m_opacity = 1.f;
-
   m_ais.Nullify();
   return true;
 }

--- a/src/sketch_underlay.cpp
+++ b/src/sketch_underlay.cpp
@@ -101,7 +101,7 @@ inline unsigned luminance_u8(uint8_t r, uint8_t g, uint8_t b)
 }
 
 inline void apply_key_and_tint(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a, bool key_white_transparent,
-                               bool line_tint_enabled, uint8_t tr, uint8_t tg, uint8_t tb)
+                               bool line_tint_enabled, uint8_t tr, uint8_t tg, uint8_t tb, uint8_t ta)
 {
   unsigned a2;
   if (key_white_transparent)
@@ -117,6 +117,7 @@ inline void apply_key_and_tint(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a, b
     r = tr;
     g = tg;
     b = tb;
+    a2 = (a2 * static_cast<unsigned>(ta)) / 255u;
   }
   a = static_cast<uint8_t>(a2);
 }
@@ -158,7 +159,8 @@ Handle(Image_PixMap) make_pixmap_bottom_up_linear(const uint8_t* rgba,
                                                   bool           line_tint_enabled,
                                                   uint8_t        tr,
                                                   uint8_t        tg,
-                                                  uint8_t        tb)
+                                                  uint8_t        tb,
+                                                  uint8_t        ta)
 {
   if (w <= 0 || h <= 0)
     return {};
@@ -178,7 +180,7 @@ Handle(Image_PixMap) make_pixmap_bottom_up_linear(const uint8_t* rgba,
     for (int ox = 0; ox < w; ++ox)
     {
       uint8_t px[4] = {srcRow[ox * 4 + 0], srcRow[ox * 4 + 1], srcRow[ox * 4 + 2], srcRow[ox * 4 + 3]};
-      apply_key_and_tint(px[0], px[1], px[2], px[3], key_white_transparent, line_tint_enabled, tr, tg, tb);
+      apply_key_and_tint(px[0], px[1], px[2], px[3], key_white_transparent, line_tint_enabled, tr, tg, tb, ta);
       dstRow[static_cast<std::size_t>(ox) * 4u + 0] = px[0];
       dstRow[static_cast<std::size_t>(ox) * 4u + 1] = px[1];
       dstRow[static_cast<std::size_t>(ox) * 4u + 2] = px[2];
@@ -199,7 +201,8 @@ Handle(Image_PixMap) make_pixmap_bottom_up_warped(const uint8_t*  rgba,
                                                   bool            line_tint_enabled,
                                                   uint8_t         tr,
                                                   uint8_t         tg,
-                                                  uint8_t         tb)
+                                                  uint8_t         tb,
+                                                  uint8_t         ta)
 {
   const double hw = 0.5 * axis_u.Magnitude();
   const double hh = 0.5 * axis_v.Magnitude();
@@ -250,7 +253,7 @@ Handle(Image_PixMap) make_pixmap_bottom_up_warped(const uint8_t*  rgba,
         sample_rgba_bilinear(rgba, w, h, sx, sy, px);
       }
 
-      apply_key_and_tint(px[0], px[1], px[2], px[3], key_white_transparent, line_tint_enabled, tr, tg, tb);
+      apply_key_and_tint(px[0], px[1], px[2], px[3], key_white_transparent, line_tint_enabled, tr, tg, tb, ta);
       const Standard_Size o = static_cast<Standard_Size>(ox) * 4u;
       dstRow[o + 0]         = px[0];
       dstRow[o + 1]         = px[1];
@@ -363,11 +366,27 @@ void Sketch_underlay::set_line_tint_rgb(uint8_t r, uint8_t g, uint8_t b)
   m_tint_b = b;
 }
 
+void Sketch_underlay::set_line_tint_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+  m_tint_r = r;
+  m_tint_g = g;
+  m_tint_b = b;
+  m_tint_a = a;
+}
+
 void Sketch_underlay::line_tint_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const
 {
   r = m_tint_r;
   g = m_tint_g;
   b = m_tint_b;
+}
+
+void Sketch_underlay::line_tint_rgba(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a) const
+{
+  r = m_tint_r;
+  g = m_tint_g;
+  b = m_tint_b;
+  a = m_tint_a;
 }
 
 void Sketch_underlay::build_ais_(const gp_Pln& pln, AIS_InteractiveContext& ctx)
@@ -417,7 +436,7 @@ void Sketch_underlay::build_ais_(const gp_Pln& pln, AIS_InteractiveContext& ctx)
     face = faceMk.Face();
 
     pix = make_pixmap_bottom_up_linear(m_rgba.data(), m_w, m_h, m_key_white_transparent, m_line_tint_enabled,
-                                       m_tint_r, m_tint_g, m_tint_b);
+                                       m_tint_r, m_tint_g, m_tint_b, m_tint_a);
   }
   else
   {
@@ -456,7 +475,7 @@ void Sketch_underlay::build_ais_(const gp_Pln& pln, AIS_InteractiveContext& ctx)
     face = faceMk.Face();
 
     pix = make_pixmap_bottom_up_warped(m_rgba.data(), m_w, m_h, m_axis_u, m_axis_v, m_key_white_transparent,
-                                       m_line_tint_enabled, m_tint_r, m_tint_g, m_tint_b);
+                                       m_line_tint_enabled, m_tint_r, m_tint_g, m_tint_b, m_tint_a);
   }
 
   if (pix.IsNull())
@@ -531,7 +550,7 @@ nlohmann::json Sketch_underlay::to_json() const
   j["visible"]               = m_visible;
   j["key_white_transparent"] = m_key_white_transparent;
   j["line_tint_enabled"]     = m_line_tint_enabled;
-  j["line_tint_rgb"]         = nlohmann::json::array({m_tint_r, m_tint_g, m_tint_b});
+  j["line_tint_rgba"]        = nlohmann::json::array({m_tint_r, m_tint_g, m_tint_b, m_tint_a});
   return j;
 }
 
@@ -568,7 +587,15 @@ bool Sketch_underlay::from_json(const nlohmann::json& j)
   m_visible               = j.value("visible", true);
   m_key_white_transparent = j.value("key_white_transparent", true);
   m_line_tint_enabled     = j.value("line_tint_enabled", true);
-  if (j.contains("line_tint_rgb") && j["line_tint_rgb"].is_array() && j["line_tint_rgb"].size() >= 3)
+  m_tint_a = 255;
+  if (j.contains("line_tint_rgba") && j["line_tint_rgba"].is_array() && j["line_tint_rgba"].size() >= 4)
+  {
+    m_tint_r = static_cast<uint8_t>(j["line_tint_rgba"][0].get<int>());
+    m_tint_g = static_cast<uint8_t>(j["line_tint_rgba"][1].get<int>());
+    m_tint_b = static_cast<uint8_t>(j["line_tint_rgba"][2].get<int>());
+    m_tint_a = static_cast<uint8_t>(j["line_tint_rgba"][3].get<int>());
+  }
+  else if (j.contains("line_tint_rgb") && j["line_tint_rgb"].is_array() && j["line_tint_rgb"].size() >= 3)
   {
     m_tint_r = static_cast<uint8_t>(j["line_tint_rgb"][0].get<int>());
     m_tint_g = static_cast<uint8_t>(j["line_tint_rgb"][1].get<int>());

--- a/src/sketch_underlay.h
+++ b/src/sketch_underlay.h
@@ -44,8 +44,10 @@ class Sketch_underlay
 
   void set_line_tint_enabled(bool on);
   void set_line_tint_rgb(uint8_t r, uint8_t g, uint8_t b);
+  void set_line_tint_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
   void line_tint_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const;
+  void line_tint_rgba(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a) const;
 
   // clang-format off
 
@@ -92,6 +94,7 @@ class Sketch_underlay
   uint8_t m_tint_r {255};
   uint8_t m_tint_g {220};
   uint8_t m_tint_b {0};
+  uint8_t m_tint_a {255};
 
   opencascade::handle<AIS_TexturedShape> m_ais;
 };

--- a/src/sketch_underlay.h
+++ b/src/sketch_underlay.h
@@ -64,6 +64,8 @@ class Sketch_underlay
   void rebuild_and_display(const gp_Pln& pln, AIS_InteractiveContext& ctx);
   void erase(AIS_InteractiveContext& ctx);
   void sync_visibility(const gp_Pln& pln, AIS_InteractiveContext& ctx);
+  /// Force viewer update after live property changes (e.g. threshold) without a full rebuild.
+  void redisplay(AIS_InteractiveContext& ctx);
 
   nlohmann::json     to_json() const;
   /// Returns false if JSON is invalid or image decode fails.

--- a/src/types.h
+++ b/src/types.h
@@ -2,6 +2,7 @@
 
 #include <Standard_Handle.hxx>
 #include <glm/glm.hpp>
+#include <memory>
 
 class AIS_InteractiveObject;
 class AIS_InteractiveContext;
@@ -32,6 +33,11 @@ using Geom_Surface_ptr           = opencascade::handle<Geom_Surface>;
 using PrsDim_LengthDimension_ptr = opencascade::handle<PrsDim_LengthDimension>;
 using Graphic3d_Camera_ptr       = opencascade::handle<Graphic3d_Camera>;
 using StdSelect_BRepOwner_ptr    = opencascade::handle<StdSelect_BRepOwner>;
+
+#define DECL_PTR(TypeName) \
+  using uptr = std::unique_ptr<TypeName>; \
+  using sptr = std::shared_ptr<TypeName>; \
+  using wptr = std::weak_ptr<TypeName>;
 
 // Primary template for non-vector types
 template <typename T>

--- a/usage-settings.md
+++ b/usage-settings.md
@@ -61,11 +61,17 @@ Between those, the pane has **six** collapsible sections. Expand a section to se
 
 ## Options panel (sketch)
 
-Some sketch-related preferences are edited in the **Options** panel while you use a tool, not in the **Settings** pane:
+Sketch-related preferences are edited in the **Options** panel while you use a tool, not in the **Settings** pane. They appear under section headings in the panel:
 
-- **Length value placement** (shown when the mode is **Toggle edge dimension** / length dimensions) - Combo: *Near first point*, *Near second point*, *Center on dimension line*, *Automatic*. This maps to the `edge_dim_label_h` key (integers **0** through **3**). Changing it persists like other GUI flags.
+- **Sketch options** (all sketch tools): **Snap dist** and **Snap guide mode** (*Traditional*, *Fullscreen*, *Both*).
+- **Toggle edge dimension** (length dimensions): **Length value placement** - combo: *Near first point*, *Near second point*, *Center on dimension line*, *Automatic*. Maps to the `edge_dim_label_h` key (integers **0** through **3**). Changing it persists like other GUI flags.
+- **Extrude sketch face**: under **Extrude**, **Both sides** and **Material** for the new solid (same document preset as **Normal** mode Options **Material**). Other modes that still show **Material** in Options use that same preset when relevant (for example **Sketch from planar face**).
+- **Add edge** / **Add node** (and similar): a **Shortcuts** line documents TAB / Shift+TAB typing behavior.
+- **Sketch operation** (mirror / revolve axis): mirror, revolve, angle, and clear-axis actions (see [usage-sketch.md](usage-sketch.md#operation-axis-tool)).
 
-**Dimension line width** for those dimensions is in **Settings -> Sketch** (see above).
+**Dimension line width** for length dimensions is in **Settings -> Sketch** (see above).
+
+For **Normal** mode (selection and document **Material** preset), **polar duplicate**, and other non-sketch Options content, see [usage.md](usage.md#user-interface) under **User Interface** (Options Panel).
 
 ## Where settings are stored
 

--- a/usage-sketch.md
+++ b/usage-sketch.md
@@ -516,7 +516,7 @@ The operation axis tool allows you to define a reference line for mirroring and 
 - Alternatively, use the "Clear axis" button in the options panel to manually clear the axis
 
 **Using the Operation Axis:**
-Once an axis is defined, the options panel will show:
+Once an axis is defined, the options panel (under the **Sketch operation** heading) shows:
 
 | | |
 | ---: | --- |

--- a/usage.md
+++ b/usage.md
@@ -55,9 +55,12 @@ EzyCad (Easy CAD) is a CAD application for hobbyist machinists to design and edi
    - [List 3D solids, materials, and display options](#shape-list)
 
 5. **Options Panel**
-   - Adjust tool parameters
-   - Set operation properties
-   - Sketch-related options (for example length dimension placement) are described in **[usage-settings.md](usage-settings.md#options-panel-sketch)**
+   - Adjust tool parameters; related controls are grouped by headings (for example **Sketch options**, **Extrude**, **Selection**, **Material**, **Polar duplicate**), depending on the active tool.
+   - **Normal** mode: **Selection** is the 3D pick filter. **Material** is the document preset for new solids that do not inherit from a clicked shape (for example toolbar **Box**, **polar duplicate** output). **Face extrude** reads the same preset in its Options **Material** row.
+   - To change material on a solid already in the scene, use the [Shape List](#shape-list).
+   - **Chamfer** and **Fillet**: distance and mode only; the result solid keeps the **source shape's material**.
+   - **Move**, **Rotate**, and **Scale**: transform options only (no material row there).
+   - Sketch-related options (snap, length dimension placement, face extrude, shortcuts) are summarized in **[usage-settings.md](usage-settings.md#options-panel-sketch)**.
 
 6. **Log Window**
    - View operation history
@@ -444,11 +447,12 @@ The polar duplicate tool allows you to create multiple copies of selected shapes
 1. <img src="res/icons/Draft_PolarArray.png" alt="Draft_PolarArray" width="20" height="20"> **Activate Polar Duplicate Tool**: Click the icon to enter polar duplicate mode
 2. **Select shape**: Select the shape that you want to duplicate
 3. **Define polar arm**: Move the mouse to see a preview line (polar arm) from the shape center to the mouse cursor. Move to the origin of the operation
-4. **Configure options** in the options panel:
+4. **Configure options** in the options panel (under **Polar duplicate**):
    - **Polar angle**: Set the total angle for the pattern (e.g., 360 deg for full circle, 180 deg for half circle)
    - **Num Elms**: Set the number of duplicate elements to create
    - **Rotate dups**: Checkbox to rotate each duplicate as it's copied (default: enabled)
    - **Combine dups**: Checkbox to combine all duplicates into a single shape (default: enabled)
+   - **Material**: Document preset for solids created when you click **Dup** (same setting as **Normal** mode Options **Material**)
 5. **Create duplicates**: Click the **"Dup"** button in the options panel to create the polar duplicates
 
 **Options explained:**
@@ -459,6 +463,7 @@ The polar duplicate tool allows you to create multiple copies of selected shapes
 | **Num Elms** | The number of duplicate elements to create. The original shape is not counted, so 5 elements means 5 copies plus the original. |
 | **Rotate dups** | When enabled, each duplicate is rotated around its own center as it's positioned. When disabled, duplicates maintain their original orientation. |
 | **Combine dups** | When enabled, all duplicates are fused together into a single shape. When disabled, each duplicate remains a separate shape. |
+| **Material** | Preset for new solids from **Dup**; matches **Normal** mode Options **Material**. Existing shapes: [Shape List](#shape-list). |
 
 **Keyboard shortcuts:**
 


### PR DESCRIPTION
Permanent "+" markers for user-placed sketch nodes (added via the Add Node tool) are now visible whenever a sketch is active in inspection mode or during Shape polar duplicate (which relies on sketch node snapping for the polar arm).

Previously, these nodes were only shown while actively using the Add Node tool (`Sketch_add_node`); they were hidden in `Sketch_inspection_mode` and `Shape_polar_duplicate`.

Changed the visibility condition in `sync_permanent_node_annos_()` from an explicit mode check to `is_sketch_mode(mode) || mode == Mode::Shape_polar_duplicate`.

## Files changed
- `src/sketch.cpp`

## Related
- Enhancement: #102 (Polar duplicate: use sketch-based points/plane when a sketch is available)
- Compare: https://github.com/trailcode/EzyCad/compare/main...Trailcode/ui_improvments2

## Test plan
- [ ] Build in Release.
- [ ] Verify permanent sketch nodes ("+") are visible in Sketch inspection mode.
- [ ] Verify nodes visible during Shape polar duplicate for snapping the polar arm.
- [ ] No regression in other sketch tools or when leaving sketch modes.

## Notes
- Untracked: `third_party/ImGuiColorTextEdit/`