### PR TITLE
docs: document underlay calibration limitations, shear handling, raw mode, and UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Sketch underlay
+
+- When an image underlay has shear from edge calibration ("Set X from edge..." or "Set Y from edge..."), the **Transform** section in Sketch properties now provides a full 6-DOF editor: Base X/Y (bitmap 0,0 origin) + direct Ux/Uy and Vx/Vy vector components. Derived U/V lengths and the angle between them are displayed live. Edits apply immediately with undo support.
+- A **Make orthogonal (keep lengths + U direction)** button projects the V vector to be perpendicular while preserving magnitudes and orientation sign; after use the familiar Center / Half width/height / Rotation sliders return.
+- The original orthogonal sliders remain for the common (non-sheared) case. The cyan underlay frame continues to show the true (possibly sheared) parallelogram extent.
+- Addresses the long-standing limitation noted in docs/bugs.md and usage-sketch.md. The raw basis editor lets users fine-tune or correct after calibration without losing the affine fit.
+
 ### Sketch / 2D Topology
 
+- Image underlays now render with a thin cyan bounding parallelogram (frame) around the full image region in the sketch plane. This makes newly added or low-contrast underlays (heavy white-key transparency, faint scans, dark view backgrounds) easy to locate and see their exact extent. The frame follows the current affine placement (including non-orthogonal after edge calibration) and is drawn for every visible underlay.
 - Documented the automatic splitting of linear edges when they intersect other edges (the core user-visible topology behavior). When a new straight edge crosses or touches the interior of an existing straight edge, or when its endpoint snaps to an existing midpoint, the intersected edge(s) are split at the intersection and the new edge is subdivided as needed. This enables T-junctions, clean crossings (4 edges), and divided faces (e.g. square + exact mid vertical produces two rectangles) without any manual steps. See the new table row "Automatic splitting on edge intersections" and the Tips under [Sketch snapping](docs/usage-sketch.md#sketch-snapping) in the user guide.
 - Added/expanded unit tests for the above (mid vertical splitter in both orders + full GUI draw-direction cases for the splitter; bridge + hole reproduction from user `bridge.ezy`).
 - An internal rewrite attempt to reduce order/draw-direction sensitivity (angular sorting of adjacency, always-normalize instead of the orientation filter, etc.) was reverted after it was found to hang in some sketches. The new user documentation above reflects the stable current behavior (no internal dev details are exposed to users).

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -9,7 +9,12 @@
 * Create sketch from face needs a temporary face select mode. When mode is changed it should go back to the previous mode. Other tools like chamfer need to do this also.
 * Add sketch node should have the ability to allow the user to specify placement distance from another node.
 * Ability to show/hide sketch nodes
-* Underlay: edge calibration can introduce shear (non-orthogonal bitmap axes). The transform panel currently assumes center + half extents + rotation (orthogonal). Need a full six-parameter affine in the UI so users can adjust position, scale, rotation, and shear without losing calibration.
+* Underlay calibration ("Set X from edge..." / "Set Y from edge...") can (and frequently does) introduce shear because the picks are measured against the basis present at click time. Full affine support exists (6-DOF editor + raw distortion toggle + per-axis flips for corner mapping), and both axes now auto-apply "Make orthogonal (keep lengths + U)" on completion. The "Define underlay datum..." tool that forced a clean perpendicular V has been removed. Rough edges that remain:
+  - The raw 6-DOF editor exposes low-level numbers (Base + U/V) rather than higher-level controls (e.g. a direct shear-angle slider).
+  - In raw mode you sometimes need the "Reverse image U/V" flips to get source (0,0) at the exact parallelogram corner you expect (due to OCCT face parametrization on sheared quads created from a wire).
+  - The two render paths (default "preserve" resampling vs. raw/direct) have deliberately different visual results for the same affine; this can be surprising until you understand the toggle.
+  - Calibration always affects the *entire* source image; there is no built-in crop/region-of-interest inside the underlay itself.
+  - The cyan frame always shows the precise current full-image parallelogram (never a simple rectangle once shear exists).
 
 * For selection mode, not all of the current modes are useful.
 * Scale mode broken.

--- a/docs/usage-sketch.md
+++ b/docs/usage-sketch.md
@@ -919,10 +919,28 @@ Import a reference image (PNG, JPEG, or BMP) behind a sketch for tracing or alig
 | --- | --- |
 | **Set X from edge...** | Two clicks along bitmap width (+U), then enter the real drawing distance (same units as sketch dimensions) |
 | **Set Y from edge...** | Two clicks along bitmap height (+V), then enter the drawing distance for Y |
-| **Define underlay datum...** | Two picks on the sketch plane: corner **(0,0)**, then direction along +U (keeps current half width and height) |
 
-After edge calibration, bitmap axes may be non-orthogonal (shear). The **Transform** sliders (**Center X/Y**, **Half width/height**, **Rotation**) then stay disabled so they do not overwrite that affine fit; use calibration picks or adjust before shear is introduced.
+After edge calibration, bitmap axes may be non-orthogonal (shear). In that case the **Transform** section switches to a 6-DOF affine editor instead of the sliders:
 
-**Transform** (orthogonal underlay only): sliders and **Rotation value** adjust center, half extents, and rotation on the sketch plane; changes apply in real time and support undo.
+- **Base X / Base Y** — location of the bitmap corner (0,0) in sketch-plane coordinates.
+- **U X / U Y** and **V X / V Y** — the two edge vectors defining the image parallelogram (+U is width direction, +V height). Their lengths and the angle between them are shown below the inputs for reference.
+- When shear is present, a checkbox **"Show raw shear distortion in image"** appears. Turn it on to make calibration mistakes (such as an incorrect Y-axis pick) visible directly as skew and distortion in the raster image pixels themselves. This complements the cyan bounds, which always show the exact current parallelogram. The default (off) uses special resampling so the source image content looks clean relative to your U/V axes.
+- Two additional checkboxes (**Reverse image U** / **Reverse image V**) appear in raw mode. These flip the source raster data so that raster (0,0) lands at the corner of the parallelogram you expect. They exist because exact texture UV ordering on a sheared OCCT face created from a wire can vary.
+
+**Auto-orthogonal after calibration**: once you have successfully set *both* X and Y (via the edge tools), the system automatically applies the equivalent of "Make orthogonal (keep lengths + U direction)". This forces V perpendicular to U while preserving the two calibrated lengths, so the friendly sliders usually become available again. You can still re-introduce shear manually in the 6-DOF editor or via the button.
+
+**Transform** (orthogonal underlay): sliders and **Rotation value** adjust center, half extents, and rotation on the sketch plane; changes apply in real time and support undo. When shear is present the sliders are replaced by the raw basis editor above so the calibrated fit is not lost.
+
+**Known limitations with image underlays** (as of the current version):
+- "Set X from edge..." and "Set Y from edge..." measure along the *current* basis at the time of the pick. If the two features you pick are not perfectly perpendicular in the source image (or your clicks are slightly off), the resulting U and V will not be orthogonal. This is supported (full affine), but it disables the simple sliders and can make the image content appear skewed until you use the raw editor or the Make orthogonal button.
+- The "Define underlay datum..." tool (which forced a clean perpendicular V) has been removed.
+- The entire source image (including margins, title block, etc.) is always mapped to the current parallelogram. If you only care about part of the image you may need to pre-crop the file.
+- In raw shear mode the visible textured region follows the exact parallelogram (cyan frame), but achieving pixel-precise "raster (0,0) at this exact corner" can require the Reverse U/V flips because of how OCCT parametrizes faces created from a general wire.
+- The two renderer paths (default "preserve" vs. raw) produce visibly different results for the same affine. The preserve path counteracts texture shear for a cleaner look; raw lets the affine act directly on the pixels (deliberately for calibration debugging).
+- The cyan frame is always the exact geometric bounds of the full mapped source image. It is *not* a crop rectangle.
+
+Changes apply live and support undo. A **Make orthogonal (keep lengths + U direction)** button (and the automatic version after both axes are set) projects V to be perpendicular to U (preserving lengths and winding) and returns you to the friendly Center / Half / Rotation sliders.
 
 Default underlay highlight tint for new imports: **Settings -> Sketch -> Underlay highlight color** (see [usage-settings.md](usage-settings.md#settings-pane)).
+
+A thin cyan frame (parallelogram when the underlay has been calibrated with shear) is always rendered around the exact bounds of each visible image underlay. This makes the placement and extent clear for new imports and in cases where most of the bitmap content keys to transparent.

--- a/res/scripts/python/sierpinski.py
+++ b/res/scripts/python/sierpinski.py
@@ -1,0 +1,95 @@
+# Sierpinski triangle sketch generator for EzyCad Python console.
+# Just for fun!
+#
+# Usage (after opening Python console, or it runs on load):
+#   create_sierpinski(order=3, size=20.0)
+#
+# It will log the unique nodes and the line segments (as pairs of points).
+# You can then:
+#   1. Create a new sketch in the UI (or use ezy.set_mode("Sketch_add_edge") etc.)
+#   2. Use the logged coordinates to add nodes/edges manually, or copy into
+#      a small loop if more Python bindings for sketch creation are added later.
+#
+# The recursion draws the standard Sierpinski gasket lines (connect midpoints
+# recursively, resulting in 3**order small upward triangles' boundaries).
+
+def _mid(a, b):
+    return ((a[0] + b[0]) / 2.0, (a[1] + b[1]) / 2.0)
+
+def _sierpinski_lines(order, p1, p2, p3, lines):
+    """Recursively append line segments (as (pA, pB) tuples) for the gasket."""
+    if order <= 0:
+        lines.append((p1, p2))
+        lines.append((p2, p3))
+        lines.append((p3, p1))
+        return
+    m12 = _mid(p1, p2)
+    m23 = _mid(p2, p3)
+    m31 = _mid(p3, p1)
+    _sierpinski_lines(order - 1, p1, m12, m31, lines)
+    _sierpinski_lines(order - 1, p2, m23, m12, lines)
+    _sierpinski_lines(order - 1, p3, m31, m23, lines)
+
+def create_sierpinski(order=3, size=20.0, center=(0.0, 0.0)):
+    """Generate and log a Sierpinski triangle of given fractal order and size.
+    Logs all unique nodes (sorted) and all line segments.
+    The triangle is equilateral pointing up, centered at the given (cx, cy).
+    """
+    cx, cy = center
+    h = size * (3.0 ** 0.5) / 2.0
+    # Base centered at (cx, cy - h/3) so centroid is at center
+    p1 = (cx - size / 2.0, cy - h / 3.0)
+    p2 = (cx + size / 2.0, cy - h / 3.0)
+    p3 = (cx, cy + 2.0 * h / 3.0)
+
+    lines = []
+    _sierpinski_lines(order, p1, p2, p3, lines)
+
+    # Dedup lines (though recursion shouldn't duplicate)
+    seen = set()
+    unique_lines = []
+    for a, b in lines:
+        key = (tuple(sorted([a, b])))
+        if key not in seen:
+            seen.add(key)
+            unique_lines.append((a, b))
+
+    # Collect unique nodes
+    nodes = {}
+    for a, b in unique_lines:
+        nodes[a] = True
+        nodes[b] = True
+    node_list = sorted(nodes.keys(), key=lambda p: (p[1], p[0]))  # bottom to top, left to right
+
+    ezy.log(f"Sierpinski triangle: order={order}, size={size}, center={center}")
+    ezy.log(f"  unique nodes: {len(node_list)}")
+    for i, (x, y) in enumerate(node_list):
+        ezy.log(f"    [{i}] ({x:.6f}, {y:.6f})")
+
+    ezy.log(f"  line segments: {len(unique_lines)}")
+    for i, (a, b) in enumerate(unique_lines):
+        ezy.log(f"    [{i}] ({a[0]:.6f},{a[1]:.6f}) -> ({b[0]:.6f},{b[1]:.6f})")
+
+    ezy.log("To build the sketch:")
+    ezy.log("  - Create or switch to a sketch (e.g. via UI or ezy.set_mode('Sketch_add_edge'))")
+    ezy.log("  - Use the node list above to place points (add-node tool or line tool).")
+    ezy.log("  - Connect them using the listed segments.")
+    ezy.log("  - Or extend the Python bindings to support sketch creation from code!")
+
+    # For convenience, also stash the data on the main module so you can access from console
+    import __main__
+    __main__.sierpinski_nodes = node_list
+    __main__.sierpinski_lines = unique_lines
+
+    return node_list, unique_lines
+
+# Auto-generate a small example on script load (so it's immediately visible in the console tab)
+# You can call create_sierpinski(4) yourself for higher detail (gets dense quickly).
+if __name__ == "__main__" or True:  # always run on exec
+    try:
+        create_sierpinski(order=2, size=10.0)  # small default so it doesn't spam
+    except Exception as ex:
+        try:
+            ezy.log(f"sierpinski auto-gen error: {ex}")
+        except:
+            pass

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1308,6 +1308,20 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
     {
       sk->underlay_ui_params(m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y,
                              m_underlay_rot);
+      // Also seed raw 6-DOF for sheared editor (will be refreshed live in the transform section too).
+      {
+        gp_Pnt2d b;
+        gp_Vec2d au, av;
+        sk->underlay_get_affine(b, au, av);
+        m_underlay_base = dvec2(b.X(), b.Y());
+        m_underlay_u    = dvec2(au.X(), au.Y());
+        m_underlay_v    = dvec2(av.X(), av.Y());
+      }
+      m_underlay_raw_shear = sk->underlay_raw_shear_display();
+      m_underlay_flip_u    = sk->underlay_flip_image_u();
+      m_underlay_flip_v    = sk->underlay_flip_image_v();
+      m_underlay_calib_x_done = false;
+      m_underlay_calib_y_done = false;
       m_underlay_opacity   = sk->underlay_opacity();
       m_underlay_vis       = sk->underlay_visible();
       m_underlay_key_white = sk->underlay_key_white_transparent();
@@ -1326,6 +1340,11 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
       m_underlay_center       = glm::dvec2(0.0, 0.0);
       m_underlay_half_extents = glm::dvec2(0.0, 0.0);
       m_underlay_rot          = 0.0;
+      m_underlay_raw_shear    = false;
+      m_underlay_flip_u       = false;
+      m_underlay_flip_v       = false;
+      m_underlay_calib_x_done = false;
+      m_underlay_calib_y_done = false;
       m_underlay_opacity      = 0.88f;
       m_underlay_vis          = true;
       m_underlay_key_white    = true;
@@ -1420,10 +1439,8 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
     const bool pick_y = m_underlay_calib_phase == Underlay_calib_phase::PickY1 ||
                         m_underlay_calib_phase == Underlay_calib_phase::PickY2 ||
                         m_underlay_calib_phase == Underlay_calib_phase::AwaitDistY;
-    const bool pick_datum = m_underlay_calib_phase == Underlay_calib_phase::PickDatumO ||
-                            m_underlay_calib_phase == Underlay_calib_phase::PickDatumU;
 
-    if (pick_x || pick_y || pick_datum)
+    if (pick_x || pick_y)
     {
       const char* hint = "";
       switch (m_underlay_calib_phase)
@@ -1447,19 +1464,13 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
       case Underlay_calib_phase::AwaitDistY:
         hint = "Enter the drawing distance for Y (dimension popup).";
         break;
-      case Underlay_calib_phase::PickDatumO:
-        hint = "Datum: first click places bitmap corner (0,0) on the sketch plane (underlay origin).";
-        break;
-      case Underlay_calib_phase::PickDatumU:
-        hint = "Datum: second click sets direction along bitmap +U from that origin; half width and height are kept.";
-        break;
       default:
         break;
       }
       ImGui::TextColored(ImVec4(1.0f, 0.82f, 0.25f, 1.0f), "%s", hint);
     }
 
-    ImGui::BeginDisabled(!sk_is_cur || pick_y || pick_datum);
+    ImGui::BeginDisabled(!sk_is_cur || pick_y);
     if (ImGui::Button("Set X from edge..."))
       begin_underlay_calib_set_x_(sk);
 
@@ -1469,7 +1480,7 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
                         "You can use Set Y before or after; until both are set, the other axis still follows default aspect.");
 
     ImGui::SameLine();
-    ImGui::BeginDisabled(!sk_is_cur || pick_x || pick_datum);
+    ImGui::BeginDisabled(!sk_is_cur || pick_x);
     if (ImGui::Button("Set Y from edge..."))
       begin_underlay_calib_set_y_(sk);
 
@@ -1477,98 +1488,225 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
     if (ui_show_help(2) && ImGui::IsItemHovered())
       ImGui::SetTooltip(
           "Two clicks along height (+V), then enter the drawing distance for Y. Order vs. Set X does not matter.");
-
-    ImGui::BeginDisabled(!sk_is_cur || pick_x || pick_y);
-    if (ImGui::Button("Define underlay datum..."))
-      begin_underlay_calib_define_datum_(sk);
-
-    ImGui::EndDisabled();
-    if (ui_show_help(2) && ImGui::IsItemHovered())
-      ImGui::SetTooltip("Two picks on the sketch plane: first sets bitmap corner (0,0); second sets the +U axis direction. "
-                        "Keeps current half width and height; aligns the image to your sketch datum.");
   }
 
   ImGui::Separator();
   ImGui::TextUnformatted("Transform (sketch plane, vs. current view)");
   {
-    const bool ul_ortho = sk->underlay_axes_orthogonal();
-    if (ui_show_help(3) && !ul_ortho)
-      ImGui::TextWrapped(
-          "Edge calibration produced shear (bitmap U and V are not perpendicular). These sliders only describe an "
-          "orthogonal transform; they stay off so they cannot overwrite your calibrated affine.");
+    // Refresh raw affine every time this pane renders for the active underlay sketch.
+    // This keeps the 6-DOF editor in sync after calibration, external changes, or when an edit
+    // causes the basis to become (or stop being) orthogonal.
+    gp_Pnt2d b;
+    gp_Vec2d au, av;
+    sk->underlay_get_affine(b, au, av);
+    m_underlay_base = dvec2(b.X(), b.Y());
+    m_underlay_u    = dvec2(au.X(), au.Y());
+    m_underlay_v    = dvec2(av.X(), av.Y());
 
-    const ImGuiIO& io    = ImGui::GetIO();
-    double         min_u = 0., min_v = 0., max_u = 1., max_v = 1.;
-    const bool     have_view = m_view->sketch_plane_view_aabb_2d(sk->get_plane(), static_cast<double>(io.DisplaySize.x),
-                                                                 static_cast<double>(io.DisplaySize.y), min_u, min_v, max_u, max_v);
-    if (!have_view)
+    const bool ul_ortho = sk->underlay_axes_orthogonal();
+
+    if (!ul_ortho)
     {
-      constexpr double k_fallback = 250.0;
-      // m_underlay_center stays sketch-plane gp_Pnt2d X / Y (same as underlay_ui_params).
-      min_u = m_underlay_center.x - k_fallback;
-      max_u = m_underlay_center.x + k_fallback;
-      min_v = m_underlay_center.y - k_fallback;
-      max_v = m_underlay_center.y + k_fallback;
+      ImGui::TextWrapped(
+          "Edge calibration produced shear (bitmap U and V are not perpendicular). The fields below directly edit the "
+          "raw affine basis (origin + U and V vectors). The orthogonal sliders are unavailable so they cannot overwrite "
+          "the calibrated fit. You can still use the calibration buttons or the Make orthogonal button below.");
     }
 
-    const double span_u      = std::max(max_u - min_u, 1e-6);
-    const double span_v      = std::max(max_v - min_v, 1e-6);
-    const double half_span_u = 0.5 * span_u;
-    const double half_span_v = 0.5 * span_v;
-    // Allow underlay larger than the visible frustum (trace paper / zoomed views).
-    const double     max_half_w = std::max(std::hypot(half_span_u, half_span_v) * 2.5, 1e-3);
-    const double     max_half_h = max_half_w;
-    constexpr double k_min_half = 1e-6;
-    double           rot_min    = -180.0;
-    double           rot_max    = 180.0;
-
-    auto apply_ul_xform = [&]()
+    if (ul_ortho)
     {
-      if (!sk->underlay_axes_orthogonal())
-        return;
-
-      sk->underlay_set_center_extents_rotation(dvec2(m_underlay_center.x, m_underlay_center.y),
-                                               dvec2(m_underlay_half_extents.x, m_underlay_half_extents.y), m_underlay_rot);
-    };
-
-    auto transform_slider = [&](const char* label, ImGuiDataType type, void* p_data, const void* p_min, const void* p_max,
-                                const char* format, ImGuiSliderFlags flags = 0)
-    {
-      const bool changed = ImGui::SliderScalar(label, type, p_data, p_min, p_max, format, flags);
-      if (ImGui::IsItemActivated())
-        m_view->push_undo_snapshot();
-
-      if (changed)
-        apply_ul_xform();
-    };
-
-    auto transform_input_double = [&](const char* label, double* p_data, double v_min, double v_max, const char* format)
-    {
-      const bool changed = ImGui::InputDouble(label, p_data, 0.0, 0.0, format);
-      if (ImGui::IsItemActivated())
-        m_view->push_undo_snapshot();
-
-      if (changed)
+      // Orthogonal case: original friendly Center / Half extents / Rotation controls (unchanged behavior).
+      const ImGuiIO& io    = ImGui::GetIO();
+      double         min_u = 0., min_v = 0., max_u = 1., max_v = 1.;
+      const bool     have_view =
+          m_view->sketch_plane_view_aabb_2d(sk->get_plane(), static_cast<double>(io.DisplaySize.x),
+                                            static_cast<double>(io.DisplaySize.y), min_u, min_v, max_u, max_v);
+      if (!have_view)
       {
-        *p_data = std::clamp(*p_data, v_min, v_max);
-        apply_ul_xform();
+        constexpr double k_fallback = 250.0;
+        // m_underlay_center stays sketch-plane gp_Pnt2d X / Y (same as underlay_ui_params).
+        min_u = m_underlay_center.x - k_fallback;
+        max_u = m_underlay_center.x + k_fallback;
+        min_v = m_underlay_center.y - k_fallback;
+        max_v = m_underlay_center.y + k_fallback;
       }
-    };
 
-    ImGui::BeginDisabled(!ul_ortho);
-    // Labels match typical sketch axes on screen: "Center X" drives plane Y (gp_Pnt2d::Y / view v), "Center Y" plane X (u).
-    transform_slider("Center X", ImGuiDataType_Double, &m_underlay_center.y, &min_v, &max_v, "%.4f",
-                     ImGuiSliderFlags_ClampOnInput);
-    transform_slider("Center Y", ImGuiDataType_Double, &m_underlay_center.x, &min_u, &max_u, "%.4f",
-                     ImGuiSliderFlags_ClampOnInput);
-    transform_slider("Half width", ImGuiDataType_Double, &m_underlay_half_extents.x, &k_min_half, &max_half_w, "%.4f",
-                     ImGuiSliderFlags_ClampOnInput | ImGuiSliderFlags_Logarithmic);
-    transform_slider("Half height", ImGuiDataType_Double, &m_underlay_half_extents.y, &k_min_half, &max_half_h, "%.4f",
-                     ImGuiSliderFlags_ClampOnInput | ImGuiSliderFlags_Logarithmic);
-    transform_slider("Rotation (deg)", ImGuiDataType_Double, &m_underlay_rot, &rot_min, &rot_max, "%.1f",
-                     ImGuiSliderFlags_ClampOnInput);
-    transform_input_double("Rotation value (deg)", &m_underlay_rot, rot_min, rot_max, "%.4f");
-    ImGui::EndDisabled();
+      const double span_u      = std::max(max_u - min_u, 1e-6);
+      const double span_v      = std::max(max_v - min_v, 1e-6);
+      const double half_span_u = 0.5 * span_u;
+      const double half_span_v = 0.5 * span_v;
+      // Allow underlay larger than the visible frustum (trace paper / zoomed views).
+      const double     max_half_w = std::max(std::hypot(half_span_u, half_span_v) * 2.5, 1e-3);
+      const double     max_half_h = max_half_w;
+      constexpr double k_min_half = 1e-6;
+      double           rot_min    = -180.0;
+      double           rot_max    = 180.0;
+
+      auto apply_ul_xform = [&]()
+      {
+        if (!sk->underlay_axes_orthogonal())
+          return;
+
+        sk->underlay_set_center_extents_rotation(dvec2(m_underlay_center.x, m_underlay_center.y),
+                                                 dvec2(m_underlay_half_extents.x, m_underlay_half_extents.y), m_underlay_rot);
+      };
+
+      auto transform_slider = [&](const char* label, ImGuiDataType type, void* p_data, const void* p_min, const void* p_max,
+                                  const char* format, ImGuiSliderFlags flags = 0)
+      {
+        const bool changed = ImGui::SliderScalar(label, type, p_data, p_min, p_max, format, flags);
+        if (ImGui::IsItemActivated())
+          m_view->push_undo_snapshot();
+
+        if (changed)
+          apply_ul_xform();
+      };
+
+      auto transform_input_double = [&](const char* label, double* p_data, double v_min, double v_max, const char* format)
+      {
+        const bool changed = ImGui::InputDouble(label, p_data, 0.0, 0.0, format);
+        if (ImGui::IsItemActivated())
+          m_view->push_undo_snapshot();
+
+        if (changed)
+        {
+          *p_data = std::clamp(*p_data, v_min, v_max);
+          apply_ul_xform();
+        }
+      };
+
+      // Labels match typical sketch axes on screen: "Center X" drives plane Y (gp_Pnt2d::Y / view v), "Center Y" plane X (u).
+      transform_slider("Center X", ImGuiDataType_Double, &m_underlay_center.y, &min_v, &max_v, "%.4f",
+                       ImGuiSliderFlags_ClampOnInput);
+      transform_slider("Center Y", ImGuiDataType_Double, &m_underlay_center.x, &min_u, &max_u, "%.4f",
+                       ImGuiSliderFlags_ClampOnInput);
+      transform_slider("Half width", ImGuiDataType_Double, &m_underlay_half_extents.x, &k_min_half, &max_half_w, "%.4f",
+                       ImGuiSliderFlags_ClampOnInput | ImGuiSliderFlags_Logarithmic);
+      transform_slider("Half height", ImGuiDataType_Double, &m_underlay_half_extents.y, &k_min_half, &max_half_h, "%.4f",
+                       ImGuiSliderFlags_ClampOnInput | ImGuiSliderFlags_Logarithmic);
+      transform_slider("Rotation (deg)", ImGuiDataType_Double, &m_underlay_rot, &rot_min, &rot_max, "%.1f",
+                       ImGuiSliderFlags_ClampOnInput);
+      transform_input_double("Rotation value (deg)", &m_underlay_rot, rot_min, rot_max, "%.4f");
+    }
+    else
+    {
+      // Sheared (non-orthogonal) case: 6-DOF raw affine editor.
+      // Base = bitmap (0,0) location in sketch plane.
+      // U and V are the full edge vectors (their magnitudes are the half-extents in those directions).
+      // Base X/Y use viewport-relative sliders (matching the previous Center X/Y behavior for position).
+
+      m_underlay_raw_shear = sk->underlay_raw_shear_display();
+      if (ImGui::Checkbox("Show raw shear distortion in image (makes bad Y-axis or other calibration mistakes visible as skew "
+                          "in the raster)",
+                          &m_underlay_raw_shear))
+      {
+        sk->underlay_set_raw_shear_display(m_underlay_raw_shear);
+        sk->underlay_rebuild_display();
+      }
+
+      if (m_underlay_raw_shear)
+      {
+        m_underlay_flip_u = sk->underlay_flip_image_u();
+        m_underlay_flip_v = sk->underlay_flip_image_v();
+
+        if (ImGui::Checkbox("Reverse image U (flip horizontal in source)", &m_underlay_flip_u))
+        {
+          sk->underlay_set_flip_image_u(m_underlay_flip_u);
+          sk->underlay_rebuild_display();
+        }
+        if (ImGui::Checkbox("Reverse image V (flip vertical in source)", &m_underlay_flip_v))
+        {
+          sk->underlay_set_flip_image_v(m_underlay_flip_v);
+          sk->underlay_rebuild_display();
+        }
+        ImGui::TextDisabled("(Cycle these to put raster (0,0) at the 'top left' corner of the parallelogram)");
+      }
+
+      const ImGuiIO& io    = ImGui::GetIO();
+      double         min_u = 0., min_v = 0., max_u = 1., max_v = 1.;
+      const bool     have_view =
+          m_view->sketch_plane_view_aabb_2d(sk->get_plane(), static_cast<double>(io.DisplaySize.x),
+                                            static_cast<double>(io.DisplaySize.y), min_u, min_v, max_u, max_v);
+      if (!have_view)
+      {
+        constexpr double k_fallback = 250.0;
+        min_u                       = m_underlay_base.x - k_fallback;
+        max_u                       = m_underlay_base.x + k_fallback;
+        min_v                       = m_underlay_base.y - k_fallback;
+        max_v                       = m_underlay_base.y + k_fallback;
+      }
+
+      auto apply_affine = [&]()
+      {
+        sk->underlay_set_affine_plane(gp_Pnt2d(m_underlay_base.x, m_underlay_base.y), gp_Vec2d(m_underlay_u.x, m_underlay_u.y),
+                                      gp_Vec2d(m_underlay_v.x, m_underlay_v.y));
+      };
+
+      // Base position sliders (viewport frustum bounds + fallback, direct plane X/Y).
+      {
+        const bool changed = ImGui::SliderScalar("Base X", ImGuiDataType_Double, &m_underlay_base.x, &min_u, &max_u, "%.4f",
+                                                 ImGuiSliderFlags_ClampOnInput);
+        if (ImGui::IsItemActivated())
+          m_view->push_undo_snapshot();
+        if (changed)
+          apply_affine();
+      }
+      {
+        const bool changed = ImGui::SliderScalar("Base Y", ImGuiDataType_Double, &m_underlay_base.y, &min_v, &max_v, "%.4f",
+                                                 ImGuiSliderFlags_ClampOnInput);
+        if (ImGui::IsItemActivated())
+          m_view->push_undo_snapshot();
+        if (changed)
+          apply_affine();
+      }
+
+      auto vector_component = [&](const char* label, double* p_data)
+      {
+        const bool changed = ImGui::InputDouble(label, p_data, 0.0, 0.0, "%.4f");
+        if (ImGui::IsItemActivated())
+          m_view->push_undo_snapshot();
+        if (changed)
+          apply_affine();
+      };
+
+      ImGui::TextUnformatted("+U vector");
+      if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Maps the horizontal (width / columns) of the source bitmap. From the Base, this vector reaches the "
+                          "right edge of the full image. Set X from edge and datum tools primarily affect +U.");
+      vector_component("U X", &m_underlay_u.x);
+      vector_component("U Y", &m_underlay_u.y);
+
+      ImGui::TextUnformatted("+V vector");
+      if (ImGui::IsItemHovered())
+        ImGui::SetTooltip(
+            "Maps the vertical (height / rows) of the source bitmap. From the Base, this vector reaches the bottom edge of the "
+            "full image. 'Set Y from edge...' and y-axis calibration adjust +V (this is what you set for the Y-axis).");
+      vector_component("V X", &m_underlay_v.x);
+      vector_component("V Y", &m_underlay_v.y);
+
+      // Live derived metrics (useful while tweaking shear cases).
+      {
+        const double lu        = std::hypot(m_underlay_u.x, m_underlay_u.y);
+        const double lv        = std::hypot(m_underlay_v.x, m_underlay_v.y);
+        double       shear_deg = 0.0;
+        if (lu > 1e-12 && lv > 1e-12)
+        {
+          const double dot = m_underlay_u.x * m_underlay_v.x + m_underlay_u.y * m_underlay_v.y;
+          const double c   = std::clamp(dot / (lu * lv), -1.0, 1.0);
+          shear_deg        = std::acos(c) * (180.0 / std::acos(-1.0));
+        }
+        ImGui::Text("U len: %.4f   V len: %.4f   Angle U-V: %.2f deg", lu, lv, shear_deg);
+      }
+
+      if (ImGui::Button("Make orthogonal (keep lengths + U direction)"))
+      {
+        m_view->push_undo_snapshot();
+        force_underlay_orthogonal_(sk);
+      }
+      if (ui_show_help(3) && ImGui::IsItemHovered())
+        ImGui::SetTooltip("Project V to be perpendicular to U. Keeps the current lengths of both axes and the original "
+                          "orientation (sign of U cross V). After this the Center / Half / Rotation sliders return.");
+    }
   }
 }
 
