### PR TITLE
Operational axis UX, revolve solid conversion, shape info dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Operation axis / Revolve
 
+- Toolbar tooltip renamed to **Operational axis** (was "Define operation axis").
+- The operational axis line is shown only while **Operational axis** mode is active; switching to another sketch mode hides it even if the axis remains defined for Mirror/Revolve.
+- After the axis is defined (mirror/revolve phase), **permanent + node markers** and **sketch snap** (axis guides, vertex lock, snap annotations) are temporarily suppressed so edge/face selection is unobstructed. Snapping and markers return when you **Clear axis** or leave Operational axis mode. Axis placement (Phase 1) still uses normal snap.
+- Operational axes are **saved and loaded** with the sketch in project JSON (`operation_axis` array of two plane points).
 - After **Revolve**, when the selection is **edges** (not a face), EzyCad does its best to convert the revolved result from a shell or faces into a **solid** so chamfer, fillet, and booleans work on closed 360° profiles. Open or partial revolutions are unchanged.
 - **?** help button next to the revolve angle field in the Options panel (tooltip + link to [Revolve solid conversion](docs/usage-sketch.md#revolve-solid-conversion) in the user guide).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Shape List
+
+- **Shape info...** on the right-click menu for a shape name or **M** button. Opens a dialog with OCCT topology and property details: root type (Solid, Shell, Face, etc.), validity, sub-shape counts, bounding box, volume, center of mass, surface area, and length where applicable. Includes document fields (name, material, display mode, visibility) and a **Refresh** button. Documented in the user guide under [Shape info](docs/usage.md#shape-info).
+
 ### Sketch underlay
 
 - When an image underlay has shear from edge calibration ("Set X from edge..." or "Set Y from edge..."), the **Transform** section in Sketch properties now provides a full 6-DOF editor: Base X/Y (bitmap 0,0 origin) + direct Ux/Uy and Vx/Vy vector components. Derived U/V lengths and the angle between them are displayed live. Edits apply immediately with undo support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Shape info...** on the right-click menu for a shape name or **M** button. Opens a dialog with OCCT topology and property details: root type (Solid, Shell, Face, etc.), validity, sub-shape counts, bounding box, volume, center of mass, surface area, and length where applicable. Includes document fields (name, material, display mode, visibility) and a **Refresh** button. Documented in the user guide under [Shape info](docs/usage.md#shape-info).
 
+### Operation axis / Revolve
+
+- After **Revolve**, when the selection is **edges** (not a face), EzyCad does its best to convert the revolved result from a shell or faces into a **solid** so chamfer, fillet, and booleans work on closed 360° profiles. Open or partial revolutions are unchanged.
+- **?** help button next to the revolve angle field in the Options panel (tooltip + link to [Revolve solid conversion](docs/usage-sketch.md#revolve-solid-conversion) in the user guide).
+
 ### Sketch underlay
 
 - When an image underlay has shear from edge calibration ("Set X from edge..." or "Set Y from edge..."), the **Transform** section in Sketch properties now provides a full 6-DOF editor: Base X/Y (bitmap 0,0 origin) + direct Ux/Uy and Vx/Vy vector components. Derived U/V lengths and the angle between them are displayed live. Edits apply immediately with undo support.

--- a/agents/issues/013-operational-axis-visibility-and-snap.md
+++ b/agents/issues/013-operational-axis-visibility-and-snap.md
@@ -61,8 +61,8 @@ Improve the **Operational axis** sketch tool so the axis line is visible only wh
 
 - `docs/bugs.md` items (now struck through).
 - Branch also includes revolve solid conversion, shape info dialog — see PR for full branch scope.
-- GitHub issue: _(fill after create)_
-- GitHub PR: _(fill after create)_
+- GitHub issue: https://github.com/trailcode/EzyCad/issues/142
+- GitHub PR: https://github.com/trailcode/EzyCad/pull/143
 
 ### Test plan
 

--- a/agents/issues/013-operational-axis-visibility-and-snap.md
+++ b/agents/issues/013-operational-axis-visibility-and-snap.md
@@ -1,0 +1,74 @@
+# Operational axis: visibility, snap suppression, persistence, and toolbar label
+
+**Suggested labels:** `enhancement`, `sketch`, `ui`, `docs`
+
+---
+
+## Title (GitHub)
+
+Operational axis mode: show axis only in tool, suppress snap/markers when defined, persist in JSON
+
+## Body (GitHub)
+
+### Summary
+
+Improve the **Operational axis** sketch tool so the axis line is visible only while that mode is active, permanent **+** node markers and sketch snap are suppressed after the axis is defined (mirror/revolve selection phase), the toolbar tooltip reads **Operational axis**, and operational axes round-trip in sketch project JSON.
+
+### Problem
+
+- The operational axis line stayed visible when switching to other sketch modes, cluttering the view.
+- After defining an axis for Mirror/Revolve, permanent node markers and snap guides interfered with selecting edges and faces (`docs/bugs.md` tracked both persistence and snap/node suppression).
+- Toolbar tooltip said "Define operation axis" while the tool also supports mirror/revolve workflows after definition.
+- Operational axes were not persisted in saved projects.
+
+### Implemented scope
+
+**Code changes:**
+
+- `src/sketch.cpp` / `src/sketch.h`: `sync_operation_axis_display_()`, `show_operation_axis_()`, `operation_axis_suppresses_sketch_snap_()`; permanent node sync hides markers when axis is defined in Operational axis mode; finalize/clear axis refresh display and annotations.
+- `src/sketch_nodes.cpp`: early return in snap paths when `Occt_view::sketch_snap_suppressed()`.
+- `src/occt_view.cpp` / `src/occt_view.h`: `sketch_snap_suppressed()`.
+- `src/sketch_json.cpp`: serialize/load `operation_axis` (two plane points).
+- `src/gui.cpp`: toolbar tooltip **Operational axis**.
+- `tests/sketch_tests.cpp`: JSON round-trip for operation axis.
+
+**Documentation:**
+
+- `CHANGELOG.md` — Operation axis / Revolve section expanded.
+- `docs/usage-sketch.md` — Operational axis tool, sketch snapping table, visibility and snap-suppression behavior.
+- `docs/usage.md` — toolbar icon list.
+- `docs/bugs.md` — struck through persistence and snap/node items.
+
+### Acceptance criteria
+
+- [ ] Operational axis line visible only in Operational axis mode.
+- [ ] After axis is defined: no permanent **+** markers, no sketch snap until Clear axis or mode change.
+- [ ] Phase 1 axis placement still snaps normally.
+- [ ] Toolbar and Options mode description say **Operational axis**.
+- [ ] `operation_axis` persists in sketch JSON save/load.
+- [ ] User guide and changelog match behavior.
+- [ ] `EzyCad_tests` pass (including `OperationAxis_JSON_RoundTrip`).
+
+### Files touched
+
+- `src/sketch.cpp`, `src/sketch.h`, `src/sketch_nodes.cpp`, `src/sketch_json.cpp`
+- `src/occt_view.cpp`, `src/occt_view.h`, `src/gui.cpp`
+- `tests/sketch_tests.cpp`
+- `CHANGELOG.md`, `docs/usage-sketch.md`, `docs/usage.md`, `docs/bugs.md`
+- `agents/issues/013-operational-axis-visibility-and-snap.md` (this draft)
+
+### Related
+
+- `docs/bugs.md` items (now struck through).
+- Branch also includes revolve solid conversion, shape info dialog — see PR for full branch scope.
+- GitHub issue: _(fill after create)_
+- GitHub PR: _(fill after create)_
+
+### Test plan
+
+- [ ] Define operational axis; confirm snap during placement.
+- [ ] After second click: axis visible, no **+** markers, no snap guides when moving cursor.
+- [ ] Mirror/Revolve selection works; Clear axis restores markers and snap.
+- [ ] Switch to another sketch tool: axis hidden; return to Operational axis: axis visible again.
+- [ ] Save/reload project: axis restored; hidden when not in Operational axis mode.
+- [ ] Run `OperationAxis_JSON_RoundTrip` and full `EzyCad_tests`.

--- a/agents/prs/008-github-body.md
+++ b/agents/prs/008-github-body.md
@@ -1,0 +1,23 @@
+Closes https://github.com/trailcode/EzyCad/issues/142
+
+## Summary
+
+- **Operational axis:** toolbar renamed to **Operational axis**; axis line visible only in that mode; after definition, permanent **+** markers and sketch snap suppressed for clearer mirror/revolve selection; axes persist in sketch JSON.
+- **Revolve:** best-effort conversion of edge revolutions to solids; contextual **?** help on revolve angle field.
+- **Shape info:** right-click shape name or **M** button opens topology/property dialog.
+- **Fixes:** shape highlight in sketch operation-axis mode; related GUI/settings refactors on the branch.
+
+Closes operational-axis visibility/snap/persistence work.
+
+## Test plan
+
+- [ ] Build `EzyCad` and `EzyCad_tests` (Release).
+- [ ] Run `OperationAxis_JSON_RoundTrip` and mirror/revolve tests.
+- [ ] Manual: Operational axis placement, snap suppression after define, Clear axis, mode switch visibility.
+- [ ] Manual: Revolve closed edge profile; Shape info shows Solid when conversion succeeds.
+- [ ] Docs: review `#operation-axis-tool` and sketch snapping section in `usage-sketch.md`.
+
+## Notes
+
+- Snap suppression applies only when an axis **exists** in Operational axis mode (not during initial two-point placement).
+- Axis visibility is mode-gated; stored axis survives tool switches and file reload.

--- a/agents/prs/008-operational-axis-revolve-shape-info.md
+++ b/agents/prs/008-operational-axis-revolve-shape-info.md
@@ -26,7 +26,8 @@ Closes operational-axis visibility/snap/persistence work tracked in `agents/issu
 
 ## Related
 
-- Issue: _(fill after create)_
+- Issue: https://github.com/trailcode/EzyCad/issues/142
+- PR: https://github.com/trailcode/EzyCad/pull/143
 - Draft: `agents/issues/013-operational-axis-visibility-and-snap.md`
 
 ## Test Plan

--- a/agents/prs/008-operational-axis-revolve-shape-info.md
+++ b/agents/prs/008-operational-axis-revolve-shape-info.md
@@ -1,0 +1,43 @@
+# PR - Trailcode/revolve_fix
+
+## Title
+
+Operational axis UX, revolve solid conversion, shape info dialog, and related fixes
+
+## Summary
+
+- **Operational axis:** toolbar renamed to **Operational axis**; axis line visible only in that mode; after definition, permanent **+** markers and sketch snap suppressed for clearer mirror/revolve selection; axes persist in sketch JSON.
+- **Revolve:** best-effort conversion of edge revolutions to solids; contextual **?** help on revolve angle field.
+- **Shape info:** right-click shape name or **M** button opens topology/property dialog.
+- **Fixes:** shape highlight in sketch operation-axis mode; related GUI/settings refactors on the branch.
+
+Closes operational-axis visibility/snap/persistence work tracked in `agents/issues/013-operational-axis-visibility-and-snap.md`.
+
+## Files Changed
+
+- `src/sketch.cpp`, `src/sketch.h`, `src/sketch_nodes.cpp`, `src/sketch_json.cpp`
+- `src/occt_view.cpp`, `src/occt_view.h`
+- `src/gui.cpp`, `src/gui.h`, `src/gui_mode.cpp`, `src/gui_settings.cpp`
+- `src/shp_info.cpp`, `src/shp_info.h`, `src/shp.cpp`, `src/utl_occt.cpp`, `src/utl_occt.h`
+- `tests/sketch_tests.cpp`
+- `CHANGELOG.md`, `docs/usage-sketch.md`, `docs/usage.md`, `docs/usage-settings.md`, `docs/bugs.md`
+- `res/ezycad_settings.json`
+- `agents/issues/013-operational-axis-visibility-and-snap.md`, `agents/prs/008-operational-axis-revolve-shape-info.md`
+
+## Related
+
+- Issue: _(fill after create)_
+- Draft: `agents/issues/013-operational-axis-visibility-and-snap.md`
+
+## Test Plan
+
+- [ ] Build `EzyCad` and `EzyCad_tests` (Release).
+- [ ] `ctest -C Release` or run `OperationAxis_JSON_RoundTrip`, mirror/revolve tests.
+- [ ] Manual: Operational axis placement, snap suppression after define, Clear axis, mode switch visibility.
+- [ ] Manual: Revolve closed edge profile → Shape info shows Solid when conversion succeeds.
+- [ ] `sphinx-build -b html -W docs docs/_build` — review `#operation-axis-tool` and sketch snapping section.
+
+## Notes
+
+- Snap suppression applies only when an axis **exists** in Operational axis mode (not during initial two-point placement).
+- Axis visibility is mode-gated; stored axis survives tool switches and file reload.

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,6 +1,6 @@
 # Known Bugs and Issues
 
-* All operational axes must be persisted.
+* ~~All operational axes must be persisted.~~
 * Create a hole in a solid, try and create a face on a curved face. No error is presented to the user. 
 * For curved surfaces, snapping needs to be computed at runtime, annotate snapping on actual curve and apply results. [![Screenshot](./images/scr1.png)](./images/scr.png)
 * Subdivision for shapes should be based on zoom or dist of object to camera. 
@@ -31,6 +31,6 @@
 * ~~Need a mirror option for edge. First specify center.~~
 * ~~Need a option to not add edge midpoint nodes.~~
 * Need a option to split a edge.
-* If the operational axis is defined. Do not render snap points and perminate nodes.
+* ~~If the operational axis is defined. Do not render snap points and perminate nodes.~~
 * Need a hotkey for face inspection mode.
 * Dist and angle input should accept basic algeraic functions, e.g. /, +, etc

--- a/docs/usage-settings.md
+++ b/docs/usage-settings.md
@@ -184,7 +184,7 @@ String: ImGui `.ini` text for window positions and docking saved with **SaveIniS
 | `imgui_rounding_general` | number | Window/child/frame/popup rounding (**0** to **32** clamped in code; sliders stop at 16 in the UI). |
 | `imgui_rounding_scroll` | number | Scrollbar and grab rounding (same clamp). |
 | `imgui_rounding_tabs` | number | Tab rounding (same clamp). |
-| `underlay_highlight_color` | array of 3 numbers | Default underlay tint (float RGB **0** to **1** per channel). |
+| `underlay_highlight_color` | array of 3 numbers | Default underlay tint (float RGB **0** to **1** per channel; default **amber/gold** **1**, **0.86**, **0**). |
 | `view_roll_step_deg` | number | Degrees per **NumPad 8**/**2**/**4**/**6** orbit and **Shift+NumPad 4**/**6** roll (allowed range **0.1** to **180** in code; default **45**). |
 | `view_zoom_scroll_scale` | number | Multiplier for `UpdateZoom` scroll delta from wheel and keyboard zoom (allowed range **0.25** to **64** in code; default **4**). With **Shift** held, the effective step is multiplied by **0.1** (Blender-style finer zoom). |
 | `load_last_opened_on_startup` | boolean | Desktop: open the last `.ezy` on launch. **Legacy:** `load_last_saved_on_startup` is read as a fallback if the newer key is absent. |

--- a/docs/usage-sketch.md
+++ b/docs/usage-sketch.md
@@ -941,7 +941,7 @@ Import a reference image (PNG, JPEG, or BMP) behind a sketch for tracing or alig
 | **Import image...** | Load PNG/JPEG/BMP into the current sketch |
 | **Remove underlay** | Clear the image from the sketch |
 | **White paper -> transparent** | Treat bright pixels as clear (typical for scanned line drawings; turn off for photos) |
-| **Tint visible lines** / **Line color** | Recolor non-transparent pixels after the white key (default yellow works on dark backgrounds) |
+| **Tint visible lines** / **Line color** | Recolor non-transparent pixels after the white key (default **amber/gold** for contrast on dark backgrounds) |
 | **Opacity** | Overall underlay transparency (**0**–**1**) |
 
 **Calibrate from sketch edges** (sketch must be **current** in the Sketch List):

--- a/docs/usage-sketch.md
+++ b/docs/usage-sketch.md
@@ -686,7 +686,7 @@ The operation axis tool allows you to define a reference *line* (a direction and
 Once the axis exists, the Options panel (under the **Sketch operation** heading) displays these controls (matching the UI):
 
 - **Mirror** button — Mirrors the currently selected sketch edges across the axis.
-- **Revolve** button (with adjacent numeric input, default **360.00**) — Revolves the selected edges or faces around the axis by the given angle (in degrees). 360° produces a full solid of revolution.
+- **Revolve** button (with adjacent numeric input, default **360.00**, and **?** help) — Revolves the selected edges or faces around the axis by the given angle (in degrees). 360° on a closed profile produces a full solid of revolution.
 - **Clear axis** button — Removes the current operation axis (required before you can define a new one).
 
 **How to Mirror:**
@@ -699,7 +699,7 @@ Once the axis exists, the Options panel (under the **Sketch operation** heading)
 1. With the Operation Axis tool active and an axis defined, select the edges or closed faces you want to revolve.
 2. (Optional) Adjust the angle in the input field next to the Revolve button (default 360.00 for a full closed revolution).
 3. Click the **Revolve** button.
-4. EzyCad creates a 3D solid by revolving the selected sketch geometry around the axis. The new 3D shape is added to the document and you are switched out of sketch mode into Normal (inspection) mode.
+4. EzyCad creates a 3D body by revolving the selected sketch geometry around the axis. When you select **edges** rather than a **face**, it does its best to convert the result into a **solid** (see [Revolve solid conversion](#revolve-solid-conversion)). The new shape is added to the document and you are switched out of sketch mode into Normal (inspection) mode.
 5. If the operation fails you will see a message such as "Revolve failed, ensure edges or faces on one side of operation axis."
 
 **Redefining the Axis:**
@@ -712,10 +712,27 @@ The controls that appear in the Options panel once an axis is defined are:
 | Control | Purpose |
 | --- | --- |
 | **Mirror** button | Mirrors selected edges across the operation axis (stays in 2D sketch). |
-| **Revolve** button + numeric field (e.g. 360.00) | Revolves selected edges or faces around the axis by the entered angle to produce a 3D solid. |
+| **Revolve** button + numeric field (e.g. 360.00) + **?** | Revolves selected edges or faces around the axis by the entered angle. Use **?** next to the angle field for solid-conversion notes. |
 | **Clear axis** button | Manually removes the current operation axis reference. |
 
 The Revolve numeric field accepts any float angle (in degrees); 360 is the most common for closed solids.
+
+### Revolve solid conversion
+
+Open CASCADE often returns a **shell** or separate **faces** when you revolve a **closed loop of edges** rather than selecting a **face**. EzyCad then does its best to convert that result into a **solid** (sewing faces when needed, then wrapping a closed shell with `MakeSolid`) so downstream tools such as **chamfer**, **fillet**, and **booleans** can work.
+
+| Selection | Typical OCCT output | After conversion |
+| --- | --- | --- |
+| Closed **face** | Solid | Unchanged (already a solid) |
+| Closed **edges** (360°) | Shell or compound of faces | Converted to solid when possible |
+| Open edge or partial angle | Surface / open shape | Left as-is (cannot close into a solid) |
+
+Use **View → Shape List → Shape info...** on the new body to confirm the root type is **Solid**. If conversion fails, try selecting the enclosed **face** instead of individual edges, or check that the profile is closed, does not cross the axis, and uses a **360°** angle.
+
+**Tips:**
+- Prefer selecting a **face** when one is available; that path usually produces a solid directly.
+- When using **edges**, select the full closed boundary of the profile.
+- Partial revolutions (angle &lt; 360°) intentionally remain open surfaces.
 
 **Important note on axis length:**
 The two points you pick define a *direction* and a point the axis passes through. The length of the drawn segment between those points is purely visual (it determines how long the reference line appears in the sketch for your convenience). It has **no effect** on the results of Mirror or Revolve. The operations always treat the axis as an infinite line in the computed direction.

--- a/docs/usage-sketch.md
+++ b/docs/usage-sketch.md
@@ -34,7 +34,7 @@ This guide covers all 2D sketching tools and operations in EzyCad. For the main 
    - ![Add Node Tool](res/icons/Sketcher_CreatePoint.png) [Add nodes](#add-node-tool)
 
 2. **Sketch Operations**
-   - ![Operation Axis Tool](res/icons/Sketcher_MirrorSketch.png) [Define operation axis](#operation-axis-tool) - Define a reference axis, then use the **Mirror** and **Revolve** controls (in the Options panel) to mirror selected sketch edges or revolve edges/faces into 3D solids.
+   - ![Operation Axis Tool](res/icons/Sketcher_MirrorSketch.png) [Operational axis](#operation-axis-tool) - Define a reference axis, then use the **Mirror** and **Revolve** controls (in the Options panel) to mirror selected sketch edges or revolve edges/faces into 3D solids.
    - ![Create Sketch from Planar Face Tool](res/icons/Macro_FaceToSketch_48.png) [Create sketch from planar face](#create-sketch-from-planar-face-tool)
 
 ## Sketch snapping
@@ -49,6 +49,7 @@ While you draw or place points in sketch mode, EzyCad helps you align to existin
 | **Mid-point snap (Add node)** | A click near a **straight** edge (not at its ends) snaps onto the segment and **splits** it at commit time (see [Add node tool](#add-node-tool)). Separate from vertex lock. |
 | **Automatic splitting on edge intersections** | When you add a new straight (linear) edge using the Line Edge tool or Multi-Line Edge tool, if it crosses or touches the interior of any existing straight edge, the existing edge is automatically split at the intersection point. The new edge is also subdivided into atomic segments where needed. The same splitting occurs when an endpoint of the new edge snaps to the midpoint of an existing edge. This produces correct T-junctions (3 edges), crossings (4 edges), and cleanly divided faces from a single sketch. Arcs have special internal handling and do not trigger the same linear splits. |
 | **Other visible sketches** | Nodes from **other visible sketches** are projected onto the current sketch plane and act as snap targets (same distance rules). Useful for multi-sketch layouts and tools such as **polar duplicate** that pick sketch points. |
+| **Operational axis mode** | While an operational axis is **defined** and **Operational axis** mode is active (mirror/revolve phase), sketch snap and permanent **+** node markers are **suppressed** so edge and face selection stays clear. Normal snapping applies again after **Clear axis** or when you leave the tool. Axis placement (before the axis exists) still uses snap. |
 
 **Angle constraint:** When a line or add-node rubber band has an active angle constraint, vertex and axis snap may be disabled or relaxed so the typed angle stays exact (see each tool's section).
 
@@ -656,7 +657,9 @@ The slot tool allows you to create an oblong or oval-shaped slot with rounded en
 
 ![Operation Axis Tool](res/icons/Sketcher_MirrorSketch.png)
 
-The operation axis tool allows you to define a reference *line* (a direction and a point it passes through) for mirroring and revolving operations in sketches. Only the direction and position matter; the length of the drawn helper segment is visual only and has no effect on the results.
+The **Operational axis** tool (toolbar tooltip: **Operational axis**) lets you define a reference *line* (a direction and a point it passes through) for mirroring and revolving operations in sketches. Only the direction and position matter; the length of the drawn helper segment is visual only and has no effect on the results.
+
+The axis reference line is **visible only while Operational axis mode is active**. If you switch to another sketch tool, the axis is hidden in the view but remains defined until you **Clear axis** or reload without it. Operational axes are **saved** in the sketch JSON when you save the project.
 
 **Features:**
 
@@ -668,18 +671,19 @@ The operation axis tool allows you to define a reference *line* (a direction and
 | **Angle constraint** | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the direction of the axis line |
 | **Mirror operations** | Use the defined axis to mirror selected edges |
 | **Revolve operations** | Use the defined axis to revolve selected edges or faces |
+| **Selection-friendly mirror/revolve** | After the axis is defined, permanent **+** markers and sketch snap are hidden so you can select edges and faces without snap clutter |
 
 **How to Use:**
 
 **Phase 1: Define the operation axis**
-1. ![Sketcher_MirrorSketch](res/icons/Sketcher_MirrorSketch.png) Select the **Operation Axis** tool from the toolbar.
+1. ![Sketcher_MirrorSketch](res/icons/Sketcher_MirrorSketch.png) Select **Operational axis** from the toolbar.
 2. Click to set the start point of the axis line on the sketch plane.
 3. Move the mouse — a live preview of the axis line follows the cursor.
 4. Click a second point (or use the input dialogs) to finalize the axis:
    - <kbd>Tab</kbd>: open distance dialog to set the length of the *drawn axis helper segment* (visual only — this length does not affect mirror or revolve operations).
    - <kbd>Shift</kbd>+<kbd>Tab</kbd>: open angle (degrees, CCW from +X) dialog to constrain direction.
    - Apply angle constraint first if using both, then length.
-5. The axis is now defined. You remain in the Operation Axis tool (this keeps the Options panel available for the Mirror/Revolve controls).
+5. The axis is now defined. You remain in Operational axis mode (this keeps the Options panel available for the Mirror/Revolve controls). Permanent **+** node markers and sketch snap are suppressed until you clear the axis or leave the tool.
 
 **Phase 2: Use Mirror or Revolve (the controls shown in the Options panel)**
 
@@ -687,24 +691,24 @@ Once the axis exists, the Options panel (under the **Sketch operation** heading)
 
 - **Mirror** button — Mirrors the currently selected sketch edges across the axis.
 - **Revolve** button (with adjacent numeric input, default **360.00**, and **?** help) — Revolves the selected edges or faces around the axis by the given angle (in degrees). 360° on a closed profile produces a full solid of revolution.
-- **Clear axis** button — Removes the current operation axis (required before you can define a new one).
+- **Clear axis** button — Removes the current operational axis (required before you can define a new one). Restores permanent node markers and sketch snap.
 
 **How to Mirror:**
-1. With the Operation Axis tool active and an axis defined, select the edges you want to mirror (click them or use a selection box; the mode stays active so normal sketch selection works for the subject geometry).
+1. With Operational axis mode active and an axis defined, select the edges you want to mirror (click them or use a selection box; snap guides and **+** markers stay hidden so selection is unobstructed).
 2. In the Options panel, click the **Mirror** button.
 3. Selected straight edges are duplicated and mirrored. Arc/circle edges are handled as pairs to preserve the geometry.
 4. The mirrored elements are added to the current sketch (the original selection remains until you change it).
 
 **How to Revolve (create 3D):**
-1. With the Operation Axis tool active and an axis defined, select the edges or closed faces you want to revolve.
+1. With Operational axis mode active and an axis defined, select the edges or closed faces you want to revolve.
 2. (Optional) Adjust the angle in the input field next to the Revolve button (default 360.00 for a full closed revolution).
 3. Click the **Revolve** button.
 4. EzyCad creates a 3D body by revolving the selected sketch geometry around the axis. When you select **edges** rather than a **face**, it does its best to convert the result into a **solid** (see [Revolve solid conversion](#revolve-solid-conversion)). The new shape is added to the document and you are switched out of sketch mode into Normal (inspection) mode.
 5. If the operation fails you will see a message such as "Revolve failed, ensure edges or faces on one side of operation axis."
 
 **Redefining the Axis:**
-- While an operation axis exists, clicks in the viewport are used to select edges or faces for Mirror/Revolve (the axis definition mode remains active so the Options panel buttons are available).
-- To redefine the axis: click the **Clear axis** button in the options panel first (this removes the current axis), then click in the viewport to place the first point of the new axis, followed by the second point (as in Phase 1 above).
+- While an operational axis exists, clicks in the viewport select edges or faces for Mirror/Revolve (Operational axis mode stays active so the Options panel buttons are available). Snap and **+** markers remain off during this phase.
+- To redefine the axis: click **Clear axis** in the options panel first (this removes the current axis and restores snap/markers), then click in the viewport to place the first point of the new axis, followed by the second point (as in Phase 1 above).
 
 **Using the Operation Axis (UI reference):**
 The controls that appear in the Options panel once an axis is defined are:
@@ -755,11 +759,12 @@ The two points you pick define a *direction* and a point the axis passes through
 - **Note**: When an angle constraint is active, snapping to nodes is disabled to maintain the angle precision
 
 **Tips:**
-- The operation axis is a reference *line* (direction + any point it passes through). Its drawn length is visual only and has no effect on mirror or revolve results.
-- Select edges or faces (while the Operation Axis tool is active) before using the Mirror or Revolve buttons in the options panel
-- To redefine the axis, first use the **Clear axis** button, then click to place the new axis points
-- Use snap points for precise axis placement relative to existing geometry
-- Constraining the angle when placing the axis is useful for precise directional reference lines (e.g. for future snapping operations)
+- The operational axis is a reference *line* (direction + any point it passes through). Its drawn length is visual only and has no effect on mirror or revolve results.
+- The axis line is drawn only while **Operational axis** mode is active; other sketch tools hide it from the view without clearing the stored axis.
+- Select edges or faces (while Operational axis mode is active) before using the Mirror or Revolve buttons in the options panel
+- To redefine the axis, first use **Clear axis**, then place the new axis points (snap works again during placement)
+- Use snap points for precise axis placement relative to existing geometry (Phase 1 only)
+- Constraining the angle when placing the axis is useful for precise directional reference lines
 - You can make the drawn axis segment long or short via <kbd>Tab</kbd> purely for visibility/clarity — it does not change the behavior of the operations
 
 ## Dimension Tool

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,6 +59,7 @@ EzyCad (Easy CAD) is an open-source CAD application for hobbyist machinists to d
 
 4. **Shape List**
    - [List 3D solids, materials, and display options](#shape-list)
+   - [Inspect shape topology and properties](#shape-info)
 
 5. **Options Panel**
    - The top of the panel always shows the name of the current tool/mode (matching the toolbar tooltip), followed immediately by a small **"?"** button. Clicking the "?" opens the online user guide directly to the section describing that specific tool (contextual help; see the per-mode links in the source `get_doc_url_for_mode` map).
@@ -112,14 +113,29 @@ At the top:
 For each shape, one row includes:
 
 - **Name** - Editable text field; change the label stored with the shape.
-- **Right-click the name** - **Delete** removes the shape from the document.
+- **Right-click the name** - **Shape info...** opens a dialog with topology and property details for that shape (see [Shape info](#shape-info) below). **Delete** removes the shape from the document.
 - **Visibility** - Checkbox (tooltip *visibility*) to show or hide that shape in the 3D view.
 - **Solid / wire** - Checkbox (tooltip *solid/wire*) to switch **shaded** display or **wireframe** for that shape.
-- **M** - Click to open a **Material** popup; right-click **M** for **Delete**. The tooltip on **M** also notes that right-clicking the name deletes the shape.
+- **M** - Click to open a **Material** popup; right-click **M** for **Shape info...** or **Delete**. The tooltip on **M** also notes that right-clicking the name deletes the shape.
 
 Rows that match the **current 3D selection** are drawn with a slightly brighter style so the list stays in sync with what is selected in the viewer (tooltip *Selected in 3D viewer* when you hover the highlighted row).
 
 The window can be closed with its close button; use **View -> Shape List** again to show it.
+
+#### Shape info
+
+Right-click a shape **name** or the **M** button in the Shape List and choose **Shape info...** to open a property dialog for that 3D shape. Use **Refresh** to recompute the values after the geometry changes.
+
+The dialog reports document fields (name, material, shaded vs wireframe display, visibility) and Open CASCADE (OCCT) topology and measurements, including:
+
+| Category | Examples |
+| --- | --- |
+| **Topology** | Root type (Solid, Shell, Face, Compound, etc.), validity, whether the shape has a location transform, closed-shell flag when the root is a shell |
+| **Counts** | Compounds, CompSolids, Solids, Shells, Faces, Wires, Edges, Vertices (nested sub-shapes included) |
+| **Bounds** | Axis-aligned bounding box min/max and overall size |
+| **Mass properties** | Volume and center of mass (when the shape encloses volume), surface area, length (for wire-like geometry) |
+
+This is useful after **Revolve**, **Extrude**, booleans, or imports when you need to confirm whether a result is a closed **Solid** or an open **Shell** / surface, or to check face and edge counts and overall size. The dialog closes automatically if the shape is deleted from the document.
 
 ## Scripting (Lua and Python)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -762,7 +762,7 @@ Contributors should follow **[ezycad_code_style.md](ezycad_code_style.md)** for 
 ### Sketch Tools
 - ![Workbench_Sketcher_none](res/icons/Workbench_Sketcher_none.png) - Sketch inspection mode
 - ![Macro_FaceToSketch_48](res/icons/Macro_FaceToSketch_48.png) - Create sketch from planar face
-- ![Sketcher_MirrorSketch](res/icons/Sketcher_MirrorSketch.png) - Define operation axis (then use Mirror/Revolve buttons + angle field in the Options panel; Clear axis)
+- ![Sketcher_MirrorSketch](res/icons/Sketcher_MirrorSketch.png) - Operational axis (then use Mirror/Revolve buttons + angle field in the Options panel; Clear axis)
 - ![Sketcher_CreatePoint](res/icons/Sketcher_CreatePoint.png) - Add node
 - ![Sketcher_Element_Line_Edge](res/icons/Sketcher_Element_Line_Edge.png) - Add line edge
 - ![ls](res/icons/ls.png) - Add multi-line edge

--- a/res/ezycad_settings.json
+++ b/res/ezycad_settings.json
@@ -22,7 +22,7 @@
     "add_mid_pt_edges": false,
     "underlay_highlight_color": [
       1.0,
-      0.8627451062202454,
+      0.8627450980392157,
       0.0
     ],
     "shape_list_hover_color": [

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -179,7 +179,7 @@ void GUI::initialize_toolbar_()
       {load_texture("res/icons/Part_Scale.png"), false, "Shape Scale (s)", Mode::Scale},
       {load_texture("res/icons/Macro_FaceToSketch_48.png"), false, "Create a sketch from planar face",
        Mode::Sketch_from_planar_face},
-      {load_texture("res/icons/Sketcher_MirrorSketch.png"), false, "Define operation axis", Mode::Sketch_operation_axis},
+      {load_texture("res/icons/Sketcher_MirrorSketch.png"), false, "Operational axis", Mode::Sketch_operation_axis},
       {load_texture("res/icons/Sketcher_CreatePoint.png"), false, "Add node", Mode::Sketch_add_node},
       {load_texture("res/icons/Sketcher_Element_Line_Edge.png"), false, "Add line edge", Mode::Sketch_add_edge},
       {load_texture("res/icons/ls.png"), false, "Add multi-line edge", Mode::Sketch_add_multi_edges},
@@ -1148,7 +1148,7 @@ void GUI::sketch_list_()
 
       if (ui_show_contextual_help() && ImGui::IsItemHovered())
         ImGui::SetTooltip(expanded ? "Collapse details" : "Expand details");
-      
+
       ImGui::PopID();
 
       ImGui::SameLine();
@@ -1405,8 +1405,8 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
 
   ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
   GUI_DOC_HELP_("Import PNG/JPEG/BMP as a sketch underlay. Adjust half-width, half-height, center, and rotation to match "
-                   "real dimensions; changes apply in real time. Click ? to open the user guide.",
-                   doc_urls::k_image_underlay);
+                "real dimensions; changes apply in real time. Click ? to open the user guide.",
+                doc_urls::k_image_underlay);
 
   if (!sk->has_underlay())
     return;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -28,6 +28,7 @@
 #include "lua_console.h"
 #include "occt_view.h"
 #include "python_console.h"
+#include "shp_info.h"
 #include "sketch.h"
 #include "utl.h"
 #include "version.h"
@@ -148,6 +149,7 @@ void GUI::render_gui()
   sketch_list_();
   sketch_properties_dialog_();
   shape_list_();
+  shape_info_dialog_();
   options_();
   message_status_window_();
   about_dialog_();
@@ -1374,7 +1376,7 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
       m_underlay_vis          = true;
       m_underlay_key_white    = true;
       m_underlay_line_tint    = true;
-      m_underlay_tint_col     = glm::vec4(1.f, 0.863f, 0.f, 1.f);
+      m_underlay_tint_col     = glm::vec4(1.f, 220.f / 255.f, 0.f, 1.f);
     }
   }
 
@@ -1421,7 +1423,7 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
 
   if (ui_show_contextual_help() && ImGui::IsItemHovered())
     ImGui::SetTooltip("Paints non-transparent pixels (after white key) with the line color. "
-                      "Default yellow reads well on dark backgrounds.");
+                      "Default amber/gold contrasts with the dark view and cyan frame.");
 
   if (m_underlay_line_tint)
     if (ImGui::ColorEdit4("Line color", &m_underlay_tint_col[0]))
@@ -2130,6 +2132,9 @@ void GUI::shape_list_()
 
     if (ImGui::BeginPopupContextItem("shape_name_ctx"))
     {
+      if (ImGui::MenuItem("Shape info..."))
+        open_shape_info_(shape);
+
       if (ImGui::MenuItem("Delete"))
         shape_to_delete = shape;
 
@@ -2195,6 +2200,9 @@ void GUI::shape_list_()
 
     if (ImGui::BeginPopupContextItem("mat_btn_ctx"))
     {
+      if (ImGui::MenuItem("Shape info..."))
+        open_shape_info_(shape);
+
       if (ImGui::MenuItem("Delete"))
         shape_to_delete = shape;
 
@@ -2222,6 +2230,112 @@ void GUI::shape_list_()
     m_view->delete_shapes({shape_to_delete});
 
   ImGui::EndChild();
+  ImGui::End();
+}
+
+void GUI::open_shape_info_(const Shp_ptr& shape)
+{
+  if (shape.IsNull())
+    return;
+
+  const std::vector<std::string>& mat_names = occt_material_combo_labels_();
+  int                             mat_idx   = shape->Material();
+  if (mat_idx < 0 || mat_idx >= static_cast<int>(mat_names.size()))
+    mat_idx = static_cast<int>(m_view->get_default_material().Name());
+
+  shp_info::Display_meta meta;
+  meta.name         = shape->get_name();
+  meta.material     = mat_names[static_cast<size_t>(mat_idx)];
+  meta.display_mode = shape->get_disp_mode() == AIS_Shaded ? "Shaded" : "Wireframe";
+  meta.visible      = shape->get_visible();
+
+  m_shape_info_shp   = shape;
+  m_shape_info_lines = shp_info::collect(shape->Shape(), &meta);
+  m_shape_info_open  = true;
+}
+
+void GUI::shape_info_dialog_()
+{
+  if (!m_shape_info_open)
+    return;
+
+  if (m_shape_info_shp.IsNull())
+  {
+    m_shape_info_open = false;
+    return;
+  }
+
+  bool shape_still_exists = false;
+  for (const Shp_ptr& s : m_view->get_shapes())
+  {
+    if (s == m_shape_info_shp)
+    {
+      shape_still_exists = true;
+      break;
+    }
+  }
+
+  if (!shape_still_exists)
+  {
+    m_shape_info_open = false;
+    m_shape_info_shp.Nullify();
+    m_shape_info_lines.clear();
+    return;
+  }
+
+  const std::string title = "Shape info: " + m_shape_info_shp->get_name();
+  ImGui::SetNextWindowSize(ImVec2(440.0f, 0.0f), ImGuiCond_FirstUseEver);
+  bool open = m_shape_info_open;
+  if (!ImGui::Begin(title.c_str(), &open, ImGuiWindowFlags_None))
+  {
+    m_shape_info_open = open;
+    ImGui::End();
+    return;
+  }
+
+  if (ImGui::Button("Refresh"))
+    open_shape_info_(m_shape_info_shp);
+
+  ImGui::Separator();
+
+  const float max_h = ImGui::GetTextLineHeightWithSpacing() * 18.0f;
+  if (ImGui::BeginChild("shape_info_scroll", ImVec2(0.0f, max_h), ImGuiChildFlags_Borders,
+                        ImGuiWindowFlags_AlwaysVerticalScrollbar))
+  {
+    if (ImGui::BeginTable("shape_info_tbl", 2, ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_RowBg))
+    {
+      ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, 120.0f);
+      ImGui::TableSetupColumn("value", ImGuiTableColumnFlags_WidthStretch);
+
+      for (const shp_info::Line& line : m_shape_info_lines)
+      {
+        if (line.label.empty() && line.value.empty())
+        {
+          ImGui::TableNextRow();
+          ImGui::TableSetColumnIndex(0);
+          ImGui::Separator();
+          ImGui::TableSetColumnIndex(1);
+          ImGui::Separator();
+          continue;
+        }
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::TextUnformatted(line.label.c_str());
+        ImGui::TableSetColumnIndex(1);
+        ImGui::TextUnformatted(line.value.c_str());
+      }
+
+      ImGui::EndTable();
+    }
+
+    ImGui::EndChild();
+  }
+
+  m_shape_info_open = open;
+  if (!open)
+    m_shape_info_shp.Nullify();
+
   ImGui::End();
 }
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2055,9 +2055,13 @@ void GUI::shape_list_()
 
   // Add checkbox for hiding all shapes except current sketches
   if (ImGui::Checkbox("Hide all", &m_hide_all_shapes))
+  {
+    if (m_hide_all_shapes)
+      m_view->set_shape_list_hover(nullptr);
     // Update visibility of all shapes based on the new state
     for (const Shp_ptr& shape : m_view->get_shapes())
       shape->set_visible(!m_hide_all_shapes);
+  }
 
   ImGui::Separator();
 
@@ -2147,7 +2151,11 @@ void GUI::shape_list_()
     ImGui::PushID(("visible" + id_suffix).c_str());
     bool visible = shape->get_visible();
     if (ImGui::Checkbox("", &visible))
+    {
+      if (!visible && m_view->shape_list_hover() == shape)
+        m_view->set_shape_list_hover(nullptr);
       shape->set_visible(visible);
+    }
 
     if (ui_show_contextual_help() && ImGui::IsItemHovered())
       ImGui::SetTooltip("visibility");

--- a/src/gui.h
+++ b/src/gui.h
@@ -107,6 +107,8 @@ inline constexpr const char* k_sketch_snapping           = "https://ezycad.readt
 inline constexpr const char* k_line_edge_midpoint_nodes  = "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#line-edge-option-add-midpoint-nodes";
 inline constexpr const char* k_line_edge_place_from_center =
     "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#line-edge-option-place-from-center";
+inline constexpr const char* k_revolve_solid_conversion =
+    "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#revolve-solid-conversion";
 inline constexpr const char* k_shape_selection_filter    = "https://ezycad.readthedocs.io/en/latest/usage.html#shape-selection-filter-normal-mode-only";
 inline constexpr const char* k_add_node_tool             = "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#add-node-tool";
 inline constexpr const char* k_image_underlay            = "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#image-underlay";

--- a/src/gui.h
+++ b/src/gui.h
@@ -21,6 +21,7 @@
 #include "log.h"
 #include "modes.h"
 #include "occt_view.h"
+#include "shp_info.h"
 #include "types.h"
 
 class Lua_console;
@@ -251,6 +252,8 @@ private:
   void sketch_list_inspector_(Sketch& sketch, int index);
   void sketch_properties_dialog_();
   void shape_list_();
+  void shape_info_dialog_();
+  void open_shape_info_(const Shp_ptr& shape);
 
   // Mode + Options panel (gui_mode.cpp)
   void options_();
@@ -437,6 +440,9 @@ private:
   bool        m_show_settings_dialog{false};
   bool        m_open_about_popup{false};
   bool        m_about_popup_open{false};
+  bool        m_shape_info_open{false};
+  Shp_ptr     m_shape_info_shp;
+  std::vector<shp_info::Line> m_shape_info_lines;
   std::string m_about_markdown;
   uint32_t    m_about_splash_gl{0};
   glm::ivec2  m_about_splash_size{512, 512};

--- a/src/gui.h
+++ b/src/gui.h
@@ -101,20 +101,23 @@ inline constexpr int k_gui_ui_contextual_help_min_verbosity = 5;
 
 namespace doc_urls
 {
-inline constexpr const char* k_view_roll                 = "https://ezycad.readthedocs.io/en/latest/usage.html#view-roll";
-inline constexpr const char* k_view_navigation           = "https://ezycad.readthedocs.io/en/latest/usage.html#view-navigation";
-inline constexpr const char* k_sketch_snapping           = "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#sketch-snapping";
-inline constexpr const char* k_line_edge_midpoint_nodes  = "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#line-edge-option-add-midpoint-nodes";
+inline constexpr const char* k_view_roll       = "https://ezycad.readthedocs.io/en/latest/usage.html#view-roll";
+inline constexpr const char* k_view_navigation = "https://ezycad.readthedocs.io/en/latest/usage.html#view-navigation";
+inline constexpr const char* k_sketch_snapping = "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#sketch-snapping";
+inline constexpr const char* k_line_edge_midpoint_nodes =
+    "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#line-edge-option-add-midpoint-nodes";
 inline constexpr const char* k_line_edge_place_from_center =
     "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#line-edge-option-place-from-center";
 inline constexpr const char* k_revolve_solid_conversion =
     "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#revolve-solid-conversion";
-inline constexpr const char* k_shape_selection_filter    = "https://ezycad.readthedocs.io/en/latest/usage.html#shape-selection-filter-normal-mode-only";
-inline constexpr const char* k_add_node_tool             = "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#add-node-tool";
-inline constexpr const char* k_image_underlay            = "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#image-underlay";
-inline constexpr const char* k_usage_settings_options      = "https://ezycad.readthedocs.io/en/latest/usage-settings.html#options-panel";
-inline constexpr const char* k_occt_view                   = "https://ezycad.readthedocs.io/en/latest/usage-occt-view.html";
-inline constexpr const char* k_startup_project             = "https://ezycad.readthedocs.io/en/latest/usage-settings.html#startup-project";
+inline constexpr const char* k_shape_selection_filter =
+    "https://ezycad.readthedocs.io/en/latest/usage.html#shape-selection-filter-normal-mode-only";
+inline constexpr const char* k_add_node_tool  = "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#add-node-tool";
+inline constexpr const char* k_image_underlay = "https://ezycad.readthedocs.io/en/latest/usage-sketch.html#image-underlay";
+inline constexpr const char* k_usage_settings_options =
+    "https://ezycad.readthedocs.io/en/latest/usage-settings.html#options-panel";
+inline constexpr const char* k_occt_view       = "https://ezycad.readthedocs.io/en/latest/usage-occt-view.html";
+inline constexpr const char* k_startup_project = "https://ezycad.readthedocs.io/en/latest/usage-settings.html#startup-project";
 } // namespace doc_urls
 
 class GUI
@@ -283,12 +286,11 @@ private:
   void options_sketch_add_slot_mode_();
 
   // Options related helpers
-  void  options_doc_help_button_();
-  void  doc_help_button_(const char* scope, int line, const char* tooltip, const char* doc_url,
-                         bool trailing_same_line = false);
-  void  options_orthographic_projection_();
-  void  options_sketch_common_();
-  void  options_sketch_len_angle_hotkeys_();
+  void options_doc_help_button_();
+  void doc_help_button_(const char* scope, int line, const char* tooltip, const char* doc_url, bool trailing_same_line = false);
+  void options_orthographic_projection_();
+  void options_sketch_common_();
+  void options_sketch_len_angle_hotkeys_();
   float options_sketch_label_col_w_() const;
 
   void on_key_move_mode_(int key);
@@ -388,22 +390,22 @@ private:
   bool                             m_angle_edit_focus_pending{false};
 
   // Mode related
-  Mode         m_mode                              = Mode::Normal;
-  Chamfer_mode m_chamfer_mode                      = Chamfer_mode::Shape;
-  Fillet_mode  m_fillet_mode                       = Fillet_mode::Shape;
-  int          m_edge_dim_label_h                  = 3;
-  float        m_edge_dim_line_width               = k_gui_edge_dim_line_width_default;
-  float        m_edge_dim_arrow_size               = k_gui_edge_dim_arrow_size_default;
-  float        m_edge_dim_color[3]                 = {k_gui_edge_dim_color_default[0], k_gui_edge_dim_color_default[1],
-                                                      k_gui_edge_dim_color_default[2]};
-  float        m_edge_dim_text_scale               = k_gui_edge_dim_text_scale_default;
-  int          m_edge_dim_arrow_style              = 0;
-  int          m_edge_dim_arrow_orientation        = 0;
-  int          m_edge_dim_text_render_mode         = k_gui_edge_dim_text_render_mode_default;
-  bool         m_show_sketch_dimensions            = true;
-  float        m_permanent_node_anno_scale         = k_gui_permanent_node_anno_scale_default;
-  bool         m_add_mid_pt_edges = false;
-  bool         m_edge_from_center = false;
+  Mode         m_mode                       = Mode::Normal;
+  Chamfer_mode m_chamfer_mode               = Chamfer_mode::Shape;
+  Fillet_mode  m_fillet_mode                = Fillet_mode::Shape;
+  int          m_edge_dim_label_h           = 3;
+  float        m_edge_dim_line_width        = k_gui_edge_dim_line_width_default;
+  float        m_edge_dim_arrow_size        = k_gui_edge_dim_arrow_size_default;
+  float        m_edge_dim_color[3]          = {k_gui_edge_dim_color_default[0], k_gui_edge_dim_color_default[1],
+                                               k_gui_edge_dim_color_default[2]};
+  float        m_edge_dim_text_scale        = k_gui_edge_dim_text_scale_default;
+  int          m_edge_dim_arrow_style       = 0;
+  int          m_edge_dim_arrow_orientation = 0;
+  int          m_edge_dim_text_render_mode  = k_gui_edge_dim_text_render_mode_default;
+  bool         m_show_sketch_dimensions     = true;
+  float        m_permanent_node_anno_scale  = k_gui_permanent_node_anno_scale_default;
+  bool         m_add_mid_pt_edges           = false;
+  bool         m_edge_from_center           = false;
   /// Degrees per numpad orbit (8/2/4/6) and Blender-style roll (Shift+NumPad 4/6); persisted in `gui.view_roll_step_deg`.
   double m_view_roll_step_deg = k_gui_view_roll_step_deg_default;
   /// Multiplier for `UpdateZoom(Aspect_ScrollDelta(..., int(y * scale)))`; persisted in `gui.view_zoom_scroll_scale`.
@@ -436,43 +438,43 @@ private:
 
   std::unordered_map<const Sketch*, bool> m_sketch_list_expanded;
 
-  bool        m_show_sketch_list{true};
-  bool        m_show_shape_list{true};
-  bool        m_show_options{true};
-  bool        m_show_settings_dialog{false};
-  bool        m_open_about_popup{false};
-  bool        m_about_popup_open{false};
-  bool        m_shape_info_open{false};
-  Shp_ptr     m_shape_info_shp;
+  bool                        m_show_sketch_list{true};
+  bool                        m_show_shape_list{true};
+  bool                        m_show_options{true};
+  bool                        m_show_settings_dialog{false};
+  bool                        m_open_about_popup{false};
+  bool                        m_about_popup_open{false};
+  bool                        m_shape_info_open{false};
+  Shp_ptr                     m_shape_info_shp;
   std::vector<shp_info::Line> m_shape_info_lines;
-  std::string m_about_markdown;
-  uint32_t    m_about_splash_gl{0};
-  glm::ivec2  m_about_splash_size{512, 512};
-  bool        m_about_assets_loaded{false};
-  bool        m_open_add_box_popup{false};
-  glm::dvec3  m_add_box_origin{0.0, 0.0, 0.0};
-  glm::dvec3  m_add_box_size{1.0, 1.0, 1.0};
-  bool        m_open_add_pyramid_popup{false};
-  glm::dvec3  m_add_pyramid_origin{0.0, 0.0, 0.0};
-  double      m_add_pyramid_side{1};
-  bool        m_open_add_sphere_popup{false};
-  glm::dvec3  m_add_sphere_origin{0.0, 0.0, 0.0};
-  double      m_add_sphere_radius{1};
-  bool        m_open_add_cylinder_popup{false};
-  glm::dvec3  m_add_cylinder_origin{0.0, 0.0, 0.0};
-  double      m_add_cylinder_radius{1}, m_add_cylinder_height{1};
-  bool        m_open_add_cone_popup{false};
-  glm::dvec3  m_add_cone_origin{0.0, 0.0, 0.0};
-  double      m_add_cone_R1{1}, m_add_cone_R2{0}, m_add_cone_height{1};
-  bool        m_open_add_torus_popup{false};
-  glm::dvec3  m_add_torus_origin{0.0, 0.0, 0.0};
-  double      m_add_torus_R1{1}, m_add_torus_R2{0.5};
-  bool        m_open_add_sketch_popup{false};
-  int         m_new_sketch_plane{0}; // 0=XY, 1=XZ, 2=YZ
-  double      m_new_sketch_offset{};
-  bool        m_hide_all_shapes{false};
-  int         m_ui_verbosity{k_gui_ui_verbosity_default};
-  bool        m_dark_mode{false};
+  std::string                 m_about_markdown;
+  uint32_t                    m_about_splash_gl{0};
+  glm::ivec2                  m_about_splash_size{512, 512};
+  bool                        m_about_assets_loaded{false};
+  bool                        m_open_add_box_popup{false};
+  glm::dvec3                  m_add_box_origin{0.0, 0.0, 0.0};
+  glm::dvec3                  m_add_box_size{1.0, 1.0, 1.0};
+  bool                        m_open_add_pyramid_popup{false};
+  glm::dvec3                  m_add_pyramid_origin{0.0, 0.0, 0.0};
+  double                      m_add_pyramid_side{1};
+  bool                        m_open_add_sphere_popup{false};
+  glm::dvec3                  m_add_sphere_origin{0.0, 0.0, 0.0};
+  double                      m_add_sphere_radius{1};
+  bool                        m_open_add_cylinder_popup{false};
+  glm::dvec3                  m_add_cylinder_origin{0.0, 0.0, 0.0};
+  double                      m_add_cylinder_radius{1}, m_add_cylinder_height{1};
+  bool                        m_open_add_cone_popup{false};
+  glm::dvec3                  m_add_cone_origin{0.0, 0.0, 0.0};
+  double                      m_add_cone_R1{1}, m_add_cone_R2{0}, m_add_cone_height{1};
+  bool                        m_open_add_torus_popup{false};
+  glm::dvec3                  m_add_torus_origin{0.0, 0.0, 0.0};
+  double                      m_add_torus_R1{1}, m_add_torus_R2{0.5};
+  bool                        m_open_add_sketch_popup{false};
+  int                         m_new_sketch_plane{0}; // 0=XY, 1=XZ, 2=YZ
+  double                      m_new_sketch_offset{};
+  bool                        m_hide_all_shapes{false};
+  int                         m_ui_verbosity{k_gui_ui_verbosity_default};
+  bool                        m_dark_mode{false};
 #ifndef NDEBUG
   bool m_show_dbg{false};
 #endif

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -111,8 +111,7 @@ std::string GUI::get_doc_url_for_mode(Mode mode)
 void GUI::options_doc_help_button_()
 {
   ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
-  GUI_DOC_HELP_("Open the relevant section of the online user guide.",
-                   get_doc_url_for_mode(get_mode()).c_str());
+  GUI_DOC_HELP_("Open the relevant section of the online user guide.", get_doc_url_for_mode(get_mode()).c_str());
 }
 
 void GUI::set_mode(Mode mode)
@@ -470,8 +469,8 @@ void GUI::options_normal_mode_()
     }
     ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
     GUI_DOC_HELP_("Hotkeys: 1-9 (Normal mode) set filter when the 3D view has focus, not while typing in UI. Click ? to "
-                     "open the user guide.",
-                     doc_urls::k_shape_selection_filter);
+                  "open the user guide.",
+                  doc_urls::k_shape_selection_filter);
 
     ImGui::EndTable();
   }
@@ -801,9 +800,9 @@ void GUI::options_sketch_operation_axis_mode_()
     ImGui::InputFloat("##float_value", &revolve_angle, 0.0f, 0.0f, "%.2f");
     ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
     GUI_DOC_HELP_("Revolve angle in degrees (360 for a full revolution). When edges are selected instead of a face, "
-                     "EzyCad does its best to convert the result from a shell or faces into a solid. Open profiles or "
-                     "partial angles may remain surfaces. Click ? to open the user guide.",
-                     doc_urls::k_revolve_solid_conversion);
+                  "EzyCad does its best to convert the result from a shell or faces into a solid. Open profiles or "
+                  "partial angles may remain surfaces. Click ? to open the user guide.",
+                  doc_urls::k_revolve_solid_conversion);
 
     if (ImGui::Button("Clear axis"))
       m_view->curr_sketch().clear_operation_axis();
@@ -901,8 +900,8 @@ void GUI::options_sketch_add_edge_mode_()
     }
     ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
     GUI_DOC_HELP_("When on, new linear edges get an automatic midpoint node (used for snapping to edge centers). "
-                     "Default is off. Click ? to open the user guide.",
-                     doc_urls::k_line_edge_midpoint_nodes);
+                  "Default is off. Click ? to open the user guide.",
+                  doc_urls::k_line_edge_midpoint_nodes);
 
     bool from_center = m_edge_from_center;
     if (ImGui::Checkbox("Place from center", &from_center))
@@ -912,8 +911,8 @@ void GUI::options_sketch_add_edge_mode_()
     }
     ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
     GUI_DOC_HELP_("First click sets the edge midpoint. The second click or Tab length input uses the full edge "
-                     "length. Click ? to open the user guide.",
-                     doc_urls::k_line_edge_place_from_center);
+                  "length. Click ? to open the user guide.",
+                  doc_urls::k_line_edge_place_from_center);
   }
 }
 
@@ -939,8 +938,8 @@ void GUI::options_sketch_add_multi_line_edge_mode_()
     }
     ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
     GUI_DOC_HELP_("When on, new linear edges get an automatic midpoint node (used for snapping to edge centers). "
-                     "Default is off. Click ? to open the user guide.",
-                     doc_urls::k_line_edge_midpoint_nodes);
+                  "Default is off. Click ? to open the user guide.",
+                  doc_urls::k_line_edge_midpoint_nodes);
   }
 }
 
@@ -1011,8 +1010,8 @@ void GUI::options_orthographic_projection_()
   }
   ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
   GUI_DOC_HELP_("Use an orthographic camera in non-sketch modes (no perspective foreshortening). Click ? to open the user "
-                   "guide.",
-                   doc_urls::k_usage_settings_options);
+                "guide.",
+                doc_urls::k_usage_settings_options);
 }
 
 void GUI::options_sketch_common_()
@@ -1058,8 +1057,8 @@ void GUI::options_sketch_common_()
 
     ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
     GUI_DOC_HELP_("Traditional: compact local snap marker.\nFullscreen: full-view crosshair/axis guides.\nBoth: show "
-                     "compact marker and fullscreen guides together. Click ? to open the user guide.",
-                     doc_urls::k_sketch_snapping);
+                  "compact marker and fullscreen guides together. Click ? to open the user guide.",
+                  doc_urls::k_sketch_snapping);
 
     ImGui::TableNextRow();
     ImGui::TableSetColumnIndex(0);
@@ -1071,9 +1070,9 @@ void GUI::options_sketch_common_()
 
     ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
     GUI_DOC_HELP_("When on (global mode): axis guide lines + markers for *all* nodes in the current sketch and all "
-                     "other visible sketches. When off (default): only closest node per active axis is annotated. Click ? "
-                     "to open the user guide.",
-                     doc_urls::k_sketch_snapping);
+                  "other visible sketches. When off (default): only closest node per active axis is annotated. Click ? "
+                  "to open the user guide.",
+                  doc_urls::k_sketch_snapping);
 
     ImGui::EndTable();
   }

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -799,6 +799,11 @@ void GUI::options_sketch_operation_axis_mode_()
     ImGui::SetNextItemWidth(80.0f);
     ImGui::SameLine();
     ImGui::InputFloat("##float_value", &revolve_angle, 0.0f, 0.0f, "%.2f");
