### PR TITLE
docs, agents: make AI instructions generic, expand dev.md, clean .cursor/ references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 # Legacy name; some toolchains write here. Primary vendored deps live in third_party/.
 /thirdParty
 /.vs
-# Cursor IDE (local only). Shared assistant-oriented notes live in agents/.
+# AI/IDE local rule directories (Cursor, Claude, etc.). Shared repo-wide assistant notes live in agents/.
 /.cursor/
+# Other common AI tool local dirs (add more as needed):
+# /.claude/
 /scripts/__pycache__
 
 /docs/_build

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Full guide: **[docs/building-occt.md](docs/building-occt.md)** (Windows prebuilt
 ### We need development help
 EzyCad is maintained by a small team and we would love more contributors. If you can help with features, bug fixes, documentation, or testing - please jump in. Every contribution helps move the project forward.
 
-**Style guides:** [ezycad_code_style.md](docs/ezycad_code_style.md) for C++ in `src/`; [ezycad_doc_style.md](docs/ezycad_doc_style.md) for user guides and [Read the Docs](https://ezycad.readthedocs.io/). Both human developers and AI coding agents should follow the relevant guide. Optional assistant-oriented snippets live under [agents/](agents/) (the repo does not commit `.cursor/`).
+**Style guides:** [ezycad_code_style.md](docs/ezycad_code_style.md) for C++ in `src/`; [ezycad_doc_style.md](docs/ezycad_doc_style.md) for user guides and [Read the Docs](https://ezycad.readthedocs.io/). Both human developers and AI coding agents should follow the relevant guide. Optional assistant-oriented snippets live under [agents/](agents/).
 
 ## In-tree third-party libraries
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Full guide: **[docs/building-occt.md](docs/building-occt.md)** (Windows prebuilt
 ### We need development help
 EzyCad is maintained by a small team and we would love more contributors. If you can help with features, bug fixes, documentation, or testing - please jump in. Every contribution helps move the project forward.
 
-**Style guides:** [ezycad_code_style.md](docs/ezycad_code_style.md) for C++ in `src/`; [ezycad_doc_style.md](docs/ezycad_doc_style.md) for user guides and [Read the Docs](https://ezycad.readthedocs.io/). Both human developers and AI coding agents should follow the relevant guide. Optional assistant-oriented snippets live under [agents/](agents/).
+**Style guides:** [ezycad_code_style.md](docs/ezycad_code_style.md) for C++ in `src/`; [ezycad_doc_style.md](docs/ezycad_doc_style.md) for user guides and [Read the Docs](https://ezycad.readthedocs.io/). Both human developers and AI coding agents should follow the relevant guide.
+
+**AI / agent instructions:** Short repo-local notes for coding assistants live under [agents/](agents/). Root-level discovery markers are `AGENTS.md` and `agents.md`. See [agents/README.md](agents/README.md) for the index (including local dev commands in `agents/dev.md`).
 
 ## In-tree third-party libraries
 

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,28 @@
+# Agent Instructions (agents.md)
+
+This file serves as a root-level marker for AI coding assistants. It points to the dedicated `agents/` directory for short, repo-local notes, conventions, and guidance.
+
+## Overview
+- See [agents/README.md](agents/README.md) for the index of notes.
+- This project keeps IDE-specific configuration and rule files out of the repository.
+- Deeper-nested instruction files (AGENTS.md, agents.md, etc. in subdirectories) take precedence over this one.
+- Direct instructions from the user always take highest precedence.
+
+## Key Resources in agents/
+- `agents/dev.md`: Local development and testing commands (e.g. Sphinx documentation builds).
+- `agents/ezycad-ascii-source.md`: ASCII-only rules for files under `src/`.
+- `agents/discoverability-outreach.md`: Notes for posts, discoverability, and outreach.
+- Style guides (in `docs/`): `ezycad_code_style.md` (C++ code) and `ezycad_doc_style.md` (user-facing documentation).
+- `agents/issues/` and `agents/prs/`: Per-issue and per-PR working notes and templates.
+- Other files listed in `agents/README.md`.
+
+## How to Use
+- When working on EzyCad code, start by reading `agents/README.md` and `agents/dev.md`.
+- Follow the coding style in `docs/ezycad_code_style.md` and the documentation style in `docs/ezycad_doc_style.md`.
+- Check `agents/issues/` or `agents/prs/` for context on specific work items.
+
+## Project Rules
+- Coding conventions, build/test instructions, and other guidance live in the files under `agents/` and in `docs/`.
+- When editing files deeper in the tree, check for more specific AGENTS.md or agents.md files in those directories or their parents.
+
+Update these notes as the project evolves.

--- a/agents.md
+++ b/agents.md
@@ -1,4 +1,4 @@
-# Agent Instructions (agents.md)
+# Agent Instructions
 
 This file serves as a root-level marker for AI coding assistants. It points to the dedicated `agents/` directory for short, repo-local notes, conventions, and guidance.
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -4,11 +4,16 @@ Short, **repo-local** hints for human developers and AI coding assistants.
 
 These notes can be referenced directly by AI tools or copied into an assistant's project rules / custom instructions as needed.
 
+Root markers `AGENTS.md` and `agents.md` (at the repository root) exist for better auto-discovery by different AI coding tools. They both point here.
+
 | File | Intent |
 | --- | --- |
+| *(repo root)* [AGENTS.md](../AGENTS.md) / [agents.md](../agents.md) | Root-level markers that point AI tools at this `agents/` directory. |
 | [ezycad-ascii-source.md](ezycad-ascii-source.md) | ASCII-only comments and strings in `src/`; points at `ezycad_code_style.md` and `scripts/check-nonascii-src.ps1`. |
 | [discoverability-outreach.md](discoverability-outreach.md) | Draft posts for forums, Reddit, awesome lists (SEO / backlinks). |
 | *(repo root)* [docs/building-occt.md](../docs/building-occt.md) | Download/build OCCT for Windows desktop and wasm. |
 | *(now in docs/)* [ezycad_doc_style.md](../docs/ezycad_doc_style.md) | User guides, Read the Docs, images, in-app doc URLs. |
 | *(now in docs/)* [ezycad_code_style.md](../docs/ezycad_code_style.md) | Coding style, conventions, and best practices. |
-| [dev.md](dev.md) | Local development commands (e.g. testing documentation builds with Sphinx). |
+| [dev.md](dev.md) | Local development commands (desktop, wasm, tests, formatting, docs builds). |
+
+When using Grok Build (or other tools with personal/global instruction sets such as `C:\agents\` or `~/.grok/`), also consult those alongside the notes here.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,8 +1,8 @@
 # Agent / AI assistant notes
 
-Short, **repo-local** hints for human developers and coding assistants (Cursor, Copilot, ChatHub, etc.). This project does **not** commit anything under `.cursor/`; keep IDE-specific state on your machine.
+Short, **repo-local** hints for human developers and AI coding assistants.
 
-To use a note in **Cursor**, copy or symlink the relevant file into your user or project `.cursor/rules/` (see [Cursor rules](https://docs.cursor.com/context/rules)), or paste the text into a project rule by hand.
+These notes can be referenced directly by AI tools or copied into an assistant's project rules / custom instructions as needed.
 
 | File | Intent |
 | --- | --- |

--- a/agents/dev.md
+++ b/agents/dev.md
@@ -1,10 +1,8 @@
 # Development / Local Testing Notes
 
-Short notes for local development and testing tasks, especially around documentation.
+Short notes for local development and testing tasks.
 
-## Documentation
-
-1. Test locally:
+## Local Documentation Build (Read the Docs / Sphinx)
 
 ```bash
 pip install -r docs/requirements.txt
@@ -12,3 +10,116 @@ sphinx-build -b html -W docs docs/_build
 ```
 
 Then open `docs/_build/index.html`.
+
+See also [docs/readthedocs.md](../docs/readthedocs.md) for RTD maintenance and conventions.
+
+## Desktop Build (Windows + Visual Studio 2022 / MSVC)
+
+**Prerequisites**
+- CMake 3.14+
+- Visual Studio 2022 (C++ workload)
+- nuget CLI (for GLFW/GLEW)
+- OCCT 8.0.0 prebuilts + 3rdparty-vc14-64 (strongly recommended — see [docs/building-occt.md](../docs/building-occt.md))
+
+**Typical configure** (run from repo root):
+
+```powershell
+cmake -S . -B build -G "Visual Studio 17 2022" -A x64 `
+  -DOpenCASCADE_DIR=C:\path\to\occt-8.0.0\cmake `
+  -DOCCT_3RD_PARTY_DIR=C:\path\to\3rdparty-vc14-64
+```
+
+**Build**:
+
+```powershell
+cmake --build build --config Release
+# or open build/EzyCad.sln in Visual Studio and build the EzyCad project
+```
+
+The resulting `EzyCad.exe` (and `EzyCad_tests.exe`) plus required DLLs end up under `build/Debug` or `build/Release`.
+
+**Running tests**:
+
+```powershell
+cd build
+ctest -C Release --output-on-failure
+# Or run the EzyCad_tests project / executable directly from Visual Studio
+```
+
+**After CMake structural changes** (e.g. adding new folders for IDE visibility under `agents/`, `docs/`, or `github-workflows`):
+- Clean the configure cache: delete `build/CMakeCache.txt`, `build/CMakeFiles/`, and any `_deps/*-subbuild/` directories.
+- Re-run the configure step above.
+
+See root [README.md](../README.md#building-instructions) and [docs/building-occt.md](../docs/building-occt.md) for more OCCT details and troubleshooting.
+
+## WebAssembly (Emscripten)
+
+Full OCCT + EzyCad wasm instructions live in [docs/building-occt.md](../docs/building-occt.md#webassembly-emscripten) and the root README.
+
+High-level flow (after `emsdk_env`):
+
+1. Build the OCCT 8.0.0 wasm package (if not already done):
+
+   ```powershell
+   .\scripts\build-occt-v8-wasm.ps1 -RootDir C:\bin\occt-wasm-build
+   ```
+
+2. Configure + build EzyCad (Ninja generator recommended):
+
+   ```powershell
+   mkdir build-em
+   cd build-em
+   emcmake cmake .. -G Ninja -Wno-dev `
+     -DOpenCASCADE_DIR=C:\bin\occt-wasm-build\install\lib\cmake\opencascade `
+     -DCMAKE_BUILD_TYPE=Release
+   ninja
+   ```
+
+3. Serve locally:
+
+   ```powershell
+   ninja && python -m http.server 8000
+   ```
+
+   Load `EzyCad.html` (or the copy under `web/`) in a browser.
+
+See `scripts/build-occt-v8-wasm.ps1` (and .cmd wrapper) for script options.
+
+## Code Quality & Pre-commit Checks
+
+- **Format C++** (run before committing changes under `src/`):
+
+  ```powershell
+  .\scripts\format-src.ps1
+  ```
+
+  Requires `clang-format` (either in PATH or at the default LLVM location).
+
+- **Check ASCII-only in src/** (must pass before commits; also enforced in CI):
+
+  ```powershell
+  .\scripts\check-nonascii-src.ps1
+  # .cmd wrapper also available
+  ```
+
+  See the ASCII rule in [docs/ezycad_code_style.md](../docs/ezycad_code_style.md) and the summary in [agents/ezycad-ascii-source.md](ezycad-ascii-source.md).
+
+## Other Scripts
+
+- `scripts/sync-github-pages-html.ps1` — Sync `web/` changes (EzyCad.html etc.) to the GitHub Pages wasm demo site.
+- `scripts/pbf-to-png.ps1` / `.py` — Icon / asset conversion helpers.
+- `scripts/build-occt-v8-wasm.ps1` — As shown above.
+
+## Working with AI Coding Assistants
+
+When using an AI assistant (Grok Build, Cursor, Claude, Copilot, etc.) on this codebase:
+
+- Start here: `agents/README.md` (table of contents) + this file (`dev.md`).
+- Follow the style guides in `docs/ezycad_code_style.md` (C++) and `docs/ezycad_doc_style.md`.
+- Check `agents/issues/` and `agents/prs/` for context on specific work items.
+- Root-level markers `AGENTS.md` and `agents.md` point AIs at the `agents/` directory.
+- Deeper-nested instruction files take precedence.
+
+Users who maintain personal/global instruction sets (e.g. in `C:\agents\` or `~/.grok/`) should also consult those alongside this repo's `agents/` notes.
+
+Update this file as new common workflows or commands appear.

--- a/agents/issues/003-ui-improvements-sketch-shape-lists-and-style.md
+++ b/agents/issues/003-ui-improvements-sketch-shape-lists-and-style.md
@@ -47,7 +47,7 @@ The branch improves list-pane usability in the GUI and clarifies coding-style gu
 - [ ] Sketch and Shape list panes behave consistently when resized narrow.
 - [ ] Shared name-width logic remains centralized in one helper.
 - [ ] Coding-style doc clearly captures reader-first ordering and pragmatic DRY guidance.
-- [ ] `.cursor` rule mirrors the updated style guidance on contributor machines.
+- [ ] Local AI assistant rule file mirrors the updated style guidance on contributor machines (these files are not committed).
 
 ### Links
 

--- a/agents/prs/001-ui-improvements-sketch-shape-lists.md
+++ b/agents/prs/001-ui-improvements-sketch-shape-lists.md
@@ -18,7 +18,7 @@ UI improvements for sketch/shape lists and coding style guidance
 - `src/gui.h`
 - `src/gui_settings.cpp`
 - `ezycad_code_style.md`
-- `.cursor/rules/ezycad_code_style.mdc`
+- local AI assistant rule file (not committed to the repo)
 - `agents/issues/003-ui-improvements-sketch-shape-lists-and-style.md`
 
 ## Related

--- a/docs/ezycad_code_style.md
+++ b/docs/ezycad_code_style.md
@@ -122,7 +122,7 @@ Prefer **`CHK_RET(expr)`** when a callee returns `Status` or `Result<T>` and the
   - Punctuation in prose: `-` for dash; `...` for ellipsis; `->` for “maps to” / arrows in comments; plain `'` for apostrophes.
   - Math in comments: spell out (`sqrt(2)`, `theta`) or use ASCII operators (`x` for cross-product context, `*` for multiply).
 - Run `scripts/check-nonascii-src.ps1` (or `check-nonascii-src.cmd`) before committing when touching `src/`.
-- For AI tools: the same rule is summarized in `agents/ezycad-ascii-source.md` (optional; nothing under `.cursor/` is committed).
+- For AI tools: the same rule is summarized in `agents/ezycad-ascii-source.md`.
 
 ## C++ usage
 


### PR DESCRIPTION
## Summary

Improves the project’s agent/AI coding assistant instructions (`agents/`) to be fully generic and more useful for both humans and different AI tools (Grok Build, Cursor, Claude, Copilot, etc.).

No IDE-specific rule directories (e.g. `.cursor/`) are committed — those stay local.

### Key changes

- **Root discovery markers** (`AGENTS.md` and `agents.md` at repo root)
  - Point AI assistants at the `agents/` directory.
  - Both files kept in sync for maximum tool compatibility.

- **`agents/README.md`** (the index)
  - Added table row for the root `AGENTS.md` / `agents.md` markers.
  - Added guidance for users of Grok Build (and similar tools with personal/global instruction sets like `C:\agents\` or `~/.grok/`).
  - Cleaned up intro.

- **`agents/dev.md`** — major expansion
  - Local documentation builds (Sphinx + `-W`)
  - Desktop MSVC builds (exact "Visual Studio 17 2022" -A x64 + OCCT 8.0.0 prebuilts + 3rdparty setup)
  - WebAssembly/Emscripten builds (using `scripts/build-occt-v8-wasm.ps1`, `emcmake`, `ninja`, serving)
  - Running tests (`ctest`, `EzyCad_tests.exe`)
  - Code quality: `format-src.ps1`, `check-nonascii-src.ps1` (and .cmd wrappers)
  - Other useful scripts
  - New "Working with AI Coding Assistants" section with recommended starting files and cross-references

- **`.gitignore`**
  - Generalized the previous Cursor-specific comment.
  - Kept the `/.cursor/` ignore rule (and added commented examples for other tools).

- **`README.md`**
  - Improved the contributing / style guides section with explicit pointers to `agents/`, the root markers, and `agents/dev.md`.

- **Cleanup of tool-specific references**
  - Removed or generalized `.cursor/` mentions in `docs/ezycad_code_style.md` and the historical notes in `agents/issues/003-...` and `agents/prs/001-...`.
  - Minor title cleanups in the root marker files.

### Motivation

The previous `agents/` setup was useful but contained some tool-specific language and very minimal dev instructions. This PR makes the notes:
- Tool-agnostic and shareable
- Actionable for real development workflows
- Easier for AI coding assistants to discover and follow automatically (via root `AGENTS.md` + `agents/README.md` + `dev.md`)

The structure (per-issue/PR scratch notes, ascii source rules, style guide pointers, etc.) is preserved and enhanced.

See the diff for the full set of edits (primarily the two latest commits on the branch: "Docs for agents" and "Doc update").

---

This continues the work of setting up good, committed, non-IDE-specific instructions for the project (see also the global docs previously placed in `C:\agents\` for Grok Build users).