@@ -1586,6 +1724,8 @@ void GUI::on_sketch_underlay_file(const std::string& file_path, const std::strin
     return;
   }
 
+  m_underlay_calib_x_done = false;
+  m_underlay_calib_y_done = false;
   m_underlay_panel_sketch = nullptr;
   show_message("Underlay: " + std::filesystem::path(file_path).filename().string());
 }
@@ -1598,6 +1738,41 @@ void GUI::cancel_underlay_calib_()
   m_underlay_calib_sketch_wk.reset();
 
   m_underlay_calib_axis_u = gp_Vec2d(0., 0.);
+}
+
+void GUI::force_underlay_orthogonal_(const Sketch::sptr& sk)
+{
+  if (!sk || !sk->has_underlay())
+    return;
+
+  gp_Pnt2d b;
+  gp_Vec2d au, av;
+  sk->underlay_get_affine(b, au, av);
+  const double lu = au.Magnitude();
+  const double lv = av.Magnitude();
+  if (lu > 1e-12 && lv > 1e-12)
+  {
+    gp_Vec2d au_n = au;
+    au_n.Normalize();
+    const double det = au.X() * av.Y() - au.Y() * av.X();
+    gp_Vec2d     av_perp;
+    if (det >= 0.0)
+    {
+      av_perp = gp_Vec2d(-au_n.Y() * lv, au_n.X() * lv);
+    }
+    else
+    {
+      av_perp = gp_Vec2d(au_n.Y() * lv, -au_n.X() * lv);
+    }
+    const gp_Vec2d au_final = au_n * lu;
+    sk->underlay_set_affine_plane(b, au_final, av_perp);
+    // Refresh locals for this frame and any immediate follow-up UI.
+    m_underlay_u = dvec2(au_final.X(), au_final.Y());
+    m_underlay_v = dvec2(av_perp.X(), av_perp.Y());
+  }
+  sk->underlay_ui_params(m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y,
+                         m_underlay_rot);
+  m_underlay_panel_sketch = nullptr;
 }
 
 void GUI::begin_underlay_calib_set_x_(const Sketch::sptr& sk)