+    ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+    GUI_DOC_HELP_("Revolve angle in degrees (360 for a full revolution). When edges are selected instead of a face, "
+                     "EzyCad does its best to convert the result from a shell or faces into a solid. Open profiles or "
+                     "partial angles may remain surfaces. Click ? to open the user guide.",
+                     doc_urls::k_revolve_solid_conversion);
 
     if (ImGui::Button("Clear axis"))
       m_view->curr_sketch().clear_operation_axis();

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -319,9 +319,10 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
         parse_bounded_float(k_gui_key_permanent_node_anno_scale, k_gui_permanent_node_anno_scale_min,
                             k_gui_permanent_node_anno_scale_max, k_gui_permanent_node_anno_scale_default);
     m_add_mid_pt_edges = b("add_mid_pt_edges", false);
-    if (g.contains("add_midpoints_to_linear_edges") && !g.contains("add_mid_pt_edges") && g["add_midpoints_to_linear_edges"].is_boolean())
+    if (g.contains("add_midpoints_to_linear_edges") && !g.contains("add_mid_pt_edges") &&
+        g["add_midpoints_to_linear_edges"].is_boolean())
       m_add_mid_pt_edges = g["add_midpoints_to_linear_edges"].get<bool>();
-    m_load_last_opened_on_startup       = b("load_last_opened_on_startup", b("load_last_saved_on_startup", false));
+    m_load_last_opened_on_startup = b("load_last_opened_on_startup", b("load_last_saved_on_startup", false));
     if (g.contains("last_opened_project_path") && g["last_opened_project_path"].is_string())
       m_last_opened_project_path = g["last_opened_project_path"].get<std::string>();
     else if (g.contains("last_saved_project_path") && g["last_saved_project_path"].is_string())
