### PR TITLE
Settings: snap guide line width, user-docs sync checklist, LF source endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,29 @@
-# Consistent LF for Markdown (diffs, GitHub, cross-platform editors)
+# Cross-platform line endings: LF in the repository (see docs/ezycad_code_style.md).
+* text=auto
+
+# Markdown
 *.md text eol=lf
+
+# EzyCad-owned source (not third_party)
+src/** text eol=lf
+tests/** text eol=lf
+scripts/** text eol=lf
+cmake/** text eol=lf
+agents/** text eol=lf
+docs/** text eol=lf
+tools/** text eol=lf
+.github/** text eol=lf
+web/** text eol=lf
+res/scripts/** text eol=lf
+
+CMakeLists.txt text eol=lf
+.clang-format text eol=lf
+.gitattributes text eol=lf
+
+# Binary assets (override path-based text rules above)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary

--- a/agents/README.md
+++ b/agents/README.md
@@ -10,6 +10,7 @@ Root markers `AGENTS.md` and `agents.md` (at the repository root) exist for bett
 | --- | --- |
 | *(repo root)* [AGENTS.md](../AGENTS.md) / [agents.md](../agents.md) | Root-level markers that point AI tools at this `agents/` directory. |
 | [ezycad-ascii-source.md](ezycad-ascii-source.md) | ASCII-only comments and strings in `src/`; points at `ezycad_code_style.md` and `scripts/check-nonascii-src.ps1`. |
+| [user-docs-sync.md](user-docs-sync.md) | When user-visible features are added or changed, which `docs/` files and JSON tables to update (Settings, Options, CHANGELOG). |
 | [discoverability-outreach.md](discoverability-outreach.md) | Draft posts for forums, Reddit, awesome lists (SEO / backlinks). |
 | *(repo root)* [docs/building-occt.md](../docs/building-occt.md) | Download/build OCCT for Windows desktop and wasm. |
 | *(now in docs/)* [ezycad_doc_style.md](../docs/ezycad_doc_style.md) | User guides, Read the Docs, images, in-app doc URLs. |

--- a/agents/dev.md
+++ b/agents/dev.md
@@ -116,6 +116,7 @@ When using an AI assistant (Grok Build, Cursor, Claude, Copilot, etc.) on this c
 
 - Start here: `agents/README.md` (table of contents) + this file (`dev.md`).
 - Follow the style guides in `docs/ezycad_code_style.md` (C++) and `docs/ezycad_doc_style.md`.
+- When you add or change user-visible functionality (UI, settings, workflows, shortcuts, persisted keys), sync user docs per [user-docs-sync.md](user-docs-sync.md) (same branch/PR as the code).
 - Check `agents/issues/` and `agents/prs/` for context on specific work items.
 - Root-level markers `AGENTS.md` and `agents.md` point AIs at the `agents/` directory.
 - Deeper-nested instruction files take precedence.

--- a/agents/ezycad-ascii-source.md
+++ b/agents/ezycad-ascii-source.md
@@ -4,4 +4,4 @@ Use this as a **Cursor rule** or paste into your assistant context when editing 
 
 In `src/`, keep **comments and string literals 7-bit ASCII** (no Unicode punctuation or symbols: smart quotes, en/em dashes, arrows, ellipsis, etc.). Use ASCII equivalents (`-`, `...`, `->`, `sqrt(2)`, plain `'`).
 
-Project style: `ezycad_code_style.md` (section **Source encoding**). Verify with `scripts/check-nonascii-src.ps1` or `scripts/check-nonascii-src.cmd`.
+Project style: `ezycad_code_style.md` (sections **Formatting** / line endings and **Source encoding**). Verify with `scripts/check-nonascii-src.ps1` or `scripts/check-nonascii-src.cmd`.

--- a/agents/user-docs-sync.md
+++ b/agents/user-docs-sync.md
@@ -1,0 +1,54 @@
+# User-facing documentation sync
+
+Use this when you add or change **user-visible** behavior (UI, settings, shortcuts, sketch/shape workflows, persisted JSON keys).
+
+Style rules live in **[docs/ezycad_doc_style.md](../docs/ezycad_doc_style.md)**. This file is the **what to update** checklist for agents and contributors.
+
+## When to update docs
+
+Update user docs in the **same PR / branch** as the code when you **add or change** anything that affects:
+
+- **Settings pane** or **Options** panel controls
+- **Persisted keys** in `ezycad_settings.json` (`gui.*`, `occt_view.*`)
+- **Sketch / shape / view** workflows users see in the app
+- **Keyboard shortcuts**, tooltips, or Help links
+- **Scripting** surface (`ezy.occt_view_settings_json()`, etc.)
+
+Skip user-guide updates for internal-only refactors (PIMPL, naming, line endings in `src/`, etc.) unless behavior or saved data changes.
+
+## Files to check
+
+| Change type | Primary docs |
+| --- | --- |
+| New/changed **Settings** or **Options** | `docs/usage-settings.md` (pane list, Options section, **`gui` / `occt_view` JSON tables**) |
+| Sketch tools, snap, dimensions | `docs/usage-sketch.md`; cross-links from `usage-settings.md` |
+| 3D view, grid, navigation | `docs/usage-occt-view.md`, `docs/usage.md` (view sections) |
+| General UI, lists, modes | `docs/usage.md` |
+| Lua / Python / settings JSON API | `docs/scripting.md` |
+| Build / OCCT / wasm | `docs/building-occt.md` |
+| Notable user-facing fix or feature | `CHANGELOG.md` under `[Unreleased]` |
+
+## Minimum checklist (settings / preferences)
+
+When adding or renaming a **Settings -> Sketch** (or other pane) control:
+
+- [ ] **Settings pane** bullet list matches on-screen labels and ranges
+- [ ] **Options** section updated if the same control appears live in **View -> Options**
+- [ ] **`gui` JSON reference table** in `usage-settings.md` lists every new/changed key (type, range, default)
+- [ ] Cross-link from the feature guide (e.g. `usage-sketch.md#sketch-snapping`) if users need context
+- [ ] `CHANGELOG.md` `[Unreleased]` entry when the change is user-visible
+- [ ] Optional: `agents/issues/` or `agents/prs/` draft lists doc files in **Test plan** / **Files touched**
+
+## Verify
+
+```bash
+pip install -r docs/requirements.txt
+sphinx-build -b html -W docs docs/_build
+```
+
+Or rely on CI [`.github/workflows/docs.yml`](../.github/workflows/docs.yml).
+
+## Related
+
+- Issue draft example with doc acceptance criteria: `agents/issues/006-sketch-snap-unification-and-docs.md`
+- Local doc build: `agents/dev.md`

--- a/docs/ezycad_code_style.md
+++ b/docs/ezycad_code_style.md
@@ -24,6 +24,15 @@ Use this style when editing or adding C/C++ code in the EzyCad project (files un
 
 ## Formatting
 
+### Line endings
+
+- Use **LF** (`\n`) for all EzyCad-owned text files: `src/`, `tests/`, `scripts/`, `cmake/`, `docs/`, `agents/`, and other project paths listed in **`.gitattributes`**.
+- Do **not** mix CRLF and LF in the same file; mixed endings trigger editor warnings and noisy diffs.
+- **`third_party/`** is vendored upstream code and is not normalized by this rule.
+- On Windows, configure your editor to **LF** for C++ (Visual Studio: *File → Advanced Save Options*, or normalize when prompted). In this repo, run `git config core.autocrlf false` so Git does not reintroduce CRLF on checkout. Git applies the rules in `.gitattributes` on commit.
+
+### clang-format
+
 Run **`scripts/format-src.ps1`** (or `clang-format -i` on individual files) before committing C++ changes. **`.clang-format`** at the repo root is the source of truth; the settings below match that file. Anything not listed inherits **`BasedOnStyle: LLVM`** (e.g. spaces not tabs, short loops not collapsed to one line).
 
 - **`BasedOnStyle: LLVM`** — Start from the LLVM preset; only the options below override it.

--- a/docs/ezycad_doc_style.md
+++ b/docs/ezycad_doc_style.md
@@ -71,3 +71,4 @@ sphinx-build -b html -W docs docs/_build
 
 - **[ezycad_code_style.md](ezycad_code_style.md)** — C++ style, versioning (`version.h`, `CHANGELOG.md`).
 - **[readthedocs.md](readthedocs.md)** — RTD integrations, webhooks, PR previews, local build instructions.
+- **[../agents/user-docs-sync.md](../agents/user-docs-sync.md)** — Checklist for which user guides and JSON tables to update when features change (for agents and contributors).

--- a/docs/usage-settings.md
+++ b/docs/usage-settings.md
@@ -58,7 +58,7 @@ Between those, the pane has **six** collapsible sections. Expand a section to se
    - **Arrow style** — *Standard*, *Sharp*, *Wide*, or *3D shaded*
    - **Arrow orientation** — *Automatic*, *Internal*, or *External*
    - **Show sketch dimensions** — global on/off for length dimensions on all sketches (tool mode may still limit which sketch shows dims when on)
-   - **Permanent node annotation size**, **Underlay highlight color**, **Snap guide color**, **Snap guide mode** (directly under **Sketch**, not inside **Dimensions**)
+   - **Permanent node annotation size**, **Underlay highlight color**, **Snap guide color**, **Snap guide line width** (slider **0.5** to **8.0**; default **1.0**), **Snap guide mode**, **All co-axial nodes** (directly under **Sketch**, not inside **Dimensions**)
 
 6. **Startup project** — **Desktop only:** **Load last opened on startup** (checkbox, with `(?)`), then **Last opened path:** … or **(No path saved yet.)** Then **Save current as startup project**, **Clear saved startup** (with `(?)`). **WebAssembly:** no load-last row; only the two buttons and `(?)`. See [Startup project](#startup-project).
 
@@ -90,7 +90,7 @@ For other non-sketch Options content (for example **Polar duplicate**), see [usa
 
 Sketch-related preferences are edited in the **Options** panel while you use a sketch tool, not in the **Settings** pane:
 
-- **Sketch options** (all sketch tools): **Snap dist** and **Snap guide mode** (*Traditional*, *Fullscreen*, *Both*). A checkbox **All co-axial nodes** enables global mode (when on): axis guide lines + markers for *all* nodes in the current and other visible sketches (full co-axial grid). Off = classic closest-per-axis only. See [How sketch snap works](usage-sketch.md#sketch-snapping) in the sketch guide (axis guides, vertex lock, cross-sketch targets). Snap guide color and mode are also in **Settings -> Sketch**.
+- **Sketch options** (all sketch tools): **Snap dist**, **Snap guide mode** (*Traditional*, *Fullscreen*, *Both*), and **All co-axial nodes** (global co-axial grid vs closest-per-axis only). See [How sketch snap works](usage-sketch.md#sketch-snapping). **Snap guide color**, **Snap guide line width**, **Snap guide mode**, and **All co-axial nodes** are also in **Settings -> Sketch** (persisted in `gui.*` keys below).
 - **Extrude sketch face**: under **Extrude**, **Both sides** and **Material** for the new solid (same document preset as **Normal** mode Options **Material**). Other modes that still show **Material** in Options use that same preset when relevant (for example **Sketch from planar face**).
 - **Add edge** / **Add node** (and similar): a **Shortcuts** line documents TAB / Shift+TAB typing behavior.
 - **Sketch operation** (mirror / revolve axis): mirror, revolve, angle, and clear-axis actions (see [usage-sketch.md](usage-sketch.md#operation-axis-tool)).
@@ -169,6 +169,11 @@ String: ImGui `.ini` text for window positions and docking saved with **SaveIniS
 | `edge_dim_arrow_style` | integer | **0** standard, **1** sharp, **2** wide, **3** 3D shaded. |
 | `edge_dim_arrow_orientation` | integer | **0** automatic, **1** internal, **2** external. |
 | `show_sketch_dimensions` | boolean | When false, hides length dimensions on all sketches. |
+| `permanent_node_anno_scale` | number | Scale for permanent **+** node markers in sketch mode (**0.25** to **3.0**; default **1.0**). |
+| `snap_guide_color` | array of 3 numbers | RGB for sketch snap guides and markers (float **0** to **1** per channel; default green **0**, **1**, **0**). |
+| `snap_guide_mode` | integer | **0** *Traditional* (local markers), **1** *Fullscreen* (view-spanning axis lines), **2** *Both* (default **0**). |
+| `snap_guide_line_width` | number | Open CASCADE line width for snap guides (axis lines, markers, co-axial overlay; **0.5** to **8.0**; default **1.0**). |
+| `annotate_all_coaxial_nodes` | boolean | When true, show axis guides and markers for *all* co-axial nodes (current sketch plus other visible sketches). When false (default), only the closest node per active axis is annotated. Also in sketch **Options**. |
 | `imgui_rounding_general` | number | Window/child/frame/popup rounding (**0** to **32** clamped in code; sliders stop at 16 in the UI). |
 | `imgui_rounding_scroll` | number | Scrollbar and grab rounding (same clamp). |
 | `imgui_rounding_tabs` | number | Tab rounding (same clamp). |
@@ -178,7 +183,7 @@ String: ImGui `.ini` text for window positions and docking saved with **SaveIniS
 | `load_last_opened_on_startup` | boolean | Desktop: open the last `.ezy` on launch. **Legacy:** `load_last_saved_on_startup` is read as a fallback if the newer key is absent. |
 | `last_opened_project_path` | string | Path of the last opened project for the option above. **Legacy:** `last_saved_project_path` is accepted if the newer key is missing. |
 
-Scripting API **`ezy.occt_view_settings_json()`** returns a JSON string with **`occt_view`** plus selected **`gui`** keys (including dimension keys above, **`gui.inspection_orthographic`**, **`gui.view_roll_step_deg`**, **`gui.view_zoom_scroll_scale`** when saved). See [scripting.md](scripting.md).
+Scripting API **`ezy.occt_view_settings_json()`** returns a JSON string with **`occt_view`** plus selected **`gui`** keys (including dimension and snap keys above, **`gui.permanent_node_anno_scale`**, **`gui.inspection_orthographic`**, **`gui.view_roll_step_deg`**, **`gui.view_zoom_scroll_scale`** when saved). See [scripting.md](scripting.md).
 
 ---
 

--- a/docs/usage-sketch.md
+++ b/docs/usage-sketch.md
@@ -37,7 +37,7 @@ This guide covers all 2D sketching tools and operations in EzyCad. For the main 
 
 ## Sketch snapping
 
-While you draw or place points in sketch mode, EzyCad helps you align to existing geometry. **Snap dist** and **Snap guide mode** are in the Options panel; guide color is in **Settings -> Sketch** (see [usage-settings.md](usage-settings.md#sketch-tools)).
+While you draw or place points in sketch mode, EzyCad helps you align to existing geometry. **Snap dist**, **Snap guide mode**, and **All co-axial nodes** are in the Options panel; **Snap guide color**, **Snap guide line width**, and the same mode/co-axial toggles are in **Settings -> Sketch** (see [usage-settings.md](usage-settings.md#sketch-tools)).
 
 | | |
 | ---: | --- |

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -75,6 +75,7 @@ std::string GUI::occt_view_settings_json() const
          return nlohmann::json::array({r, g, b});
        }()},
       {"snap_guide_mode", static_cast<int>(Sketch_nodes::get_snap_guide_mode())},
+      {"snap_guide_line_width", Sketch_nodes::get_snap_guide_line_width()},
       {"annotate_all_coaxial_nodes", Sketch_nodes::get_annotate_all_coaxial_nodes()},
       {"ui_verbosity", m_ui_verbosity},
   };
@@ -134,6 +135,7 @@ void GUI::save_occt_view_settings()
          return nlohmann::json::array({r, g, b});
        }()},
       {"snap_guide_mode", static_cast<int>(Sketch_nodes::get_snap_guide_mode())},
+      {"snap_guide_line_width", Sketch_nodes::get_snap_guide_line_width()},
       {"annotate_all_coaxial_nodes", Sketch_nodes::get_annotate_all_coaxial_nodes()},
 #ifndef NDEBUG
       {"show_dbg", m_show_dbg},
@@ -377,6 +379,10 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
           mode <= static_cast<int>(Sketch_nodes::Snap_guide_mode::Both))
         Sketch_nodes::set_snap_guide_mode(static_cast<Sketch_nodes::Snap_guide_mode>(mode));
     }
+
+    Sketch_nodes::set_snap_guide_line_width(1.0f);
+    if (g.contains("snap_guide_line_width") && g["snap_guide_line_width"].is_number())
+      Sketch_nodes::set_snap_guide_line_width(g["snap_guide_line_width"].get<float>());
 
     Sketch_nodes::set_annotate_all_coaxial_nodes(false);
     if (g.contains("annotate_all_coaxial_nodes") && g["annotate_all_coaxial_nodes"].is_boolean())
@@ -1152,6 +1158,33 @@ void GUI::settings_()
             ImGui::BeginTooltip();
             ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
             ImGui::TextDisabled("Color used by fullscreen snap guides and snap markers in sketch mode.");
+            ImGui::PopTextWrapPos();
+            ImGui::EndTooltip();
+          }
+        }
+      }
+
+      ImGui::TableNextRow();
+      ImGui::TableSetColumnIndex(0);
+      ImGui::AlignTextToFramePadding();
+      ImGui::TextUnformatted("Snap guide line width");
+      ImGui::TableSetColumnIndex(1);
+      {
+        float line_width = Sketch_nodes::get_snap_guide_line_width();
+        if (ImGui::SliderFloat("##snap_guide_line_width", &line_width, 0.5f, 8.0f, "%.2f"))
+        {
+          Sketch_nodes::set_snap_guide_line_width(line_width);
+          save_occt_view_settings();
+        }
+        if (ui_show_help(2))
+        {
+          ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+          ImGui::TextDisabled("(?)");
+          if (ImGui::IsItemHovered())
+          {
+            ImGui::BeginTooltip();
+            ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
+            ImGui::TextDisabled("Line width for sketch snap guides (axis lines, markers, and co-axial overlay).");
             ImGui::PopTextWrapPos();
             ImGui::EndTooltip();
           }

--- a/src/sketch_nodes.cpp
+++ b/src/sketch_nodes.cpp
@@ -17,9 +17,10 @@
 
 namespace
 {
-double                        s_snap_dist_pixels = 35.0;
-Sketch_nodes::Snap_guide_mode s_snap_guide_mode  = Sketch_nodes::Snap_guide_mode::Traditional;
-glm::vec3                     s_snap_guide_color{0.0f, 1.0f, 0.0f};
+double                        s_snap_dist_pixels         = 35.0;
+Sketch_nodes::Snap_guide_mode s_snap_guide_mode          = Sketch_nodes::Snap_guide_mode::Traditional;
+glm::vec3                     s_snap_guide_color         {0.0f, 1.0f, 0.0f};
+float                         s_snap_guide_line_width    = 1.0f;
 bool                          s_annotate_all_coaxial_nodes = false;
 } // namespace
 
@@ -313,17 +314,17 @@ void Sketch_nodes::Impl::update_node_snap_anno_(const gp_Pnt2d& pt, const double
   else
     anno_shape = traditional_shape;
 
-  const glm::vec3& c = s_snap_guide_color;
   if (m_snap_anno.IsNull())
   {
     m_snap_anno = new AIS_Shape(anno_shape);
-    m_snap_anno->SetWidth(3.0);
-    m_snap_anno->SetColor(Quantity_Color(c.x, c.y, c.z, Quantity_TOC_RGB));
+    m_snap_anno->SetWidth(s_snap_guide_line_width);
+    m_snap_anno->SetColor(Quantity_Color(s_snap_guide_color.x, s_snap_guide_color.y, s_snap_guide_color.z, Quantity_TOC_RGB));
     m_ctx.Display(m_snap_anno, true);
   }
   else
   {
     m_snap_anno->Set(anno_shape);
+    m_snap_anno->SetWidth(s_snap_guide_line_width);
     m_ctx.Redisplay(m_snap_anno, true);
   }
 }
@@ -378,17 +379,18 @@ void Sketch_nodes::Impl::update_axis_snap_anno_(int axis_index, const std::vecto
 
   TopoDS_Shape anno_shape = comp;
 
-  const glm::vec3& c = s_snap_guide_color;
   if (m_snap_anno_axis[axis_index].IsNull())
   {
     m_snap_anno_axis[axis_index] = new AIS_Shape(anno_shape);
-    m_snap_anno_axis[axis_index]->SetWidth(1.0);
-    m_snap_anno_axis[axis_index]->SetColor(Quantity_Color(c.x, c.y, c.z, Quantity_TOC_RGB));
+    m_snap_anno_axis[axis_index]->SetWidth(s_snap_guide_line_width);
+    m_snap_anno_axis[axis_index]->SetColor(
+        Quantity_Color(s_snap_guide_color.x, s_snap_guide_color.y, s_snap_guide_color.z, Quantity_TOC_RGB));
     m_ctx.Display(m_snap_anno_axis[axis_index], true);
   }
   else
   {
     m_snap_anno_axis[axis_index]->Set(anno_shape);
+    m_snap_anno_axis[axis_index]->SetWidth(s_snap_guide_line_width);
     m_ctx.Redisplay(m_snap_anno_axis[axis_index], true);
   }
 }
@@ -489,17 +491,18 @@ void Sketch_nodes::Impl::update_global_coaxial_annotations_(double snap_dist)
     builder.Add(comp, small);
   }
 
-  const glm::vec3& c = s_snap_guide_color;
   if (m_global_coax_anno.IsNull())
   {
     m_global_coax_anno = new AIS_Shape(comp);
-    m_global_coax_anno->SetWidth(1.0);
-    m_global_coax_anno->SetColor(Quantity_Color(c.x, c.y, c.z, Quantity_TOC_RGB));
+    m_global_coax_anno->SetWidth(s_snap_guide_line_width);
+    m_global_coax_anno->SetColor(
+        Quantity_Color(s_snap_guide_color.x, s_snap_guide_color.y, s_snap_guide_color.z, Quantity_TOC_RGB));
     m_ctx.Display(m_global_coax_anno, true);
   }
   else
   {
     m_global_coax_anno->Set(comp);
+    m_global_coax_anno->SetWidth(s_snap_guide_line_width);
     m_ctx.Redisplay(m_global_coax_anno, true);
   }
 }
@@ -812,6 +815,10 @@ void Sketch_nodes::get_snap_guide_color(float& r, float& g, float& b)
   g = s_snap_guide_color.y;
   b = s_snap_guide_color.z;
 }
+
+void Sketch_nodes::set_snap_guide_line_width(float width) { s_snap_guide_line_width = std::clamp(width, 0.5f, 8.0f); }
+
+float Sketch_nodes::get_snap_guide_line_width() { return s_snap_guide_line_width; }
 
 void Sketch_nodes::set_annotate_all_coaxial_nodes(bool enable) { s_annotate_all_coaxial_nodes = enable; }
 

--- a/src/sketch_nodes.h
+++ b/src/sketch_nodes.h
@@ -74,6 +74,8 @@ public:
   static Snap_guide_mode get_snap_guide_mode();
   static void            set_snap_guide_color(float r, float g, float b);
   static void            get_snap_guide_color(float& r, float& g, float& b);
+  static void            set_snap_guide_line_width(float width);
+  static float           get_snap_guide_line_width();
 
   // When true, axis snap annotations (small markers) are shown for *all* nodes sharing the
   // same X or Y (within snap tolerance) in the current sketch (and outside points from other


### PR DESCRIPTION
## Summary

Adds **Snap guide line width** in Settings, completes user-guide coverage for snap-related `gui` JSON keys, introduces an **agent doc-sync checklist**, and standardizes **LF** line endings for project-owned source.

Closes #126.

## Changes

### Snap guide line width

- **`gui.snap_guide_line_width`** (default **1.0**, range **0.5**–**8.0**) in **Settings → Sketch**.
- Drives OCCT `SetWidth` for snap axis guides, markers, and co-axial overlay.
- Persisted in `ezycad_settings.json`; applied on create and redisplay.

### User documentation

- `docs/usage-settings.md` — Settings pane list, Options cross-links, **`gui` JSON table** (`snap_guide_*`, `annotate_all_coaxial_nodes`, `permanent_node_anno_scale`).
- `docs/usage-sketch.md` — sketch snapping intro updated for line width.

### Agent / contributor workflow

- `agents/user-docs-sync.md` — checklist for syncing user docs when adding or changing user-visible functionality.
- Linked from `agents/README.md`, `agents/dev.md`, `docs/ezycad_doc_style.md`.

### Line endings

- `.gitattributes` — LF for `src/`, `tests/`, `scripts/`, `docs/`, etc.; binary overrides for images.
- `docs/ezycad_code_style.md` — line-ending convention documented.

## Commits

| Commit | Description |
| --- | --- |
| `facc82e` | Snap guide line width setting + user guide JSON/docs |
| `7b88b9f` | Agent user-docs-sync checklist + LF gitattributes |

## Test plan

- [x] Build `EzyCad_lib` in Release.
- [x] **Settings → Sketch → Snap guide line width** — guides thicken/thin on next snap.
- [x] Restart app — width persists.
- [x] `usage-settings.md` JSON table matches `gui` keys in saved settings.
- [x] `sphinx-build -b html -W docs docs/_build` passes.

## Compare

https://github.com/trailcode/EzyCad/compare/main...Trailcode/settings