@@ -1636,25 +1811,6 @@ void GUI::begin_underlay_calib_set_y_(const Sketch::sptr& sk)
   m_underlay_calib_sketch_wk = sk;
   m_underlay_calib_phase     = Underlay_calib_phase::PickY1;
   show_message("Underlay Y: uses the current transform. Click two points along +V; then enter the drawing distance.");
-}
-
-void GUI::begin_underlay_calib_define_datum_(const Sketch::sptr& sk)
-{
-  if (!sk || !sk->has_underlay())
-    return;
-
-  if (m_view->curr_sketch_shared() != sk)
-  {
-    show_message("Make this sketch current in the sketch list, then try again.");
-    return;
-  }
-
-  cancel_underlay_calib_();
-  sk->underlay_ui_params(m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y,
-                         m_underlay_rot);
-  m_underlay_calib_sketch_wk = sk;
-  m_underlay_calib_phase     = Underlay_calib_phase::PickDatumO;
-  show_message("Datum: click where bitmap corner (0,0) should lie on the sketch plane.");
 }
 
 void GUI::underlay_calib_prompt_x_distance_(const Sketch::sptr& sk)
@@ -1699,7 +1855,13 @@ void GUI::underlay_calib_prompt_x_distance_(const Sketch::sptr& sk)
     m_underlay_calib_axis_u = s->underlay_axis_u_vec();
     s->underlay_ui_params(m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y,
                           m_underlay_rot);