@@ -594,8 +595,8 @@ void GUI::settings_()
 
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       GUI_DOC_HELP_("Degrees per key press: NumPad 8/2/4/6 orbit (like LMB drag), Shift+NumPad 4/6, Shift+4/6, or "
-                       "Shift+Left/Right roll. Ctrl+click the slider to type a value. Click ? to open the user guide.",
-                       doc_urls::k_view_roll);
+                    "Shift+Left/Right roll. Ctrl+click the slider to type a value. Click ? to open the user guide.",
+                    doc_urls::k_view_roll);
 
       ImGui::TableNextRow();
       ImGui::TableSetColumnIndex(0);
@@ -618,9 +619,9 @@ void GUI::settings_()
 
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       GUI_DOC_HELP_("Multiplier for mouse wheel and +/- zoom (same as UpdateZoom scroll delta). Hold Shift while "
-                       "zooming for Blender-style finer steps (x0.1). Ctrl+click to type a value. Click ? to open the "
-                       "user guide.",
-                       doc_urls::k_view_navigation);
+                    "zooming for Blender-style finer steps (x0.1). Ctrl+click to type a value. Click ? to open the "
+                    "user guide.",
+                    doc_urls::k_view_navigation);
 
       ImGui::EndTable();
     }
@@ -655,8 +656,7 @@ void GUI::settings_()
       ImGui::TableSetColumnIndex(1);
       r_changed |= ImGui::SliderFloat("##round_scr", &m_imgui_rounding_scroll, 0.f, 16.f, "%.0f");
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
-      GUI_DOC_HELP_("Scrollbars and sliders applies the same radius to scrollbar tracks and slider grabs.",
-                       nullptr);
+      GUI_DOC_HELP_("Scrollbars and sliders applies the same radius to scrollbar tracks and slider grabs.", nullptr);
 
       ImGui::TableNextRow();
       ImGui::TableSetColumnIndex(0);
@@ -733,8 +733,8 @@ void GUI::settings_()
           ImGui::ColorEdit4("##shape_list_hover", &m_shape_list_hover_color[0], ImGuiColorEditFlags_Float);
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       GUI_DOC_HELP_("Highlight color when hovering a row in the Shape List pane. Updates immediately if a shape is "
-                       "hovered.",
-                       doc_urls::k_occt_view);
+                    "hovered.",
+                    doc_urls::k_occt_view);
       ImGui::EndTable();
     }
     if (shape_list_hover_changed)
@@ -780,8 +780,8 @@ void GUI::settings_()
       }
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       GUI_DOC_HELP_("Show or hide the OCCT reference grid in the 3D view. When shown, the grid lies on the active "
-                       "sketch plane. Click ? to open the user guide.",
-                       doc_urls::k_occt_view);
+                    "sketch plane. Click ? to open the user guide.",
+                    doc_urls::k_occt_view);
 
       ImGui::TableNextRow();
       ImGui::TableSetColumnIndex(0);
@@ -816,8 +816,8 @@ void GUI::settings_()
         geom_changed = true;
       ImGui::SameLine(0.f, ImGui::GetStyle().ItemInnerSpacing.x);
       GUI_DOC_HELP_("Full width of the drawn grid on X (edge to edge through the center). Same length scale as sketch "
-                       "dimensions. OCCT uses half this value internally. Click ? to open the user guide.",
-                       doc_urls::k_occt_view);
+                    "dimensions. OCCT uses half this value internally. Click ? to open the user guide.",
+                    doc_urls::k_occt_view);
 
       ImGui::TableNextRow();
       ImGui::TableSetColumnIndex(0);