+    m_underlay_calib_x_done = true;
     m_underlay_panel_sketch = nullptr;
+
+    if (m_underlay_calib_x_done && m_underlay_calib_y_done)
+    {
+      force_underlay_orthogonal_(s);
+    }
 
     m_dist_callback        = nullptr;
     m_underlay_calib_phase = Underlay_calib_phase::None;
@@ -1752,7 +1914,13 @@ void GUI::underlay_calib_prompt_y_distance_(const Sketch::sptr& sk)
 
     s->underlay_ui_params(m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y,
                           m_underlay_rot);
+    m_underlay_calib_y_done = true;
     m_underlay_panel_sketch = nullptr;
+
+    if (m_underlay_calib_x_done && m_underlay_calib_y_done)
+    {
+      force_underlay_orthogonal_(s);
+    }
 
     m_dist_callback = nullptr;
     cancel_underlay_calib_();
@@ -1833,35 +2001,6 @@ bool GUI::try_underlay_calib_click_(const ScreenCoords& screen_coords)
     m_underlay_calib_y1 = *pt;
     show_message("Enter drawing distance for Y.");
     underlay_calib_prompt_y_distance_(sk);
-    return true;
-
-  case Underlay_calib_phase::PickDatumO:
-    m_underlay_calib_datum_o = *pt;
-    m_underlay_calib_phase   = Underlay_calib_phase::PickDatumU;
-    show_message("Datum: click a second point along bitmap +U from that origin (direction only).");
-    return true;
-
-  case Underlay_calib_phase::PickDatumU:
-    if (too_short(m_underlay_calib_datum_o, *pt))
-    {
-      show_message("Datum direction segment too short.");
-      return true;
-    }
-
-    m_view->push_undo_snapshot();
-    if (!sk->underlay_set_datum_origin_and_u_direction(m_underlay_calib_datum_o, *pt))
-    {
-      m_view->pop_undo_snapshot();
-      show_message("Could not set underlay datum (degenerate direction or axes).");
-      cancel_underlay_calib_();
-      return true;
-    }
-
-    sk->underlay_ui_params(m_underlay_center.x, m_underlay_center.y, m_underlay_half_extents.x, m_underlay_half_extents.y,
-                           m_underlay_rot);
-    m_underlay_panel_sketch = nullptr;
-    cancel_underlay_calib_();
-    show_message("Underlay datum set: origin at (0,0) and +U direction; half sizes unchanged.");
     return true;
 
   default:

--- a/src/gui.h
+++ b/src/gui.h
@@ -45,10 +45,7 @@ enum class Underlay_calib_phase : std::uint8_t
   AwaitDistX,
   PickY1,
   PickY2,
-  AwaitDistY,
-  /// Two clicks: bitmap corner (0,0), then a point along bitmap +U (datum / origin on plane).
-  PickDatumO,
-  PickDatumU
+  AwaitDistY
 };
 /// One entry under File > Examples (menu label + path to `.ezy` on disk).
 struct Example_file
@@ -308,8 +305,8 @@ private:
   bool try_underlay_calib_click_(const ScreenCoords& screen_coords);
   void begin_underlay_calib_set_x_(const std::shared_ptr<Sketch>& sk);
   void begin_underlay_calib_set_y_(const std::shared_ptr<Sketch>& sk);
-  void begin_underlay_calib_define_datum_(const std::shared_ptr<Sketch>& sk);
   void underlay_calib_prompt_x_distance_(const std::shared_ptr<Sketch>& sk);
+  void force_underlay_orthogonal_(const std::shared_ptr<Sketch>& sk);
   void underlay_calib_prompt_y_distance_(const std::shared_ptr<Sketch>& sk);
 #if defined(__EMSCRIPTEN__)
   void sketch_underlay_file_dialog_async();
@@ -462,17 +459,25 @@ private:
   gp_Vec2d              m_underlay_calib_axis_u{}; // After X distance (model units)
   gp_Pnt2d              m_underlay_calib_y0{};
   gp_Pnt2d              m_underlay_calib_y1{};
-  gp_Pnt2d              m_underlay_calib_datum_o{};
   /// If set, next underlay import (menu or async) applies to this sketch; otherwise current sketch.
   std::weak_ptr<Sketch> m_underlay_import_sketch_target;
   glm::dvec2            m_underlay_center{};
   glm::dvec2            m_underlay_half_extents{};
   double                m_underlay_rot{};