@@ -828,8 +828,8 @@ void GUI::settings_()
         geom_changed = true;
       ImGui::SameLine(0.f, ImGui::GetStyle().ItemInnerSpacing.x);
       GUI_DOC_HELP_("Full height of the drawn grid on Y (edge to edge through the center). OCCT uses half this value "
-                       "internally. Click ? to open the user guide.",
-                       doc_urls::k_occt_view);
+                    "internally. Click ? to open the user guide.",
+                    doc_urls::k_occt_view);
 
       ImGui::TableNextRow();
       ImGui::TableSetColumnIndex(0);
@@ -882,8 +882,7 @@ void GUI::settings_()
             dim_changed           = true;
           }
           ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
-          GUI_DOC_HELP_("Thickness of sketch edge length dimensions (Open CASCADE line width scale; 1.0 = default).",
-                           nullptr);
+          GUI_DOC_HELP_("Thickness of sketch edge length dimensions (Open CASCADE line width scale; 1.0 = default).", nullptr);
         }
 
         ImGui::TableNextRow();
@@ -899,8 +898,7 @@ void GUI::settings_()
             dim_changed           = true;
           }
           ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
-          GUI_DOC_HELP_("Arrow head length for sketch and extrude length dimensions (Open CASCADE display units).",
-                           nullptr);
+          GUI_DOC_HELP_("Arrow head length for sketch and extrude length dimensions (Open CASCADE display units).", nullptr);
         }
 
         ImGui::TableNextRow();
@@ -951,8 +949,8 @@ void GUI::settings_()
           }
           ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
           GUI_DOC_HELP_("How dimension value labels are composited. Z-layer Top and Topmost avoid ghosting against the "
-                           "grid; Topmost is the default.",
-                           nullptr);
+                        "grid; Topmost is the default.",
+                        nullptr);
         }
 
         ImGui::TableNextRow();
@@ -1039,8 +1037,8 @@ void GUI::settings_()
           }
           ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
           GUI_DOC_HELP_("When off, hides all sketch length dimensions. Tool mode may still limit which sketch shows "
-                           "dimensions when this is on.",
-                           nullptr);
+                        "dimensions when this is on.",
+                        nullptr);
         }
 
         ImGui::EndTable();
@@ -1068,7 +1066,7 @@ void GUI::settings_()
         }
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("Scale for permanent '+' node markers in sketch mode. Click ? to open the user guide.",
-                         doc_urls::k_add_node_tool);
+                      doc_urls::k_add_node_tool);
       }
 
       ImGui::TableNextRow();
@@ -1086,8 +1084,8 @@ void GUI::settings_()
         }
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("When checked, the Add line edge and Add multi-line edge tools create a midpoint node on each "
-                         "new straight edge (for center snapping). Default is unchecked. Click ? to open the user guide.",
-                         doc_urls::k_line_edge_midpoint_nodes);
+                      "new straight edge (for center snapping). Default is unchecked. Click ? to open the user guide.",
+                      doc_urls::k_line_edge_midpoint_nodes);
       }
 
       ImGui::TableNextRow();