-  float                 m_underlay_opacity{0.88f};
-  bool                  m_underlay_vis{true};
-  bool                  m_underlay_key_white{true};
-  bool                  m_underlay_line_tint{true};
-  glm::vec4             m_underlay_tint_col{1.f, 220.f / 255.f, 0.f, 1.f};
+  // Raw 6-DOF affine state for the sheared underlay editor (base + U + V). Refreshed from model when panel is active.
+  glm::dvec2 m_underlay_base{};
+  glm::dvec2 m_underlay_u{};
+  glm::dvec2 m_underlay_v{};
+  bool       m_underlay_raw_shear{false};
+  bool       m_underlay_flip_u{false};
+  bool       m_underlay_flip_v{false};
+  bool       m_underlay_calib_x_done{false};
+  bool       m_underlay_calib_y_done{false};
+  float      m_underlay_opacity{0.88f};
+  bool       m_underlay_vis{true};
+  bool       m_underlay_key_white{true};
+  bool       m_underlay_line_tint{true};
+  glm::vec4  m_underlay_tint_col{1.f, 220.f / 255.f, 0.f, 1.f};
   /// Default underlay tint for new imports (0-1, persisted in ezycad_settings.json).
   glm::vec4 m_underlay_highlight_color{1.f, 220.f / 255.f, 0.f, 1.f};
   /// Shape List hover highlight in the OCCT view (0-1, persisted in ezycad_settings.json).

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -2967,45 +2967,6 @@ gp_Vec2d Sketch::underlay_axis_u_vec() const
   return m_underlay->axis_u();
 }
 
-bool Sketch::underlay_set_datum_origin_and_u_direction(const gp_Pnt2d& origin, const gp_Pnt2d& along_u_point)
-{
-  if (!m_underlay || !m_underlay->has_image())
-    return false;
-
-  gp_Vec2d       du(along_u_point.X() - origin.X(), along_u_point.Y() - origin.Y());
-  const double   du_len = du.Magnitude();
-  const gp_Vec2d au_old = m_underlay->axis_u();
-  const gp_Vec2d av_old = m_underlay->axis_v();
-  const double   len_u  = au_old.Magnitude();
-  const double   len_v  = av_old.Magnitude();
-  if (len_u <= 1e-12 || len_v <= 1e-12 || du_len <= 1e-12)
-    return false;
-
-  du.Multiply(1.0 / du_len);
-  const double ux = du.X();
-  const double uy = du.Y();
-
-  const double det_old = au_old.X() * av_old.Y() - au_old.Y() * av_old.X();
-  double       px{};
-  double       py{};
-  if (det_old >= 0.0)
-  {
-    px = -uy;
-    py = ux;
-  }
-  else
-  {
-    px = uy;
-    py = -ux;
-  }
-
-  const gp_Vec2d au_new(len_u * ux, len_u * uy);
-  const gp_Vec2d av_new(len_v * px, len_v * py);
-
-  underlay_set_affine_plane(origin, au_new, av_new);
-  return true;
-}
-
 void Sketch::underlay_set_center_extents_rotation(const dvec2& center, const dvec2& half_extents, double rot_deg)
 {
   EZY_ASSERT(m_underlay);
@@ -3074,6 +3035,51 @@ void Sketch::underlay_set_line_tint_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_
   underlay_rebuild_display();
 }
 
+void Sketch::underlay_set_raw_shear_display(bool on)
+{
+  if (!m_underlay)
+    return;
+  m_underlay->set_raw_shear_display(on);
+  underlay_rebuild_display();
+}
+
+bool Sketch::underlay_raw_shear_display() const
+{
+  if (!m_underlay)
+    return false;
+  return m_underlay->raw_shear_display();
+}
+
+void Sketch::underlay_set_flip_image_u(bool on)
+{
+  if (!m_underlay)
+    return;
+  m_underlay->set_flip_image_u(on);
+  underlay_rebuild_display();
+}
+
+void Sketch::underlay_set_flip_image_v(bool on)
+{
+  if (!m_underlay)
+    return;
+  m_underlay->set_flip_image_v(on);
+  underlay_rebuild_display();
+}
+
+bool Sketch::underlay_flip_image_u() const
+{
+  if (!m_underlay)
+    return false;
+  return m_underlay->flip_image_u();
+}
+
+bool Sketch::underlay_flip_image_v() const
+{
+  if (!m_underlay)
+    return false;
+  return m_underlay->flip_image_v();
+}
+
 bool Sketch::underlay_line_tint_enabled() const { return m_underlay ? m_underlay->line_tint_enabled() : true; }
 
 void Sketch::underlay_line_tint_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const
@@ -3116,6 +3122,20 @@ void Sketch::underlay_ui_params(double& cx, double& cy, double& half_w, double& 
   cx                = b.X() + 0.5 * (au.X() + av.X());
   cy                = b.Y() + 0.5 * (au.Y() + av.Y());
   rot_deg           = std::atan2(au.Y(), au.X()) * (180.0 / std::numbers::pi);
+}
+
+void Sketch::underlay_get_affine(gp_Pnt2d& base, gp_Vec2d& axis_u, gp_Vec2d& axis_v) const
+{
+  if (!m_underlay || !m_underlay->has_image())
+  {
+    base   = gp_Pnt2d(0., 0.);
+    axis_u = gp_Vec2d(0., 0.);
+    axis_v = gp_Vec2d(0., 0.);
+    return;
+  }
+  base   = m_underlay->base();
+  axis_u = m_underlay->axis_u();
+  axis_v = m_underlay->axis_v();
 }
 
 bool Sketch::underlay_axes_orthogonal() const

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -164,10 +164,19 @@ public:
   void                underlay_set_line_tint_enabled(bool on);
   void                underlay_set_line_tint_rgb(uint8_t r, uint8_t g, uint8_t b);
   void                underlay_set_line_tint_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+  void                underlay_set_raw_shear_display(bool on);
+  [[nodiscard]] bool  underlay_raw_shear_display() const;
+  void                underlay_set_flip_image_u(bool on);
+  void                underlay_set_flip_image_v(bool on);
+  [[nodiscard]] bool  underlay_flip_image_u() const;
+  [[nodiscard]] bool  underlay_flip_image_v() const;
   [[nodiscard]] bool  underlay_line_tint_enabled() const;
   void                underlay_line_tint_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const;
   void                underlay_line_tint_rgba(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a) const;
   void                underlay_ui_params(double& cx, double& cy, double& half_w, double& half_h, double& rot_deg) const;
+  /// Retrieve the raw affine basis (bitmap origin + U and V edge vectors in sketch plane 2D coords).
+  /// Used by the 6-DOF editor for sheared (non-orthogonal) underlays.
+  void underlay_get_affine(gp_Pnt2d& base, gp_Vec2d& axis_u, gp_Vec2d& axis_v) const;
   /// True when texture U and V directions are perpendicular (no shear). Orthogonal UI assumes this.
   [[nodiscard]] bool underlay_axes_orthogonal() const;
   void               underlay_rebuild_display();
@@ -181,8 +190,6 @@ public:
   /// Keep U axis; adjust V and base so segment \a y0-\a y1 has length \a target_len (after X calibration).
   [[nodiscard]] bool     underlay_rescale_v_chord_to_length(const gp_Pnt2d& y0, const gp_Pnt2d& y1, double target_len);
   [[nodiscard]] gp_Vec2d underlay_axis_u_vec() const;
-  /// Datum on sketch plane: bitmap (0,0) at \a origin; +U toward \a along_u_point; keeps |axis_u|, |axis_v| and winding.
-  [[nodiscard]] bool underlay_set_datum_origin_and_u_direction(const gp_Pnt2d& origin, const gp_Pnt2d& along_u_point);
 
   // private:
   friend class Sketch_json;

--- a/src/sketch_underlay.cpp
+++ b/src/sketch_underlay.cpp
@@ -2,13 +2,17 @@
 
 #include <AIS_InteractiveContext.hxx>
 #include <AIS_InteractiveObject.hxx>
+#include <AIS_Shape.hxx>
 #include <AIS_TexturedShape.hxx>
+#include <Quantity_NameOfColor.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <Image_PixMap.hxx>
 #include <Precision.hxx>
 #include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopoDS_Wire.hxx>
 #include <algorithm>
 #include <cmath>
 #include <cstring>
@@ -259,6 +263,11 @@ void Sketch_underlay::remove_ais_(AIS_InteractiveContext& ctx)
     ctx.Remove(m_ais, false);
     m_ais.Nullify();
   }
+  if (!m_border.IsNull())
+  {
+    ctx.Remove(m_border, false);
+    m_border.Nullify();
+  }
 }
 
 bool Sketch_underlay::set_image_rgba(std::vector<uint8_t>&& rgba, int w, int h)
@@ -347,6 +356,14 @@ void Sketch_underlay::set_line_tint_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_
   m_tint_a = a;
 }
 
+void Sketch_underlay::set_raw_shear_display(bool on)
+{
+  if (m_raw_shear_display != on)
+  {
+    m_raw_shear_display = on;
+  }
+}
+
 void Sketch_underlay::line_tint_rgb(uint8_t& r, uint8_t& g, uint8_t& b) const
 {
   r = m_tint_r;
@@ -384,6 +401,17 @@ void Sketch_underlay::build_ais_(const gp_Pln& pln, AIS_InteractiveContext& ctx)
   if (du_len <= Precision::Confusion() || dv_len <= Precision::Confusion())
     return;
 
+  // Image quad corners in the sketch plane (always a parallelogram from base + u + v).
+  // These define the tight bounds for the rendered border rectangle around the underlay.
+  const gp_Pnt2d b00 = m_base;
+  const gp_Pnt2d b10(m_base.X() + m_axis_u.X(), m_base.Y() + m_axis_u.Y());
+  const gp_Pnt2d b11(b10.X() + m_axis_v.X(), b10.Y() + m_axis_v.Y());
+  const gp_Pnt2d b01(m_base.X() + m_axis_v.X(), m_base.Y() + m_axis_v.Y());
+  const gp_Pnt   Q00 = to_3d(pln, b00).Translated(nudge);
+  const gp_Pnt   Q10 = to_3d(pln, b10).Translated(nudge);
+  const gp_Pnt   Q11 = to_3d(pln, b11).Translated(nudge);
+  const gp_Pnt   Q01 = to_3d(pln, b01).Translated(nudge);
+
   const auto axes_orthogonal = [](const gp_Vec2d& au, const gp_Vec2d& av) -> bool
   {
     const double dot   = au.X() * av.X() + au.Y() * av.Y();
@@ -395,50 +423,81 @@ void Sketch_underlay::build_ais_(const gp_Pln& pln, AIS_InteractiveContext& ctx)
 
   Handle(Image_PixMap) pix;
 
-  if (axes_orthogonal(m_axis_u, m_axis_v))
-  {
-    // Rotation + uniform scale: build a rectangular face in a plane whose U/V match bitmap axes so texture is not
-    // sheared (no inverse-resample pixmap needed).
-    const gp_Dir            Zpl = pln.Position().Direction();
-    const gp_Dir            Xu(Du);
-    const gp_Ax3            ax3(P0, Zpl, Xu);
-    const gp_Pln            local_pln(ax3);
-    BRepBuilderAPI_MakeFace faceMk(local_pln, 0.0, du_len, 0.0, dv_len);
-    if (!faceMk.IsDone())
-      return;
-    face = faceMk.Face();
+  const bool is_ortho = axes_orthogonal(m_axis_u, m_axis_v);
 
-    pix = make_pixmap_bottom_up_linear(m_rgba.data(), m_w, m_h, m_key_white_transparent, m_line_tint_enabled, m_tint_r,
-                                       m_tint_g, m_tint_b, m_tint_a);
+  if (is_ortho || !m_raw_shear_display)
+  {
+    if (is_ortho)
+    {
+      // Rotation + uniform scale: build a rectangular face in a plane whose U/V match bitmap axes so texture is not
+      // sheared (no inverse-resample pixmap needed).
+      const gp_Dir            Zpl = pln.Position().Direction();
+      const gp_Dir            Xu(Du);
+      const gp_Ax3            ax3(P0, Zpl, Xu);
+      const gp_Pln            local_pln(ax3);
+      BRepBuilderAPI_MakeFace faceMk(local_pln, 0.0, du_len, 0.0, dv_len);
+      if (!faceMk.IsDone())
+        return;
+      face = faceMk.Face();
+
+      pix = make_pixmap_bottom_up_linear(m_rgba.data(), m_w, m_h, m_key_white_transparent, m_line_tint_enabled, m_tint_r,
+                                         m_tint_g, m_tint_b, m_tint_a);
+    }
+    else
+    {
+      // Sheared affine (e.g. after Y-from-edge calibration): axis-aligned bbox + inverse-rotated pixmap resample.
+      // This preserves the source image appearance relative to the U/V axes (no extra distortion in the raster).
+      const double hw    = 0.5 * m_axis_u.Magnitude();
+      const double hh    = 0.5 * m_axis_v.Magnitude();
+      const double theta = std::atan2(m_axis_u.Y(), m_axis_u.X());
+      const double c     = std::cos(theta);
+      const double s     = std::sin(theta);
+      const double hx    = std::max(std::abs(hw * c) + std::abs(hh * s), 1e-12);
+      const double hy    = std::max(std::abs(hw * s) + std::abs(hh * c), 1e-12);
+      const double cx    = m_base.X() + 0.5 * (m_axis_u.X() + m_axis_v.X());
+      const double cy    = m_base.Y() + 0.5 * (m_axis_u.Y() + m_axis_v.Y());
+
+      const gp_Pnt2d c00(cx - hx, cy - hy);
+      const gp_Pnt2d c10(cx + hx, cy - hy);
+      const gp_Pnt2d c11(cx + hx, cy + hy);
+      const gp_Pnt2d c01(cx - hx, cy + hy);
+
+      const gp_Pnt p00 = to_3d(pln, c00).Translated(nudge);
+      const gp_Pnt p10 = to_3d(pln, c10).Translated(nudge);
+      const gp_Pnt p11 = to_3d(pln, c11).Translated(nudge);
+      const gp_Pnt p01 = to_3d(pln, c01).Translated(nudge);
+
+      BRepBuilderAPI_MakeWire wireMk;
+      wireMk.Add(BRepBuilderAPI_MakeEdge(p00, p10).Edge());
+      wireMk.Add(BRepBuilderAPI_MakeEdge(p10, p11).Edge());
+      wireMk.Add(BRepBuilderAPI_MakeEdge(p11, p01).Edge());
+      wireMk.Add(BRepBuilderAPI_MakeEdge(p01, p00).Edge());
+      if (!wireMk.IsDone())
+        return;
+
+      BRepBuilderAPI_MakeFace faceMk(wireMk.Wire(), true);
+      if (!faceMk.IsDone())
+        return;
+      face = faceMk.Face();
+
+      pix = make_pixmap_bottom_up_warped(m_rgba.data(), m_w, m_h, m_axis_u, m_axis_v, m_key_white_transparent,
+                                         m_line_tint_enabled, m_tint_r, m_tint_g, m_tint_b, m_tint_a);
+    }
   }
   else
   {
-    // Sheared affine (e.g. after Y-from-edge calibration): axis-aligned bbox + inverse-rotated pixmap resample.
-    const double hw    = 0.5 * m_axis_u.Magnitude();
-    const double hh    = 0.5 * m_axis_v.Magnitude();
-    const double theta = std::atan2(m_axis_u.Y(), m_axis_u.X());
-    const double c     = std::cos(theta);
-    const double s     = std::sin(theta);
-    const double hx    = std::max(std::abs(hw * c) + std::abs(hh * s), 1e-12);
-    const double hy    = std::max(std::abs(hw * s) + std::abs(hh * c), 1e-12);
-    const double cx    = m_base.X() + 0.5 * (m_axis_u.X() + m_axis_v.X());
-    const double cy    = m_base.Y() + 0.5 * (m_axis_u.Y() + m_axis_v.Y());
-
-    const gp_Pnt2d c00(cx - hx, cy - hy);
-    const gp_Pnt2d c10(cx + hx, cy - hy);
-    const gp_Pnt2d c11(cx + hx, cy + hy);
-    const gp_Pnt2d c01(cx - hx, cy + hy);
-
-    const gp_Pnt p00 = to_3d(pln, c00).Translated(nudge);
-    const gp_Pnt p10 = to_3d(pln, c10).Translated(nudge);
-    const gp_Pnt p11 = to_3d(pln, c11).Translated(nudge);
-    const gp_Pnt p01 = to_3d(pln, c01).Translated(nudge);
-
+    // Raw shear mode (m_raw_shear_display true): use the *exact* parallelogram quad face
+    // for the textured shape (the visible raster "is" the cyan parallelogram).
+    // Linear (unmodified) pixmap + user-controlled flips. The sheared geometry of the
+    // face applies the affine directly to the pixels, so a bad Y-axis calibration makes
+    // the raster image visibly skewed/distorted, with content "skewed to the bounds".
+    // Flips let the user put raster 0,0 at the desired corner of the para (addresses
+    // the UV mapping on wire faces).
     BRepBuilderAPI_MakeWire wireMk;
-    wireMk.Add(BRepBuilderAPI_MakeEdge(p00, p10).Edge());
-    wireMk.Add(BRepBuilderAPI_MakeEdge(p10, p11).Edge());
-    wireMk.Add(BRepBuilderAPI_MakeEdge(p11, p01).Edge());
-    wireMk.Add(BRepBuilderAPI_MakeEdge(p01, p00).Edge());
+    wireMk.Add(BRepBuilderAPI_MakeEdge(Q00, Q10).Edge());
+    wireMk.Add(BRepBuilderAPI_MakeEdge(Q10, Q11).Edge());
+    wireMk.Add(BRepBuilderAPI_MakeEdge(Q11, Q01).Edge());
+    wireMk.Add(BRepBuilderAPI_MakeEdge(Q01, Q00).Edge());
     if (!wireMk.IsDone())
       return;
 
@@ -447,8 +506,41 @@ void Sketch_underlay::build_ais_(const gp_Pln& pln, AIS_InteractiveContext& ctx)
       return;
     face = faceMk.Face();
 
-    pix = make_pixmap_bottom_up_warped(m_rgba.data(), m_w, m_h, m_axis_u, m_axis_v, m_key_white_transparent,
-                                       m_line_tint_enabled, m_tint_r, m_tint_g, m_tint_b, m_tint_a);
+    pix = make_pixmap_bottom_up_linear(m_rgba.data(), m_w, m_h, m_key_white_transparent, m_line_tint_enabled, m_tint_r,
+                                       m_tint_g, m_tint_b, m_tint_a);
+
+    if (!pix.IsNull())
+    {
+      uint8_t*     data     = pix->ChangeData();
+      const size_t ww       = pix->Width();
+      const size_t hh       = pix->Height();
+      const size_t rowBytes = ww * 4;
+
+      if (m_flip_image_v)
+      {
+        // vertical flip (V / image rows)
+        for (size_t r = 0; r < hh / 2; ++r)
+        {
+          uint8_t* r1 = data + r * rowBytes;
+          uint8_t* r2 = data + (hh - 1 - r) * rowBytes;
+          for (size_t c = 0; c < rowBytes; ++c)
+            std::swap(r1[c], r2[c]);
+        }
+      }
+      if (m_flip_image_u)
+      {
+        // horizontal flip (U / image columns)
+        for (size_t r = 0; r < hh; ++r)
+        {
+          uint8_t* row = data + r * rowBytes;
+          for (size_t c = 0; c < ww / 2; ++c)
+          {
+            for (int ch = 0; ch < 4; ++ch)
+              std::swap(row[c * 4 + ch], row[(ww - 1 - c) * 4 + ch]);
+          }
+        }
+      }
+    }
   }
 
   if (pix.IsNull())
@@ -462,10 +554,31 @@ void Sketch_underlay::build_ais_(const gp_Pln& pln, AIS_InteractiveContext& ctx)
   m_ais->SetTransparency(1.0 - static_cast<double>(m_opacity));
   m_ais->SetDisplayMode(3);
 
+  // Build a thin wireframe border around the exact image quad (parallelogram) so the underlay extent
+  // is always obvious, even for newly added images or when most content is keyed transparent.
+  {
+    BRepBuilderAPI_MakeWire wmk;
+    wmk.Add(BRepBuilderAPI_MakeEdge(Q00, Q10).Edge());
+    wmk.Add(BRepBuilderAPI_MakeEdge(Q10, Q11).Edge());
+    wmk.Add(BRepBuilderAPI_MakeEdge(Q11, Q01).Edge());
+    wmk.Add(BRepBuilderAPI_MakeEdge(Q01, Q00).Edge());
+    if (wmk.IsDone())
+    {
+      m_border = new AIS_Shape(wmk.Wire());
+      m_border->SetColor(Quantity_NOC_CYAN);
+      m_border->SetWidth(1.5);
+    }
+  }
+
   if (m_visible)
   {
     ctx.Display(m_ais, 3, 0, false);
     ctx.Deactivate(opencascade::handle<AIS_InteractiveObject>(m_ais));
+    if (!m_border.IsNull())
+    {
+      ctx.Display(m_border, false);
+      ctx.Deactivate(opencascade::handle<AIS_InteractiveObject>(m_border));
+    }
   }
 }
 
@@ -512,6 +625,7 @@ nlohmann::json Sketch_underlay::to_json() const
   j["key_white_transparent"] = m_key_white_transparent;
   j["line_tint_enabled"]     = m_line_tint_enabled;
   j["line_tint_rgba"]        = nlohmann::json::array({m_tint_r, m_tint_g, m_tint_b, m_tint_a});
+  j["raw_shear_display"]     = m_raw_shear_display;
   return j;
 }
 
@@ -562,6 +676,7 @@ bool Sketch_underlay::from_json(const nlohmann::json& j)
     m_tint_g = static_cast<uint8_t>(j["line_tint_rgb"][1].get<int>());
     m_tint_b = static_cast<uint8_t>(j["line_tint_rgb"][2].get<int>());
   }