@@ -1098,8 +1096,8 @@ void GUI::settings_()
       ul_changed |= ImGui::ColorEdit4("##underlay_hi", &m_underlay_highlight_color[0], ImGuiColorEditFlags_Float);
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       GUI_DOC_HELP_("Updates all sketch underlays immediately. Also used as the default when you import a new image. "
-                       "Per-sketch overrides in Sketch List if needed. Click ? to open the user guide.",
-                       doc_urls::k_image_underlay);
+                    "Per-sketch overrides in Sketch List if needed. Click ? to open the user guide.",
+                    doc_urls::k_image_underlay);
 
       ImGui::TableNextRow();
       ImGui::TableSetColumnIndex(0);
@@ -1116,8 +1114,8 @@ void GUI::settings_()
         }
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("Color used by fullscreen snap guides and snap markers in sketch mode. Click ? to open the user "
-                         "guide.",
-                         doc_urls::k_sketch_snapping);
+                      "guide.",
+                      doc_urls::k_sketch_snapping);
       }
 
       ImGui::TableNextRow();
@@ -1134,8 +1132,8 @@ void GUI::settings_()
         }
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("Line width for sketch snap guides (axis lines, markers, and co-axial overlay). Click ? to open "
-                         "the user guide.",
-                         doc_urls::k_sketch_snapping);
+                      "the user guide.",
+                      doc_urls::k_sketch_snapping);
       }
 
       ImGui::TableNextRow();
@@ -1164,8 +1162,8 @@ void GUI::settings_()
         }
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("Traditional: compact local snap marker.\nFullscreen: full-view crosshair/axis guides.\nBoth: show "
-                         "compact marker and fullscreen guides together. Click ? to open the user guide.",
-                         doc_urls::k_sketch_snapping);
+                      "compact marker and fullscreen guides together. Click ? to open the user guide.",
+                      doc_urls::k_sketch_snapping);
       }
 
       ImGui::TableNextRow();
@@ -1182,9 +1180,9 @@ void GUI::settings_()
         }
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("When on (global mode): axis guide lines + markers for *all* nodes in the current sketch and all "
-                         "other visible sketches. When off (default): only closest node per active axis is annotated. Click ? "
-                         "to open the user guide.",
-                         doc_urls::k_sketch_snapping);
+                      "other visible sketches. When off (default): only closest node per active axis is annotated. Click ? "
+                      "to open the user guide.",
+                      doc_urls::k_sketch_snapping);
       }
 
       ImGui::EndTable();
@@ -1235,8 +1233,8 @@ void GUI::settings_()
         save_occt_view_settings();
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       GUI_DOC_HELP_("When enabled, EzyCad opens the last .ezy file you opened (path is stored in settings). Click ? to "
-                       "open the user guide.",
-                       doc_urls::k_startup_project);
+                    "open the user guide.",
+                    doc_urls::k_startup_project);
       ImGui::EndTable();
     }
     if (ui_show_contextual_help() && !m_last_opened_project_path.empty())
@@ -1252,8 +1250,8 @@ void GUI::settings_()
       clear_saved_startup_project_();
     ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
     GUI_DOC_HELP_("Save the current document (geometry, view, and tool mode) as what loads when EzyCad starts. If none is "
-                     "saved, the install default (res/default.ezy) is used. Click ? to open the user guide.",
-                     doc_urls::k_startup_project);
+                  "saved, the install default (res/default.ezy) is used. Click ? to open the user guide.",
+                  doc_urls::k_startup_project);
   }
 
   ImGui::Separator();

--- a/src/occt_view.cpp
+++ b/src/occt_view.cpp
@@ -1642,6 +1642,11 @@ bool Occt_view::is_headless() const { return m_headless_view; }
 // Mode related
 Mode Occt_view::get_mode() const { return m_gui.get_mode(); }
 
+bool Occt_view::sketch_snap_suppressed() const
+{
+  return m_cur_sketch && get_mode() == Mode::Sketch_operation_axis && m_cur_sketch->has_operation_axis();
+}
+
 void Occt_view::apply_camera_projection()
 {
   if (is_headless())
@@ -2022,8 +2027,8 @@ void Occt_view::load(const std::string& json_str, bool restore_view)
     m_sketches.push_back(Sketch_json::from_json(*this, s));
     if (s["isCurrent"])
     {
-      //if(m_cur_sketch)
-        //MSG("Multiple sketches marked as current in JSON; using the last one.");
+      // if(m_cur_sketch)
+      // MSG("Multiple sketches marked as current in JSON; using the last one.");
 
       m_cur_sketch = m_sketches.back();
     }

--- a/src/occt_view.cpp
+++ b/src/occt_view.cpp
@@ -628,6 +628,21 @@ void Occt_view::create_default_sketch_()
   m_cur_sketch->set_current();
 }
 
+void Occt_view::ensure_current_sketch_()
+{
+  if (m_cur_sketch)
+    return;
+
+  if (!m_sketches.empty())
+  {
+    m_cur_sketch = m_sketches.front();
+    m_cur_sketch->set_current();
+    return;
+  }
+
+  create_default_sketch_();
+}
+
 void Occt_view::add_sketch(const gp_Pln& pln, const std::string& base_name)
 {
   push_undo_snapshot();
@@ -1802,13 +1817,14 @@ void Occt_view::remove_sketch(const Sketch_ptr& sketch)
 
 Sketch& Occt_view::curr_sketch()
 {
-  EZY_ASSERT(m_cur_sketch);
+  ensure_current_sketch_();
   return *m_cur_sketch;
 }
 
 Occt_view::Sketch_ptr Occt_view::curr_sketch_shared() const
 {
-  EZY_ASSERT(m_cur_sketch);
+  if (!m_cur_sketch)
+    const_cast<Occt_view*>(this)->ensure_current_sketch_();
   return m_cur_sketch;
 }
 
@@ -2006,12 +2022,14 @@ void Occt_view::load(const std::string& json_str, bool restore_view)
     m_sketches.push_back(Sketch_json::from_json(*this, s));
     if (s["isCurrent"])
     {
-      EZY_ASSERT(!m_cur_sketch);
+      //if(m_cur_sketch)
+        //MSG("Multiple sketches marked as current in JSON; using the last one.");
+
       m_cur_sketch = m_sketches.back();
     }
   }
-  // We need at lease one sketch. TODO what if the user deletes them all?
-  EZY_ASSERT(m_cur_sketch);
+
+  ensure_current_sketch_();
 
   for (const json& s : j["shapes"])
   {

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -229,6 +229,7 @@ public:
 
   /// Highlight \a shp in the 3D viewer while the Shape List row is hovered (null clears).
   void set_shape_list_hover(const Shp_ptr& shp);
+  const Shp_ptr&             shape_list_hover() const { return m_shape_list_hover; }
   /// Re-apply list-hover highlight after Settings changes the hover color.
   void refresh_shape_list_hover_highlight();
 

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -112,6 +112,8 @@ public:
   void on_chamfer_mode();
   void on_fillet_mode();
   Mode get_mode() const;
+  /// True while the operational axis is defined and mirror/revolve selection is active.
+  bool sketch_snap_suppressed() const;
 
   void cleanup();
 
@@ -228,8 +230,8 @@ public:
   void                       set_shp_selection_mode(const TopAbs_ShapeEnum selection_mode);
 
   /// Highlight \a shp in the 3D viewer while the Shape List row is hovered (null clears).
-  void set_shape_list_hover(const Shp_ptr& shp);
-  const Shp_ptr&             shape_list_hover() const { return m_shape_list_hover; }
+  void           set_shape_list_hover(const Shp_ptr& shp);
+  const Shp_ptr& shape_list_hover() const { return m_shape_list_hover; }
   /// Re-apply list-hover highlight after Settings changes the hover color.
   void refresh_shape_list_hover_highlight();
 

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -266,6 +266,7 @@ private:
   void finalize_sketch_extrude_();
   bool cancel_sketch_extrude_();
   void create_default_sketch_();
+  void ensure_current_sketch_();
   void remove_selected_length_dimensions_from_sketches_();
 
   // Query related

--- a/src/shp.cpp
+++ b/src/shp.cpp
@@ -40,7 +40,10 @@ void Shp::set_visible(const bool visible)
     m_ctx.Display(this, m_disp_mode, AIS_Shape::SelectionMode(m_selection_mode), true);
   }
   else
+  {
+    m_ctx.Unhilight(this, false);
     m_ctx.Erase(this, true);
+  }
 }
 
 void Shp::set_selection_mode(const TopAbs_ShapeEnum mode)

--- a/src/shp_info.cpp
+++ b/src/shp_info.cpp
@@ -1,0 +1,135 @@
+#include "shp_info.h"
+
+#include <cstdio>
+#include <string>
+
+#include <BRepBndLib.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <BRepGProp.hxx>
+#include <BRep_Tool.hxx>
+#include <GProp_GProps.hxx>
+#include <TopAbs_ShapeEnum.hxx>
+#include <TopExp_Explorer.hxx>
+
+#include "utl_occt.h"
+
+namespace shp_info
+{
+namespace
+{
+std::string fmt_double(const double v)
+{
+  char buf[64];
+  std::snprintf(buf, sizeof(buf), "%.6g", v);
+  return buf;
+}
+
+void add_line(std::vector<Line>& out, const char* label, const std::string& value) { out.push_back({label, value}); }
+
+int count_subshapes(const TopoDS_Shape& shape, const TopAbs_ShapeEnum type)
+{
+  int n = 0;
+  for (TopExp_Explorer exp(shape, type); exp.More(); exp.Next())
+    ++n;
+
+  return n;
+}
+
+std::string shape_type_name(const TopAbs_ShapeEnum type)
+{
+  const auto idx = static_cast<std::size_t>(type);
+  if (idx < c_names_TopAbs_ShapeEnum.size())
+    return std::string(c_names_TopAbs_ShapeEnum[idx]);
+
+  return "Unknown";
+}
+} // namespace
+
+std::vector<Line> collect(const TopoDS_Shape& shape, const Display_meta* display)
+{
+  std::vector<Line> lines;
+
+  if (display)
+  {
+    add_line(lines, "Name", display->name);
+    add_line(lines, "Material", display->material);
+    add_line(lines, "Display", display->display_mode);
+    add_line(lines, "Visible", display->visible ? "yes" : "no");
+    lines.push_back({"", ""});
+  }
+
+  if (shape.IsNull())
+  {
+    add_line(lines, "Shape", "null");
+    return lines;
+  }
+
+  const TopAbs_ShapeEnum root_type = shape.ShapeType();
+  add_line(lines, "Root type", shape_type_name(root_type));
+
+  BRepCheck_Analyzer analyzer(shape);
+  add_line(lines, "Valid", analyzer.IsValid() ? "yes" : "no");
+
+  if (!shape.Location().IsIdentity())
+    add_line(lines, "Located", "yes");
+
+  if (root_type == TopAbs_SHELL)
+    add_line(lines, "Closed shell", BRep_Tool::IsClosed(shape) ? "yes" : "no");
+
+  const int n_compound  = count_subshapes(shape, TopAbs_COMPOUND);
+  const int n_compsolid = count_subshapes(shape, TopAbs_COMPSOLID);
+  const int n_solid     = count_subshapes(shape, TopAbs_SOLID);
+  const int n_shell     = count_subshapes(shape, TopAbs_SHELL);
+  const int n_face      = count_subshapes(shape, TopAbs_FACE);
+  const int n_wire      = count_subshapes(shape, TopAbs_WIRE);
+  const int n_edge      = count_subshapes(shape, TopAbs_EDGE);
+  const int n_vertex    = count_subshapes(shape, TopAbs_VERTEX);
+
+  lines.push_back({"", ""});
+  add_line(lines, "Compounds", std::to_string(n_compound));
+  add_line(lines, "CompSolids", std::to_string(n_compsolid));
+  add_line(lines, "Solids", std::to_string(n_solid));
+  add_line(lines, "Shells", std::to_string(n_shell));
+  add_line(lines, "Faces", std::to_string(n_face));
+  add_line(lines, "Wires", std::to_string(n_wire));
+  add_line(lines, "Edges", std::to_string(n_edge));
+  add_line(lines, "Vertices", std::to_string(n_vertex));
+
+  Bnd_Box bbox;
+  BRepBndLib::Add(shape, bbox);
+  if (!bbox.IsVoid())
+  {
+    double xmin, ymin, zmin, xmax, ymax, zmax;
+    bbox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+    lines.push_back({"", ""});
+    add_line(lines, "BBox X", fmt_double(xmin) + " .. " + fmt_double(xmax));
+    add_line(lines, "BBox Y", fmt_double(ymin) + " .. " + fmt_double(ymax));
+    add_line(lines, "BBox Z", fmt_double(zmin) + " .. " + fmt_double(zmax));
+    add_line(lines, "BBox size", fmt_double(xmax - xmin) + " x " + fmt_double(ymax - ymin) + " x " +
+                                fmt_double(zmax - zmin));
+  }
+
+  GProp_GProps vol_props;
+  BRepGProp::VolumeProperties(shape, vol_props);
+  if (vol_props.Mass() > 0.0)
+  {
+    const gp_Pnt com = vol_props.CentreOfMass();
+    lines.push_back({"", ""});
+    add_line(lines, "Volume", fmt_double(vol_props.Mass()));
+    add_line(lines, "Center of mass",
+             fmt_double(com.X()) + ", " + fmt_double(com.Y()) + ", " + fmt_double(com.Z()));
+  }
+
+  GProp_GProps surf_props;
+  BRepGProp::SurfaceProperties(shape, surf_props);
+  if (surf_props.Mass() > 0.0)
+    add_line(lines, "Surface area", fmt_double(surf_props.Mass()));
+
+  GProp_GProps lin_props;
+  BRepGProp::LinearProperties(shape, lin_props);
+  if (lin_props.Mass() > 0.0)
+    add_line(lines, "Length", fmt_double(lin_props.Mass()));
+
+  return lines;
+}
+} // namespace shp_info

--- a/src/shp_info.cpp
+++ b/src/shp_info.cpp
@@ -105,8 +105,7 @@ std::vector<Line> collect(const TopoDS_Shape& shape, const Display_meta* display
     add_line(lines, "BBox X", fmt_double(xmin) + " .. " + fmt_double(xmax));
     add_line(lines, "BBox Y", fmt_double(ymin) + " .. " + fmt_double(ymax));
     add_line(lines, "BBox Z", fmt_double(zmin) + " .. " + fmt_double(zmax));
-    add_line(lines, "BBox size", fmt_double(xmax - xmin) + " x " + fmt_double(ymax - ymin) + " x " +
-                                fmt_double(zmax - zmin));
+    add_line(lines, "BBox size", fmt_double(xmax - xmin) + " x " + fmt_double(ymax - ymin) + " x " + fmt_double(zmax - zmin));
   }
 
   GProp_GProps vol_props;
@@ -116,8 +115,7 @@ std::vector<Line> collect(const TopoDS_Shape& shape, const Display_meta* display
     const gp_Pnt com = vol_props.CentreOfMass();
     lines.push_back({"", ""});
     add_line(lines, "Volume", fmt_double(vol_props.Mass()));
-    add_line(lines, "Center of mass",
-             fmt_double(com.X()) + ", " + fmt_double(com.Y()) + ", " + fmt_double(com.Z()));
+    add_line(lines, "Center of mass", fmt_double(com.X()) + ", " + fmt_double(com.Y()) + ", " + fmt_double(com.Z()));
   }
 
   GProp_GProps surf_props;

--- a/src/shp_info.h
+++ b/src/shp_info.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <TopoDS_Shape.hxx>
+
+namespace shp_info
+{
+struct Display_meta
+{
+  std::string name;
+  std::string material;
+  std::string display_mode;
+  bool        visible = true;
+};
+
+struct Line
+{
+  std::string label;
+  std::string value;
+};
+
+/// Collect OCCT topology and property lines for the shape info dialog.
+std::vector<Line> collect(const TopoDS_Shape& shape, const Display_meta* display = nullptr);
+} // namespace shp_info

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -48,14 +48,14 @@ std::optional<Symmetric_edge_span> symmetric_edge_from_center(const gp_Pnt2d& ce
   if (full_len <= Precision::Confusion())
     return std::nullopt;
 
-  const double half = full_len * 0.5;
+  const double   half = full_len * 0.5;
   const gp_Vec2d v(dir);
   return Symmetric_edge_span{center.Translated(-v * half), center.Translated(v * half), full_len};
 }
 
 std::optional<Symmetric_edge_span> symmetric_edge_from_center_and_hint(const gp_Pnt2d& center, const gp_Pnt2d& dir_hint_pt)
 {
-  gp_Vec2d v(center, dir_hint_pt);
+  gp_Vec2d     v(center, dir_hint_pt);
   const double half = v.Magnitude();
   if (half <= Precision::Confusion())
     return std::nullopt;
@@ -252,12 +252,13 @@ void Sketch::sync_permanent_node_annos_()
 
   const Mode mode = get_mode();
   // Show "+" markers for permanent user nodes in sketch modes and polar duplicate (which snaps to sketch nodes).
-  const bool show_permanent_marks = is_sketch_mode(mode) || mode == Mode::Shape_polar_duplicate;
+  const bool show_permanent_marks    = is_sketch_mode(mode) || mode == Mode::Shape_polar_duplicate;
+  const bool hide_for_operation_axis = operation_axis_suppresses_sketch_snap_();
 
   for (size_t i = 0, n = m_nodes.size(); i < n; ++i)
   {
     const Sketch_nodes::Node& node = m_nodes[i];
-    const bool                show = m_visible && node.permanent && !node.deleted && show_permanent_marks;
+    const bool show = m_visible && node.permanent && !node.deleted && show_permanent_marks && !hide_for_operation_axis;
 
     if (!show)
     {
@@ -552,9 +553,9 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
 
       if (m_show_dim_input)
       {
-        gp_Dir2d       edge_dir = get_unit_dir(span_a, span_b);
-        ScreenCoords   spos     = m_view.get_screen_coords(to_3d(m_pln, center_point(span_a, span_b)));
-        auto           cb       = [&, edge_dir](float new_dist, bool is_finial)
+        gp_Dir2d     edge_dir = get_unit_dir(span_a, span_b);
+        ScreenCoords spos     = m_view.get_screen_coords(to_3d(m_pln, center_point(span_a, span_b)));
+        auto         cb       = [&, edge_dir](float new_dist, bool is_finial)
         {
           m_entered_edge_len = {edge_dir, new_dist * m_view.get_dimension_scale()};
           m_show_dim_input   = !is_finial;
@@ -576,8 +577,7 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
           ScreenCoords current_pos(dvec2(ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y));
           sketch_pt_move(current_pos);
         };
-        float angle_to_show =
-            m_entered_edge_angle.has_value() ? float(*m_entered_edge_angle) : float(current_angle_deg);
+        float angle_to_show = m_entered_edge_angle.has_value() ? float(*m_entered_edge_angle) : float(current_angle_deg);
         m_view.gui().set_angle_edit(angle_to_show, std::move(std::function<void(float, bool)>(cb)), spos);
       }
     };
@@ -1215,6 +1215,9 @@ void Sketch::finalize_operation_axis_()
 {
   m_operation_axis = std::move(m_tmp_edges.back());
   cancel_elm(); // Reset state, we have the operation axis
+  sync_operation_axis_display_();
+  sync_permanent_node_annos_();
+  m_nodes.hide_snap_annos();
 }
 
 void Sketch::clear_operation_axis()
@@ -1223,6 +1226,8 @@ void Sketch::clear_operation_axis()
     m_ctx.Remove(m_operation_axis->shp, false);
 
   m_operation_axis = std::nullopt;
+  sync_permanent_node_annos_();
+  m_nodes.hide_snap_annos();
 }
 
 bool Sketch::has_operation_axis() const { return m_operation_axis.has_value(); }
@@ -1403,7 +1408,7 @@ void Sketch::check_dimension_seg_(Linestring_type linestring_type)
   Edge& edge = m_tmp_edges.back();
   if (edge_from_center_active_() && linestring_type == Linestring_type::Single)
   {
-    const gp_Pnt2d&                  center = m_nodes[edge.node_idx_a];
+    const gp_Pnt2d&                    center = m_nodes[edge.node_idx_a];
     std::optional<Symmetric_edge_span> span =
         symmetric_edge_from_center(center, m_entered_edge_len->dir, m_entered_edge_len->len);
     if (!span)
@@ -1648,8 +1653,7 @@ void Sketch::sketch_json_set_operation_axis_(const gp_Pnt2d& pt_a, const gp_Pnt2
   update_edge_shp_(axis, pt_a, pt_b);
   m_operation_axis = std::move(axis);
 
-  if (m_visible && is_current())
-    m_ctx.Display(m_operation_axis->shp, AIS_WireFrame, 0, false);
+  sync_operation_axis_display_();
 }
 
 std::vector<Sketch::Edge> Sketch::get_selected_edges_() const
@@ -2657,7 +2661,29 @@ void Sketch::on_mode()
 {
   // Reset state
   cancel_elm();
+  sync_operation_axis_display_();
   sync_permanent_node_annos_();
+}
+
+bool Sketch::show_operation_axis_() const
+{
+  return m_operation_axis.has_value() && m_visible && is_current() && get_mode() == Mode::Sketch_operation_axis;
+}
+
+bool Sketch::operation_axis_suppresses_sketch_snap_() const
+{
+  return get_mode() == Mode::Sketch_operation_axis && m_operation_axis.has_value();
+}
+
+void Sketch::sync_operation_axis_display_()
+{
+  if (!m_operation_axis.has_value())
+    return;
+
+  if (show_operation_axis_())
+    m_ctx.Display(m_operation_axis->shp, AIS_WireFrame, 0, false);
+  else
+    m_ctx.Erase(m_operation_axis->shp, false);
 }
 
 Mode Sketch::get_mode() const { return m_view.get_mode(); }
@@ -2737,10 +2763,7 @@ void Sketch::set_visible(bool state)
     if (m_underlay && m_underlay->has_image())
       m_underlay->rebuild_and_display(m_pln, m_ctx);
 
-    // Show operation axis only if this sketch is current
-    if (m_operation_axis.has_value() && is_current())
-      m_ctx.Display(m_operation_axis->shp, AIS_WireFrame, 0, false);
-
+    sync_operation_axis_display_();
     sync_permanent_node_annos_();
   }
   else
@@ -2970,9 +2993,7 @@ void Sketch::set_current()
       }
     }
 
-  // Show operation axis for current sketch if it exists and sketch is visible
-  if (m_operation_axis.has_value() && m_visible)
-    m_ctx.Display(m_operation_axis->shp, AIS_WireFrame, 0, false);
+  sync_operation_axis_display_();
 
   // DBG_MSG("m_outside_snap_pts " << m_nodes.m_outside_snap_pts.size());
 }

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -1,4 +1,5 @@
 #include "sketch.h"
+#include "utl_occt.h"
 
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
@@ -1329,7 +1330,7 @@ Shp_rslt Sketch::revolve_selected(const double angle)
     const gp_Ax1 axis(pt_a, direction);
 
     BRepPrimAPI_MakeRevol revolMaker(compound, axis, angle);
-    return Shp_rslt(new Shp(m_ctx, revolMaker.Shape()));
+    return Shp_rslt(new Shp(m_ctx, try_make_solid(revolMaker.Shape())));
   }
   catch (const Standard_Failure& e)
   {

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -1636,6 +1636,22 @@ void Sketch::sketch_json_add_linear_edge_(size_t idx_a, size_t idx_b, std::optio
   m_nodes.finalize();
 }
 
+void Sketch::sketch_json_set_operation_axis_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  if (!unique(pt_a, pt_b))
+    return;
+
+  clear_operation_axis();
+
+  Edge axis{m_nodes.get_node_exact(pt_a)};
+  axis.node_idx_b = m_nodes.get_node_exact(pt_b);
+  update_edge_shp_(axis, pt_a, pt_b);
+  m_operation_axis = std::move(axis);
+
+  if (m_visible && is_current())
+    m_ctx.Display(m_operation_axis->shp, AIS_WireFrame, 0, false);
+}
+
 std::vector<Sketch::Edge> Sketch::get_selected_edges_() const
 {
   std::vector<Edge> ret;
@@ -1979,6 +1995,13 @@ void Sketch::update_faces_()
 
     if (edge.node_idx_arc.has_value())
       used_nodes[*edge.node_idx_arc] = true;
+  }
+
+  if (m_operation_axis.has_value())
+  {
+    used_nodes[m_operation_axis->node_idx_a] = true;
+    if (m_operation_axis->node_idx_b.has_value())
+      used_nodes[*m_operation_axis->node_idx_b] = true;
   }
 
   // Remove dangling edges (edges with degree-1 endpoints) iteratively.

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -317,6 +317,8 @@ public:
   static bool is_linear_edge_(const Edge& e);
   /// JSON load: linear edge using existing node indices (`idx_mid` is the edge midpoint node).
   void sketch_json_add_linear_edge_(size_t idx_a, size_t idx_b, std::optional<size_t> idx_mid);
+  /// JSON load: restore the sketch operation axis from two plane points.
+  void sketch_json_set_operation_axis_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
 
   // Selected related
   std::vector<Edge>                get_selected_edges_() const;

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -344,6 +344,9 @@ public:
   void update_edge_style_(AIS_Shape_ptr& shp);
   void update_node_mark_style_(AIS_Shape_ptr& shp);
   void sync_permanent_node_annos_();
+  void sync_operation_axis_display_();
+  bool show_operation_axis_() const;
+  bool operation_axis_suppresses_sketch_snap_() const;
   void update_originating_face_style();
 
   void rebuild_length_dimension_display_(Length_dimension& d);

--- a/src/sketch_json.cpp
+++ b/src/sketch_json.cpp
@@ -6,11 +6,13 @@
 #include <Geom_TrimmedCurve.hxx>
 #include <Precision.hxx>
 #include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <vector>
 
 #include "dbg.h"
+#include "geom.h"
 #include "sketch.h"
 #include "sketch_nodes.h"
 #include "sketch_underlay.h"
@@ -223,6 +225,15 @@ nlohmann::json Sketch_json::to_json(const Sketch& sketch)
   if (sketch.m_underlay && sketch.m_underlay->has_image())
     j["underlay"] = sketch.m_underlay->to_json();
 
+  if (sketch.m_operation_axis.has_value())
+  {
+    const Sketch::Edge& axis = *sketch.m_operation_axis;
+    EZY_ASSERT(axis.node_idx_b.has_value());
+    EZY_ASSERT(!axis.shp.IsNull());
+    const auto [pt_a, pt_b] = get_edge_endpoints(sketch.m_pln, TopoDS::Edge(axis.shp->Shape()));
+    j["operation_axis"]     = json::array({::to_json(pt_a), ::to_json(pt_b)});
+  }
+
   return j;
 }
 
@@ -298,6 +309,13 @@ Sketch::sptr Sketch_json::from_json(Occt_view& view, const nlohmann::json& j)
       if (ret->m_visible && ret->m_underlay->has_image())
         ret->m_underlay->rebuild_and_display(ret->m_pln, ret->m_ctx);
     }