+  m_raw_shear_display = j.value("raw_shear_display", false);
   if (m_opacity < 0.f)
     m_opacity = 0.f;
   if (m_opacity > 1.f)

--- a/src/sketch_underlay.h
+++ b/src/sketch_underlay.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 class AIS_TexturedShape;
+class AIS_Shape;
 class AIS_InteractiveContext;
 class gp_Pln;
 
@@ -58,6 +59,14 @@ public:
   [[nodiscard]] int      image_w()               const { return m_w; }
   [[nodiscard]] int      image_h()               const { return m_h; }
 
+  void                set_raw_shear_display(bool on);
+  [[nodiscard]] bool  raw_shear_display() const { return m_raw_shear_display; }
+
+  void set_flip_image_u(bool on) { m_flip_image_u = on; }
+  void set_flip_image_v(bool on) { m_flip_image_v = on; }
+  [[nodiscard]] bool flip_image_u() const { return m_flip_image_u; }
+  [[nodiscard]] bool flip_image_v() const { return m_flip_image_v; }
+
   // clang-format on
 
   void rebuild_and_display(const gp_Pln& pln, AIS_InteractiveContext& ctx);
@@ -93,5 +102,15 @@ private:
   uint8_t m_tint_b{0};
   uint8_t m_tint_a{255};
 
+  /// When true and the axes are sheared, the source image is textured directly onto the
+  /// sheared parallelogram quad (raw affine applied to pixels). This makes calibration
+  /// mistakes (e.g. incorrect Y-axis) visible as skew/distortion in the raster image itself.
+  /// Default false uses special resampling to preserve source image appearance relative to U/V.
+  bool m_raw_shear_display{false};
+
+  bool m_flip_image_u{false}; // for raw mode: flip source along U (horizontal in image)
+  bool m_flip_image_v{false}; // for raw mode: flip source along V (vertical in image)
+
   opencascade::handle<AIS_TexturedShape> m_ais;
+  opencascade::handle<AIS_Shape>         m_border;
 };


### PR DESCRIPTION
Documents the current limitations and behaviors for sketch image underlays:

- Edge calibration (Set X / Set Y) can introduce shear.
- 6-DOF editor + 'Show raw shear distortion' toggle + U/V flips when sheared (to visualize mistakes and control corner mapping).
- Auto 'Make orthogonal (keep lengths + U direction)' after both axes are successfully set.
- 'Define underlay datum...' tool removed.
- Renderer differences (preserve vs raw), cyan frame always exact bounds, full image mapped, OCCT face param nuances requiring flips in raw mode, etc.

Updated:
- docs/usage-sketch.md (expanded guidance + explicit limitations subsection)
- docs/bugs.md (refreshed the underlay item)

This accompanies the recent underlay UX work (6-DOF, raw mode, auto-ortho, datum removal).

Closes #136