+  }
+
+  if (j.contains("operation_axis") && j["operation_axis"].is_array() && j["operation_axis"].size() >= 2)
+  {
+    const gp_Pnt2d pt_a = ::from_json_pnt2d(j["operation_axis"][0]);
+    const gp_Pnt2d pt_b = ::from_json_pnt2d(j["operation_axis"][1]);
+    ret->sketch_json_set_operation_axis_(pt_a, pt_b);
   }
 
   if (j["isCurrent"])

--- a/src/sketch_nodes.cpp
+++ b/src/sketch_nodes.cpp
@@ -123,6 +123,12 @@ bool Sketch_nodes::Impl::view_bounds_2d_(double& min_u, double& min_v, double& m
 
 std::optional<size_t> Sketch_nodes::Impl::try_pick_existing_node(const ScreenCoords& screen_coords)
 {
+  if (m_view.sketch_snap_suppressed())
+  {
+    m_owner->hide_snap_annos();
+    return std::nullopt;
+  }
+
   std::optional<gp_Pnt2d> pt_opt = m_view.pt_on_plane(screen_coords, m_pln);
   if (!pt_opt)
   {
@@ -165,7 +171,7 @@ std::optional<size_t> Sketch_nodes::Impl::try_pick_existing_node(const ScreenCoo
 std::optional<gp_Pnt2d> Sketch_nodes::Impl::snap(const ScreenCoords& screen_coords)
 {
   std::optional<gp_Pnt2d> pt = m_view.pt_on_plane(screen_coords, m_pln);
-  if (pt)
+  if (pt && !m_view.sketch_snap_suppressed())
     m_owner->try_get_node_idx_snap(*pt);
 
   return pt;
@@ -511,6 +517,12 @@ std::optional<size_t> Sketch_nodes::Impl::try_get_node_idx_snap(
     gp_Pnt2d&                  pt, // `pt` could be snapped to a node, an axis of another node, or an outside snap point.
     const std::vector<size_t>& to_exclude)
 {
+  if (m_view.sketch_snap_suppressed())
+  {
+    m_owner->hide_snap_annos();
+    return std::nullopt;
+  }
+
   const double snap_dist = snap_radius_world_(pt);
 
   if (!s_annotate_all_coaxial_nodes && m_global_coax_anno)

--- a/src/utl_occt.cpp
+++ b/src/utl_occt.cpp
@@ -1,0 +1,124 @@
+#include "utl_occt.h"
+
+#include <BRep_Builder.hxx>
+#include <BRepBuilderAPI_MakeSolid.hxx>
+#include <BRepBuilderAPI_Sewing.hxx>
+#include <Precision.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Shell.hxx>
+
+namespace
+{
+TopoDS_Shape solid_from_shell(const TopoDS_Shell& shell)
+{
+  if (shell.IsNull())
+    return TopoDS_Shape();
+
+  BRepBuilderAPI_MakeSolid maker(shell);
+  if (!maker.IsDone())
+    return TopoDS_Shape();
+
+  TopoDS_Shape solid = maker.Solid();
+  return solid;
+}
+
+TopoDS_Shape solids_from_shells(const TopoDS_Shape& shape)
+{
+  TopoDS_Compound out;
+  BRep_Builder    builder;
+  builder.MakeCompound(out);
+
+  int solid_count = 0;
+  for (TopExp_Explorer exp(shape, TopAbs_SHELL); exp.More(); exp.Next())
+  {
+    const TopoDS_Shape solid = solid_from_shell(TopoDS::Shell(exp.Current()));
+    if (!solid.IsNull())
+    {
+      builder.Add(out, solid);
+      ++solid_count;
+    }
+  }
+
+  if (solid_count == 0)
+    return TopoDS_Shape();
+
+  if (solid_count == 1)
+  {
+    for (TopExp_Explorer exp(out, TopAbs_SOLID); exp.More(); exp.Next())
+      return exp.Current();
+  }
+
+  return out;
+}
+
+TopoDS_Shape solid_from_sewn_faces(const TopoDS_Shape& shape)
+{
+  BRepBuilderAPI_Sewing sewer(Precision::Confusion());
+  int                   face_count = 0;
+  for (TopExp_Explorer exp(shape, TopAbs_FACE); exp.More(); exp.Next())
+  {
+    sewer.Add(exp.Current());
+    ++face_count;
+  }
+
+  if (face_count == 0)
+    return TopoDS_Shape();
+
+  sewer.Perform();
+  const TopoDS_Shape sewed = sewer.SewedShape();
+  if (sewed.IsNull())
+    return TopoDS_Shape();
+
+  if (sewed.ShapeType() == TopAbs_SHELL)
+    return solid_from_shell(TopoDS::Shell(sewed));
+
+  return solids_from_shells(sewed);
+}
+} // namespace
+
+TopoDS_Shape try_make_solid(const TopoDS_Shape& shape)
+{
+  if (shape.IsNull())
+    return shape;
+
+  switch (shape.ShapeType())
+  {
+  case TopAbs_SOLID:
+  case TopAbs_COMPSOLID:
+    return shape;
+
+  case TopAbs_SHELL:
+  {
+    const TopoDS_Shape solid = solid_from_shell(TopoDS::Shell(shape));
+    return solid.IsNull() ? shape : solid;
+  }
+
+  case TopAbs_COMPOUND:
+  {
+    int           solid_count = 0;
+    TopoDS_Shape  lone_solid;
+    for (TopExp_Explorer exp(shape, TopAbs_SOLID); exp.More(); exp.Next())
+    {
+      lone_solid = exp.Current();
+      ++solid_count;
+    }
+    if (solid_count == 1)
+      return lone_solid;
+
+    const TopoDS_Shape from_shells = solids_from_shells(shape);
+    if (!from_shells.IsNull())
+      return from_shells;
+
+    const TopoDS_Shape from_faces = solid_from_sewn_faces(shape);
+    if (!from_faces.IsNull())
+      return from_faces;
+
+    return shape;
+  }
+
+  default:
+    return shape;
+  }
+}

--- a/src/utl_occt.cpp
+++ b/src/utl_occt.cpp
@@ -97,8 +97,8 @@ TopoDS_Shape try_make_solid(const TopoDS_Shape& shape)
 
   case TopAbs_COMPOUND:
   {
-    int           solid_count = 0;
-    TopoDS_Shape  lone_solid;
+    int          solid_count = 0;
+    TopoDS_Shape lone_solid;
     for (TopExp_Explorer exp(shape, TopAbs_SOLID); exp.More(); exp.Next())
     {
       lone_solid = exp.Current();

--- a/src/utl_occt.h
+++ b/src/utl_occt.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <TopAbs_ShapeEnum.hxx>
+#include <TopoDS_Shape.hxx>
 #include <array>
 #include <cstddef>
 #include <string_view>
@@ -26,3 +27,8 @@ constexpr std::array<std::string_view, static_cast<std::size_t>(TopAbs_SHAPE) + 
 static_assert(c_names_TopAbs_ShapeEnum.size() == static_cast<std::size_t>(TopAbs_SHAPE) + 1u);
 
 #undef EZY_TOPABS_SHAPE_ENUM_LIST
+
+/// When \a shape is a closed shell (or compound of closed shells), wrap it as a solid.
+/// Otherwise returns \a shape unchanged.
+TopoDS_Shape try_make_solid(const TopoDS_Shape& shape);
+

--- a/src/utl_occt.h
+++ b/src/utl_occt.h
@@ -31,4 +31,3 @@ static_assert(c_names_TopAbs_ShapeEnum.size() == static_cast<std::size_t>(TopAbs
 /// When \a shape is a closed shell (or compound of closed shells), wrap it as a solid.
 /// Otherwise returns \a shape unchanged.
 TopoDS_Shape try_make_solid(const TopoDS_Shape& shape);
-

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -15,6 +15,7 @@
 #include "occt_view.h"
 #include "sketch.h"
 #include "sketch_json.h"
+#include "utl_occt.h"
 
 using namespace glm;
 
@@ -2342,7 +2343,7 @@ TEST_F(Sketch_test, RevolveSelected_SimpleEdgeProfile)
   gp_Ax1 revolAxis(axA, dir);
 
   BRepPrimAPI_MakeRevol expectedMaker(profile, revolAxis, 2 * std::numbers::pi);
-  TopoDS_Shape expected = expectedMaker.Shape();
+  TopoDS_Shape expected = try_make_solid(expectedMaker.Shape());
 
   EXPECT_FALSE(expected.IsNull());
 
@@ -2454,7 +2455,7 @@ TEST_F(Sketch_test, RevolveSelected_ClosedEdgeProfile)
   gp_Ax1 revolAxis(axA, dir);
 
   BRepPrimAPI_MakeRevol expectedMaker(profile, revolAxis, 2 * std::numbers::pi);
-  TopoDS_Shape expected = expectedMaker.Shape();
+  TopoDS_Shape expected = try_make_solid(expectedMaker.Shape());
 
   EXPECT_FALSE(expected.IsNull());
 
@@ -2481,12 +2482,8 @@ TEST_F(Sketch_test, RevolveSelected_ClosedEdgeProfile)
   EXPECT_NEAR(aymax, eymax, 1e-8);
   EXPECT_NEAR(azmax, ezmax, 1e-8);
 
-  // For a closed profile revolved 360°, we expect a meaningful 3D result.
-  EXPECT_TRUE(actual.ShapeType() == TopAbs_SOLID ||
-              actual.ShapeType() == TopAbs_COMPOUND ||
-              actual.ShapeType() == TopAbs_SHELL ||
-              actual.ShapeType() == TopAbs_FACE)
-      << "Revolved closed profile should produce a non-degenerate 3D shape";
+  // For a closed profile revolved 360°, we expect a solid of revolution.
+  EXPECT_EQ(actual.ShapeType(), TopAbs_SOLID) << "Closed edge profile revolved 360 deg should be a solid";
 }
 
 // Test that split edges have midpoints for snapping

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -2029,6 +2029,40 @@ TEST_F(Sketch_test, UpdateFaces_DanglingEdgesRemoval)
   EXPECT_EQ(total_edges, 12) << "All 12 edges (4 rectangle + 8 dangling) should still exist in the sketch";
 }
 
+// Test operation axis persistence in sketch JSON save/load.
+TEST_F(Sketch_test, OperationAxis_JSON_RoundTrip)
+{
+  gp_Pln default_plane(gp::Origin(), gp::DZ());
+  Sketch sketch("TestSketch", view(), default_plane);
+
+  gui().set_mode(Mode::Sketch_operation_axis);
+
+  const gp_Pnt2d axis_start(0.0, 0.0);
+  const gp_Pnt2d axis_end(10.0, 3.0);
+  sketch.add_sketch_pt(ScreenCoords(dvec2(axis_start.X(), axis_start.Y())));
+  sketch.add_sketch_pt(ScreenCoords(dvec2(axis_end.X(), axis_end.Y())));
+  ASSERT_TRUE(sketch.has_operation_axis());
+
+  const nlohmann::json j = Sketch_json::to_json(sketch);
+  ASSERT_TRUE(j.contains("operation_axis"));
+  ASSERT_TRUE(j["operation_axis"].is_array());
+  EXPECT_EQ(j["operation_axis"].size(), 2u);
+  EXPECT_NEAR(j["operation_axis"][0]["x"].get<double>(), axis_start.X(), 1e-8);
+  EXPECT_NEAR(j["operation_axis"][0]["y"].get<double>(), axis_start.Y(), 1e-8);
+  EXPECT_NEAR(j["operation_axis"][1]["x"].get<double>(), axis_end.X(), 1e-8);
+  EXPECT_NEAR(j["operation_axis"][1]["y"].get<double>(), axis_end.Y(), 1e-8);
+
+  const std::shared_ptr<Sketch> loaded = Sketch_json::from_json(view(), j);
+  ASSERT_TRUE(loaded->has_operation_axis());
+
+  const nlohmann::json j2 = Sketch_json::to_json(*loaded);
+  ASSERT_TRUE(j2.contains("operation_axis"));
+  EXPECT_NEAR(j2["operation_axis"][0]["x"].get<double>(), axis_start.X(), 1e-8);
+  EXPECT_NEAR(j2["operation_axis"][0]["y"].get<double>(), axis_start.Y(), 1e-8);
+  EXPECT_NEAR(j2["operation_axis"][1]["x"].get<double>(), axis_end.X(), 1e-8);
+  EXPECT_NEAR(j2["operation_axis"][1]["y"].get<double>(), axis_end.Y(), 1e-8);
+}
+
 // Test mirror_selected_edges error handling when no edges are selected
 TEST_F(Sketch_test, MirrorSelectedEdges_NoEdgesSelected)
 {


### PR DESCRIPTION
Closes https://github.com/trailcode/EzyCad/issues/142

## Summary

- **Operational axis:** toolbar renamed to **Operational axis**; axis line visible only in that mode; after definition, permanent **+** markers and sketch snap suppressed for clearer mirror/revolve selection; axes persist in sketch JSON.
- **Revolve:** best-effort conversion of edge revolutions to solids; contextual **?** help on revolve angle field.
- **Shape info:** right-click shape name or **M** button opens topology/property dialog.
- **Fixes:** shape highlight in sketch operation-axis mode; related GUI/settings refactors on the branch.

Closes operational-axis visibility/snap/persistence work.

## Test plan

- [x] Build `EzyCad` and `EzyCad_tests` (Release).
- [x] Run `OperationAxis_JSON_RoundTrip` and mirror/revolve tests.
- [x] Manual: Operational axis placement, snap suppression after define, Clear axis, mode switch visibility.
- [x] Manual: Revolve closed edge profile; Shape info shows Solid when conversion succeeds.
- [x] Docs: review `#operation-axis-tool` and sketch snapping section in `usage-sketch.md`.

## Notes

- Snap suppression applies only when an axis **exists** in Operational axis mode (not during initial two-point placement).
- Axis visibility is mode-gated; stored axis survives tool switches and file reload.
