### PR TITLE
Sketch delta-based undo/redo with Sketch_op_recorder and PIMPL Sketch_delta

### DIFF
--- a/agents/issues/014-sketch-delta-undo-redo.md
+++ b/agents/issues/014-sketch-delta-undo-redo.md
@@ -1,0 +1,73 @@
+# Sketch delta-based undo/redo for sketch operations
+
+**Suggested labels:** `enhancement`, `sketch`, `refactor`
+
+---
+
+## Title (GitHub)
+
+Replace sketch JSON undo snapshots with delta-based `Sketch_delta` / `Sketch_op_recorder`
+
+## Body (GitHub)
+
+### Summary
+
+Sketch edits previously pushed full JSON undo snapshots, which was heavy and made precise undo of individual geometry changes harder to reason about. This change introduces a `Delta` hierarchy, records explicit `prev_*` / `curr_*` lists during each sketch operation via an RAII `Sketch_op_recorder`, and applies those lists on undo/redo. Arc, circle, linear edge, length dimension, and operation-axis changes are covered on the paths wired in `sketch.cpp`.
+
+### Problem
+
+- Full JSON snapshots for every sketch undo step are expensive and opaque; diffing element snapshots was fragile.
+- Arc and circle undo did not reliably remove or restore both internal edges per arc segment.
+- Failed sketch operations (e.g. mirror with no edges selected) could leave an empty recorder scope that should not push undo.
+- Implementation details (`Prev_edge_rec`, apply logic, etc.) belonged in `.cpp` files behind PIMPL, not in public headers.
+
+### Implemented scope
+
+**Code changes:**
+
+- `src/delta.h`: abstract `Delta` base (`apply_forward`, `apply_reverse`, `clone`).
+- `src/sketch_delta.h` / `src/sketch_delta.cpp`: `Sketch_op_recorder` and `Sketch_delta` with PIMPL; record types (`Prev_edge_rec`, `Curr_linear_edge_record`, `Arc_edge_record`, `Length_dim_record`) live in `Sketch_delta::Impl`.
+- `src/occt_view.h` / `src/occt_view.cpp`: undo stack holds `std::unique_ptr<Delta>`; `push_undo_delta()` alongside existing JSON `push_undo_snapshot()` for non-sketch ops.
+- `src/sketch.cpp` / `src/sketch.h`: sketch finalize, split, add-edge, mirror, and related paths wrap work in `Sketch_op_recorder`; `m_undo_recorder` set during active recorder scope; arc/circle add records curr edges and nodes; `remove_arc_edge_` matches arc pairs by shared AIS shape.
+- `src/sketch_nodes.cpp` / `src/sketch_nodes.h`: `restore_node_at` logic moved into `Sketch_nodes::Impl`.
+- `src/gui.cpp` / `src/gui.h`: `sketch_left_click()` and `mirror_selected_sketch_edges()` extracted for headless GUI tests.
+- `tests/sketch_tests.cpp`: undo tests for arc, circle, crossing linear finalize; `MirrorSelectedEdges_NoEdgesSelected` asserts no undo push on failed mirror.
+
+**Documentation:**
+
+- `docs/ezycad_code_style.md`: reader-first `.cpp` layout, file-local helpers at bottom, PIMPL guidance (`Sketch_nodes`, `Sketch_delta`).
+
+### Acceptance criteria
+
+- [ ] Linear sketch edge add/finalize undo restores prior geometry and splits correctly.
+- [ ] Arc and circle undo remove/restore all internal arc edges; redo restores them.
+- [ ] Mirror with no selection shows error and does **not** push an undo step.
+- [ ] `Sketch_delta` / `Sketch_op_recorder` use PIMPL; record structs are not in the public header.
+- [ ] Non-sketch operations still use JSON undo snapshots where unchanged.
+- [ ] `EzyCad_tests` pass (see test plan).
+
+### Files touched
+
+- `src/delta.h`, `src/sketch_delta.h`, `src/sketch_delta.cpp`
+- `src/occt_view.h`, `src/occt_view.cpp`
+- `src/sketch.h`, `src/sketch.cpp`, `src/sketch_json.cpp`
+- `src/sketch_nodes.h`, `src/sketch_nodes.cpp`
+- `src/gui.h`, `src/gui.cpp`, `src/gui_mode.cpp`
+- `tests/sketch_tests.cpp`
+- `docs/ezycad_code_style.md`
+- `agents/issues/014-sketch-delta-undo-redo.md` (this draft)
+
+### Related
+
+- Branch: `Trailcode/better_undo_redo`
+- Draft PR: `agents/prs/009-sketch-delta-undo-redo.md`
+- GitHub issue: (fill after opening)
+- GitHub PR: (fill after opening)
+
+### Test plan
+
+- [ ] Build `EzyCad_tests` (Release).
+- [ ] Run:
+  `EzyCad_tests.exe --gtest_filter=Sketch_test.Undo*:Sketch_test.MirrorSelectedEdges_NoEdgesSelected`
+- [ ] Manual: add linear edge, undo/redo; add arc/circle, undo/redo; mirror edges with selection; mirror with no selection (no undo entry).
+- [ ] Confirm shape ops and other undo paths still work via JSON snapshots.

--- a/agents/issues/014-sketch-delta-undo-redo.md
+++ b/agents/issues/014-sketch-delta-undo-redo.md
@@ -61,8 +61,8 @@ Sketch edits previously pushed full JSON undo snapshots, which was heavy and mad
 
 - Branch: `Trailcode/better_undo_redo`
 - Draft PR: `agents/prs/009-sketch-delta-undo-redo.md`
-- GitHub issue: (fill after opening)
-- GitHub PR: (fill after opening)
+- GitHub issue: https://github.com/trailcode/EzyCad/issues/144
+- GitHub PR: https://github.com/trailcode/EzyCad/pull/145
 
 ### Test plan
 

--- a/agents/prs/009-sketch-delta-undo-redo.md
+++ b/agents/prs/009-sketch-delta-undo-redo.md
@@ -1,0 +1,57 @@
+# PR - Trailcode/better_undo_redo
+
+## Title
+
+Sketch delta-based undo/redo with `Sketch_op_recorder` and PIMPL `Sketch_delta`
+
+## Summary
+
+- **Delta undo for sketches:** New `Delta` base and `Sketch_delta` record explicit `prev_*` / `curr_*` state (linear edges, arcs, length dims, operation axis, node tombstones) instead of full JSON snapshots for sketch operations.
+- **`Sketch_op_recorder`:** RAII scope records changes during one edit; `commit()` pushes a delta, `cancel()` drops it (e.g. mirror with no selection). Destructor cancels if still uncommitted.
+- **Arc/circle undo:** Fixed internal-edge removal/restoration; circle undo covers both semicircles (four internal edges).
+- **PIMPL:** `Sketch_delta` and `Sketch_op_recorder` hide implementation in `.cpp`; record types live in `Sketch_delta::Impl`. `Sketch_nodes::restore_node_at` moved to `Sketch_nodes::Impl`.
+- **Tests / GUI hooks:** Headless tests for undo (arc, circle, crossing edges) and mirror-with-no-selection cancel path; `GUI::sketch_left_click()` and `GUI::mirror_selected_sketch_edges()` for testability.
+- **Code style doc:** Reader-first `.cpp` order, helpers at file bottom, PIMPL examples.
+
+Closes sketch delta undo work tracked in `agents/issues/014-sketch-delta-undo-redo.md`.
+
+## Files Changed
+
+- `src/delta.h`
+- `src/sketch_delta.h`, `src/sketch_delta.cpp`
+- `src/occt_view.h`, `src/occt_view.cpp`
+- `src/sketch.h`, `src/sketch.cpp`, `src/sketch_json.cpp`
+- `src/sketch_nodes.h`, `src/sketch_nodes.cpp`
+- `src/gui.h`, `src/gui.cpp`, `src/gui_mode.cpp`
+- `tests/sketch_tests.cpp`
+- `docs/ezycad_code_style.md`
+- `agents/issues/014-sketch-delta-undo-redo.md`, `agents/prs/009-sketch-delta-undo-redo.md`
+
+## Related
+
+- Issue: (fill after opening — link to GitHub issue from `agents/issues/014-sketch-delta-undo-redo.md`)
+- Compare / branch: `Trailcode/better_undo_redo`
+- Draft: `agents/issues/014-sketch-delta-undo-redo.md`
+
+## Test Plan
+
+- [x] Build `EzyCad_lib` and `EzyCad_tests` (Release).
+- [x] Run:
+  `EzyCad_tests.exe --gtest_filter=Sketch_test.Undo*:Sketch_test.MirrorSelectedEdges_NoEdgesSelected`
+  (4 tests: arc undo, circle undo, crossing linear finalize undo, mirror no-selection cancel)
+- [ ] Manual: sketch linear edge add + undo/redo; arc/circle + undo/redo; mirror with axis and selected edges; mirror with no selection (error, undo stack unchanged).
+- [ ] Smoke: shape fuse/cut/chamfer undo still uses JSON snapshots.
+- [ ] No user-facing docs required for this refactor (internal undo architecture).
+
+## Notes
+
+- `push_undo_snapshot()` remains for non-sketch operations (shapes, GUI material changes, etc.).
+- `Sketch_op_recorder::cancel()` is called explicitly when mirror finds no selected edges; otherwise uncommitted recorders cancel in the destructor.
+- `note_prev_arc_edge` is available on the recorder but linear-style prev filtering at op start is the primary wired path; arc prev recording may expand in follow-up ops.
+- Record types intentionally live in `Sketch_delta::Impl`, not the public header.
+
+## Post-merge (checklist for the author)
+
+- [ ] Open GitHub issue from `agents/issues/014-sketch-delta-undo-redo.md` and link PR.
+- [ ] Fill issue/PR URLs in both agent drafts.
+- [ ] Consider `[Unreleased]` CHANGELOG entry if sketch undo behavior is user-visible enough to mention.

--- a/agents/prs/009-sketch-delta-undo-redo.md
+++ b/agents/prs/009-sketch-delta-undo-redo.md
@@ -29,7 +29,8 @@ Closes sketch delta undo work tracked in `agents/issues/014-sketch-delta-undo-re
 
 ## Related
 
-- Issue: (fill after opening — link to GitHub issue from `agents/issues/014-sketch-delta-undo-redo.md`)
+- Issue: https://github.com/trailcode/EzyCad/issues/144
+- PR: https://github.com/trailcode/EzyCad/pull/145
 - Compare / branch: `Trailcode/better_undo_redo`
 - Draft: `agents/issues/014-sketch-delta-undo-redo.md`
 
@@ -52,6 +53,6 @@ Closes sketch delta undo work tracked in `agents/issues/014-sketch-delta-undo-re
 
 ## Post-merge (checklist for the author)
 
-- [ ] Open GitHub issue from `agents/issues/014-sketch-delta-undo-redo.md` and link PR.
-- [ ] Fill issue/PR URLs in both agent drafts.
+- [x] Open GitHub issue from `agents/issues/014-sketch-delta-undo-redo.md` and link PR.
+- [x] Fill issue/PR URLs in both agent drafts.
 - [ ] Consider `[Unreleased]` CHANGELOG entry if sketch undo behavior is user-visible enough to mention.

--- a/docs/ezycad_code_style.md
+++ b/docs/ezycad_code_style.md
@@ -65,8 +65,9 @@ User-facing Markdown (now in `docs/`: `usage.md`, `usage-*.md`, `scripting.md`, 
 
 ## Code organization
 
-- **Reader-first order** (`.cpp`): Arrange functions from high-level behavior to lower-level detail so the first screen shows the primary workflow before helper details.
-- **Helper placement**: Prefer keeping narrow file-local helpers close to the functions that use them. Avoid large top-of-file helper blocks unless helpers are broadly reused across the file.
+- **Reader-first order** (`.cpp`): Put **public API and high-level workflow** at the top of the file (constructors, main entry points, orchestration). Put **lower-level details** below so the first screen shows what the module does before how it does it.
+- **Helper functions** (`.cpp`): Prefer **file-local static helpers** in an anonymous namespace at the **bottom** of the implementing `.cpp` file. Forward-declare them near the top (or above their first use) when needed. Avoid large helper blocks at the top of the file; the goal is high-level code first, helpers last for readability.
+- **PIMPL** (`class Foo; class Foo::Impl`): Use when hiding implementation details or when you want to swap implementations (e.g. `Sketch_nodes`, `Sketch_delta`). Keep record types and the public surface in the header; put data members and apply/clone logic in `Impl` inside the `.cpp`.
 - **Templates**: Prefer putting template implementations in `.inl` files included from the header (e.g. `types.inl`, `utl.inl`).
 - **OCCT handles**: Use `opencascade::handle<T>` and project aliases (e.g. `AIS_Shape_ptr`, `Shp_ptr`).
 - **Result/error handling**: See **Fail fast** below. Use `Result<T>` and `Status` from `utl.h`, `CHK_RET(...)` for early return on failure.
@@ -80,7 +81,7 @@ User-facing Markdown (now in `docs/`: `usage.md`, `usage-*.md`, `scripting.md`, 
 - Too much DRY can increase coupling by forcing unrelated code through one shared abstraction.
 - Prefer readability over clever reuse when repetition is small and explicit code is clearer.
 - **When duplication is acceptable**: a few lines repeated across nearby UI or glue code can beat a shared helper if call sites are likely to diverge (different tooltips, widths, or disabled logic) or if extracting would scatter one screen across many symbols. Prefer **locality**: keep a small block self-contained so a reader does not jump to understand one pane.
-- **Rule of thumb**: extract when the behavior is **the same and stable** (or when a bug fix must touch N copies); wait when the pattern is still moving. If you extract, prefer a **narrow file-local helper** next to its users over a generic framework.
+- **Rule of thumb**: extract when the behavior is **the same and stable** (or when a bug fix must touch N copies); wait when the pattern is still moving. If you extract, prefer a **file-local static helper at the bottom of the `.cpp`** (see **Code organization**) over a generic framework.
 - Context matters: stronger DRY is often good in monolith/shared-library code; some duplication can be healthier in fast-changing or separated systems.
 - Balance DRY with KISS, YAGNI, and overall cognitive load.
 

--- a/docs/ezycad_code_style.md
+++ b/docs/ezycad_code_style.md
@@ -67,7 +67,7 @@ User-facing Markdown (now in `docs/`: `usage.md`, `usage-*.md`, `scripting.md`, 
 
 - **Reader-first order** (`.cpp`): Put **public API and high-level workflow** at the top of the file (constructors, main entry points, orchestration). Put **lower-level details** below so the first screen shows what the module does before how it does it.
 - **Helper functions** (`.cpp`): Prefer **file-local static helpers** in an anonymous namespace at the **bottom** of the implementing `.cpp` file. Forward-declare them near the top (or above their first use) when needed. Avoid large helper blocks at the top of the file; the goal is high-level code first, helpers last for readability.
-- **PIMPL** (`class Foo; class Foo::Impl`): Use when hiding implementation details or when you want to swap implementations (e.g. `Sketch_nodes`, `Sketch_delta`). Keep record types and the public surface in the header; put data members and apply/clone logic in `Impl` inside the `.cpp`.
+- **PIMPL** (`class Foo; class Foo::Impl`): Use when hiding implementation details or when you want to swap implementations (e.g. `Sketch_nodes`, `Sketch_delta`). Keep the public surface in the header; put data members, private record types, and apply/clone logic in `Impl` inside the `.cpp`.
 - **Templates**: Prefer putting template implementations in `.inl` files included from the header (e.g. `types.inl`, `utl.inl`).
 - **OCCT handles**: Use `opencascade::handle<T>` and project aliases (e.g. `AIS_Shape_ptr`, `Shp_ptr`).
 - **Result/error handling**: See **Fail fast** below. Use `Result<T>` and `Status` from `utl.h`, `CHK_RET(...)` for early return on failure.

--- a/src/delta.h
+++ b/src/delta.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <memory>
+
+class Occt_view;
+
+/// One undo/redo step. Subclasses record a forward change; `apply_reverse` undoes it and
+/// `apply_forward` redoes it.
+class Delta
+{
+public:
+  virtual ~Delta() = default;
+
+  virtual void                   apply_forward(Occt_view& view) = 0;
+  virtual void                   apply_reverse(Occt_view& view) = 0;
+  virtual std::unique_ptr<Delta> clone() const                  = 0;
+};

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2703,6 +2703,74 @@ void GUI::on_mouse_pos(const ScreenCoords& screen_coords)
   }
 }
 
+void GUI::mirror_selected_sketch_edges() { m_view->curr_sketch().mirror_selected_edges(); }
+
+void GUI::on_left_click_(const ScreenCoords& screen_coords)
+{
+  switch (m_mode)
+  {
+    // clang-format off
+    case Mode::Move:                m_view->shp_move().finalize();                      break;
+    case Mode::Rotate:              m_view->shp_rotate().finalize();                    break;
+    case Mode::Scale:               m_view->shp_scale().finalize();                     break;
+    case Mode::Sketch_face_extrude: m_view->sketch_face_extrude(screen_coords, false);  break;
+    // clang-format on
+
+  case Mode::Sketch_add_node:
+  case Mode::Sketch_add_edge:
+  case Mode::Sketch_add_multi_edges:
+  case Mode::Sketch_add_seg_circle_arc:
+  case Mode::Sketch_add_square:
+  case Mode::Sketch_add_rectangle:
+  case Mode::Sketch_add_rectangle_center_pt:
+  case Mode::Sketch_add_circle:
+  case Mode::Sketch_add_slot:
+    hide_dist_edit();
+    m_view->curr_sketch().add_sketch_pt(screen_coords);
+    break;
+
+  case Mode::Sketch_operation_axis:
+    // Only treat LMB as "place axis point" while *defining* the axis.
+    // Once an axis exists, we stay in this mode so the Options panel can show
+    // the Mirror/Revolve/Clear buttons. Further clicks must be allowed to
+    // select sketch edges/faces (via AIS selection) without redefining the axis.
+    // To redefine, the user must first use the "Clear axis" button.
+    if (!m_view->curr_sketch().has_operation_axis())
+    {
+      hide_dist_edit();
+      m_view->curr_sketch().add_sketch_pt(screen_coords);
+    }
+    break;
+
+  case Mode::Shape_chamfer:
+    if (Status s = m_view->shp_chamfer().add_chamfer(screen_coords, m_chamfer_mode); !s.is_ok())
+      show_message(s.message());
+
+    break;
+
+  case Mode::Shape_fillet:
+    if (Status s = m_view->shp_fillet().add_fillet(screen_coords, m_fillet_mode); !s.is_ok())
+      show_message(s.message());
+
+    break;
+
+  case Mode::Shape_polar_duplicate:
+    if (Status s = m_view->shp_polar_dup().add_point(screen_coords); !s.is_ok())
+      show_message(s.message());
+
+    break;
+
+  default:
+    break;
+  }
+}
+
+void GUI::sketch_left_click(const ScreenCoords& screen_coords)
+{
+  m_view->on_mouse_move(screen_coords);
+  on_left_click_(screen_coords);
+}
+
 void GUI::on_mouse_button(int button, int action, int mods)
 {
   const ScreenCoords screen_coords(dvec2(ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y));
@@ -2721,62 +2789,7 @@ void GUI::on_mouse_button(int button, int action, int mods)
   m_view->ctx().UpdateCurrentViewer();
 
   if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS && mods == 0)
-    switch (m_mode)
-    {
-      // clang-format off
-      case Mode::Move:                m_view->shp_move().finalize();                      break;
-      case Mode::Rotate:              m_view->shp_rotate().finalize();                    break;
-      case Mode::Scale:               m_view->shp_scale().finalize();                     break;
-      case Mode::Sketch_face_extrude: m_view->sketch_face_extrude(screen_coords, false);  break;
-      // clang-format on
-
-    case Mode::Sketch_add_node:
-    case Mode::Sketch_add_edge:
-    case Mode::Sketch_add_multi_edges:
-    case Mode::Sketch_add_seg_circle_arc:
-    case Mode::Sketch_add_square:
-    case Mode::Sketch_add_rectangle:
-    case Mode::Sketch_add_rectangle_center_pt:
-    case Mode::Sketch_add_circle:
-    case Mode::Sketch_add_slot:
-      hide_dist_edit();
-      m_view->curr_sketch().add_sketch_pt(screen_coords);
-      break;
-
-    case Mode::Sketch_operation_axis:
-      // Only treat LMB as "place axis point" while *defining* the axis.
-      // Once an axis exists, we stay in this mode so the Options panel can show
-      // the Mirror/Revolve/Clear buttons. Further clicks must be allowed to
-      // select sketch edges/faces (via AIS selection) without redefining the axis.
-      // To redefine, the user must first use the "Clear axis" button.
-      if (!m_view->curr_sketch().has_operation_axis())
-      {
-        hide_dist_edit();
-        m_view->curr_sketch().add_sketch_pt(screen_coords);
-      }
-      break;
-
-    case Mode::Shape_chamfer:
-      if (Status s = m_view->shp_chamfer().add_chamfer(screen_coords, m_chamfer_mode); !s.is_ok())
-        show_message(s.message());
-
-      break;
-
-    case Mode::Shape_fillet:
-      if (Status s = m_view->shp_fillet().add_fillet(screen_coords, m_fillet_mode); !s.is_ok())
-        show_message(s.message());
-
-      break;
-
-    case Mode::Shape_polar_duplicate:
-      if (Status s = m_view->shp_polar_dup().add_point(screen_coords); !s.is_ok())
-        show_message(s.message());
-
-      break;
-
-    default:
-      break;
-    }
+    on_left_click_(screen_coords);
 
   else if (button == GLFW_MOUSE_BUTTON_RIGHT && action == GLFW_PRESS && mods == 0)
     // Right button is to finalize the current operation.

--- a/src/gui.h
+++ b/src/gui.h
@@ -138,9 +138,13 @@ public:
   void render_gui();
   void render_occt();
 
-  void        on_key(int key, int scancode, int action, int mods); // gui_mode.cpp
-  void        on_mouse_pos(const ScreenCoords& screen_coords);
-  void        on_mouse_button(int button, int action, int mods);
+  void on_key(int key, int scancode, int action, int mods); // gui_mode.cpp
+  void on_mouse_pos(const ScreenCoords& screen_coords);
+  void on_mouse_button(int button, int action, int mods);
+  /// Headless/tests: same sketch LMB placement as on_mouse_button (does not require ImGui mouse pos).
+  void sketch_left_click(const ScreenCoords& screen_coords);
+  /// Options panel **Mirror** button action (operation axis mode).
+  void        mirror_selected_sketch_edges();
   void        on_mouse_scroll(double xoffset, double yoffset);
   void        on_resize(int width, int height);
   Mode        get_mode() const { return m_mode; }
@@ -253,6 +257,7 @@ private:
   };
   void dist_edit_();
   void angle_edit_();
+  void on_left_click_(const ScreenCoords& screen_coords);
   void sketch_list_();
   void sketch_list_inspector_(Sketch& sketch, int index);
   void sketch_properties_dialog_();

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -788,7 +788,7 @@ void GUI::options_sketch_operation_axis_mode_()
   if (m_view->curr_sketch().has_operation_axis())
   {
     if (ImGui::Button("Mirror"))
-      m_view->curr_sketch().mirror_selected_edges();
+      mirror_selected_sketch_edges();
 
     static float revolve_angle = 360.0f;
 

--- a/src/occt_view.cpp
+++ b/src/occt_view.cpp
@@ -45,6 +45,7 @@
 #include <gp_Trsf.hxx>
 
 #include "dbg.h"
+#include "delta.h"
 #include "geom.h"
 #include "gui.h"
 #include "ply_io.h"
@@ -1870,9 +1871,7 @@ Shp_extrude&   Occt_view::shp_extrude()   { return m_shp_extrude;    }
 // clang-format on
 
 // ---------------------------------------------------------------------------
-// Undo / redo (full snapshot per step). A future delta-based approach would save
-// memory (one delta per step instead of full document) and CPU (apply/invert
-// deltas instead of to_json/load).
+// Undo / redo: sketch edits use element deltas; other operations use full JSON snapshots.
 void Occt_view::push_undo_snapshot()
 {
   if (m_restoring)
@@ -1882,6 +1881,20 @@ void Occt_view::push_undo_snapshot()
   Undo_entry entry;
   entry.json = to_json();
   entry.mode = m_gui.get_mode();
+  m_undo_stack.push_back(std::move(entry));
+  if (m_undo_stack.size() > k_max_undo)
+    m_undo_stack.erase(m_undo_stack.begin());
+}
+
+void Occt_view::push_undo_delta(std::unique_ptr<Delta> delta)
+{
+  if (m_restoring || !delta)
+    return;
+
+  m_redo_stack.clear();
+  Undo_entry entry;
+  entry.delta = std::move(delta);
+  entry.mode  = m_gui.get_mode();
   m_undo_stack.push_back(std::move(entry));
   if (m_undo_stack.size() > k_max_undo)
     m_undo_stack.erase(m_undo_stack.begin());
@@ -1900,14 +1913,25 @@ bool Occt_view::undo()
   if (!can_undo())
     return false;
 
-  m_restoring            = true;
-  const Undo_entry state = m_undo_stack.back();
+  m_restoring      = true;
+  Undo_entry state = std::move(m_undo_stack.back());
   m_undo_stack.pop_back();
+
   Undo_entry redo_entry;
-  redo_entry.json = to_json();
   redo_entry.mode = m_gui.get_mode();
+
+  if (state.delta)
+  {
+    redo_entry.delta = state.delta->clone();
+    state.delta->apply_reverse(*this);
+  }
+  else
+  {
+    redo_entry.json = to_json();
+    load(state.json, false); // Keep current view so undo/redo keeps a single perspective
+  }
+
   m_redo_stack.push_back(std::move(redo_entry));
-  load(state.json, false); // Keep current view so undo/redo keeps a single perspective
   m_gui.set_mode(state.mode);
   if (state.mode == Mode::Sketch_inspection_mode)
     m_gui.set_show_sketch_list(true);
@@ -1921,14 +1945,25 @@ bool Occt_view::redo()
   if (!can_redo())
     return false;
 
-  m_restoring            = true;
-  const Undo_entry state = m_redo_stack.back();
+  m_restoring      = true;
+  Undo_entry state = std::move(m_redo_stack.back());
   m_redo_stack.pop_back();
+
   Undo_entry undo_entry;
-  undo_entry.json = to_json();
   undo_entry.mode = m_gui.get_mode();
+
+  if (state.delta)
+  {
+    undo_entry.delta = state.delta->clone();
+    state.delta->apply_forward(*this);
+  }
+  else
+  {
+    undo_entry.json = to_json();
+    load(state.json, false); // Keep current view so undo/redo keeps a single perspective
+  }
+
   m_undo_stack.push_back(std::move(undo_entry));
-  load(state.json, false); // Keep current view so undo/redo keeps a single perspective
   m_gui.set_mode(state.mode);
   if (state.mode == Mode::Sketch_inspection_mode)
     m_gui.set_show_sketch_list(true);

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -26,8 +26,9 @@
 #include "shp_scale.h"
 #include "types.h"
 
-class Sketch;
+class Delta;
 class GUI;
+class Sketch;
 struct Length_dimension_style;
 class Prs3d_Drawer;
 class TopoDS_Face;
@@ -88,10 +89,11 @@ public:
   /// Writes STEP, IGES, binary STL, or PLY to \a file_path. Uses selected shapes if any, else all shapes.
   [[nodiscard]] Status export_document(Export_format fmt, const std::string& file_path);
 
-  // Undo / redo (document snapshot stack).
-  /// Saves current document (full JSON) and mode. A future delta-based approach would save memory
-  /// (store only changes per step) and CPU (apply/invert deltas instead of full serialize/load).
+  // Undo / redo (delta steps for sketch edits; full JSON snapshot for other operations).
+  /// Saves current document (full JSON) and mode.
   void push_undo_snapshot();
+  /// Records a sketch element delta (added/removed nodes and edges).
+  void push_undo_delta(std::unique_ptr<Delta> delta);
   /// Removes the last snapshot without restoring (e.g. aborted edit that did not change the document).
   void   pop_undo_snapshot();
   bool   undo();
@@ -313,8 +315,9 @@ private:
 
   struct Undo_entry
   {
-    std::string json;
-    Mode        mode; // Mode at time of operation; restored when navigating stacks
+    std::unique_ptr<Delta> delta;
+    std::string            json; // Full-document snapshot when `delta` is null
+    Mode                   mode; // Mode at time of operation; restored when navigating stacks
   };
 
   std::vector<Undo_entry> m_undo_stack;

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -29,6 +29,7 @@
 #include "imgui.h"
 #include "modes.h"
 #include "occt_view.h"
+#include "sketch_delta.h"
 #include "sketch_underlay.h"
 #include "utl.h"
 
@@ -725,6 +726,17 @@ void Sketch::finalize_edges_()
     m_tmp_edges.pop_back();
   }
 
+  if (m_tmp_edges.empty())
+    return;
+
+  // Record user-intent edges before any split/append side effects.
+  for (const Edge& te : m_tmp_edges)
+  {
+    EZY_ASSERT(te.node_idx_b.has_value());
+    if (m_undo_recorder)
+      m_undo_recorder->note_curr_linear_edge(m_nodes[te.node_idx_a], m_nodes[*te.node_idx_b]);
+  }
+
   std::vector<size_t> split_mid_points;
   for (Edge& e : m_tmp_edges)
   {
@@ -813,9 +825,16 @@ void Sketch::finalize_edges_()
           Edge edge_b{mid_pt_idx, *itr->node_idx_b};
           update_edge_shp_(edge_a, m_nodes[itr->node_idx_a], m_nodes[mid_pt_idx]);
           update_edge_shp_(edge_b, m_nodes[itr->node_idx_b], m_nodes[mid_pt_idx]);
+          if (m_undo_recorder)
+            m_undo_recorder->note_prev_linear_edge(itr->node_idx_a, *itr->node_idx_b, itr->node_idx_mid, itr->name);
           // Set midpoints for the new split edges so they can be snapped to
           edge_a.node_idx_mid = m_nodes.add_new_node(get_midpoint(m_nodes[itr->node_idx_a], m_nodes[mid_pt_idx]), true);
           edge_b.node_idx_mid = m_nodes.add_new_node(get_midpoint(m_nodes[mid_pt_idx], m_nodes[itr->node_idx_b]), true);
+          if (m_undo_recorder)
+          {
+            m_undo_recorder->note_curr_node(edge_a.node_idx_mid.value());
+            m_undo_recorder->note_curr_node(edge_b.node_idx_mid.value());
+          }
           m_ctx.Remove(itr->shp, false);
           m_edges.erase(itr);
           m_nodes[mid_pt_idx].midpoint = false;
@@ -830,7 +849,12 @@ void Sketch::finalize_edges_()
   // GUI finalize path produces the same atomic edge count as direct add_edge_ (e.g. 4
   // edges for a cross, whether or not the cross is at an existing mid).
   for (const auto& ip : batch_inters)
-    split_linear_edges_at_node_if_interior_(m_nodes.get_node_exact(ip));
+  {
+    const size_t nidx = m_nodes.get_node_exact(ip);
+    if (m_undo_recorder)
+      m_undo_recorder->note_curr_node(nidx);
+    split_linear_edges_at_node_if_interior_(nidx);
+  }
 
   m_nodes.hide_snap_annos();
   update_faces_();
@@ -840,7 +864,9 @@ void Sketch::add_node_pt_(const ScreenCoords& screen_coords)
 {
   auto commit_b = [this](size_t node_b)
   {
-    m_view.push_undo_snapshot();
+    Sketch_op_recorder rec(m_view, *this);
+    if (m_undo_recorder)
+      m_undo_recorder->note_curr_node(node_b);
     split_linear_edges_at_node_if_interior_(node_b);
 
     // Add-node mode: the rubber band is only for placement (snap / dimension / angle). Do not create
@@ -851,6 +877,7 @@ void Sketch::add_node_pt_(const ScreenCoords& screen_coords)
     m_tmp_dim_anno.Nullify();
     m_nodes.hide_snap_annos();
     update_faces_();
+    rec.commit();
   };
 
   if (m_entered_edge_angle.has_value() && m_tmp_edges.size())
@@ -907,13 +934,16 @@ void Sketch::add_node_pt_(const ScreenCoords& screen_coords)
       return;
     }
 
-    m_view.push_undo_snapshot();
-    const size_t ni = m_nodes.add_new_node(pt, false, true);
+    Sketch_op_recorder rec(m_view, *this);
+    const size_t       ni = m_nodes.add_new_node(pt, false, true);
+    if (m_undo_recorder)
+      m_undo_recorder->note_curr_node(ni);
     split_linear_edges_at_node_if_interior_(ni);
     m_ctx.Remove(m_tmp_dim_anno, true);
     m_tmp_dim_anno.Nullify();
     m_nodes.hide_snap_annos();
     update_faces_();
+    rec.commit();
   };
 
   move_sketch_pt_(screen_coords, check_node);
@@ -1029,6 +1059,9 @@ void Sketch::split_linear_edges_at_node_if_interior_(size_t node_idx)
       Edge edge_b{node_idx};
       update_edge_end_pt_(edge_b, b);
 
+      if (m_undo_recorder)
+        m_undo_recorder->note_prev_linear_edge(itr->node_idx_a, *itr->node_idx_b, itr->node_idx_mid, itr->name);
+
       m_ctx.Remove(itr->shp, false);
       m_edges.erase(itr);
       m_nodes[node_idx].midpoint = false;
@@ -1062,9 +1095,14 @@ void Sketch::add_arc_circle_pt_(const ScreenCoords& screen_coords)
 
   if (m_tmp_node_idxs.size() == 3)
   {
-    add_arc_circle_(m_tmp_node_idxs);
+    Sketch_op_recorder rec(m_view, *this);
+    const gp_Pnt2d&    pt_a = m_nodes[m_tmp_node_idxs[0]];
+    const gp_Pnt2d&    pt_c = m_nodes[m_tmp_node_idxs[1]];
+    const gp_Pnt2d&    pt_b = m_nodes[m_tmp_node_idxs[2]];
+    add_arc_circle_(pt_a, pt_b, pt_c);
     m_tmp_node_idxs.clear();
     update_faces_();
+    rec.commit();
   }
 }
 
@@ -1214,6 +1252,9 @@ void Sketch::add_operation_axis_pt_(const ScreenCoords& screen_coords)
 void Sketch::finalize_operation_axis_()
 {
   m_operation_axis = std::move(m_tmp_edges.back());
+  if (m_undo_recorder && m_operation_axis->node_idx_b.has_value())
+    m_undo_recorder->note_curr_operation_axis(m_nodes[m_operation_axis->node_idx_a], m_nodes[*m_operation_axis->node_idx_b]);
+
   cancel_elm(); // Reset state, we have the operation axis
   sync_operation_axis_display_();
   sync_permanent_node_annos_();
@@ -1235,11 +1276,12 @@ bool Sketch::has_operation_axis() const { return m_operation_axis.has_value(); }
 void Sketch::mirror_selected_edges()
 {
   EZY_ASSERT(m_operation_axis.has_value());
-  m_view.push_undo_snapshot();
+  Sketch_op_recorder rec(m_view, *this);
 
   const std::vector<Edge> mirror_edges = get_selected_edges_();
   if (mirror_edges.empty())
   {
+    rec.cancel();
     m_view.gui().show_message(ERROR_NO_EDGES_SELECTED);
     return;
   }
@@ -1297,6 +1339,7 @@ void Sketch::mirror_selected_edges()
 
   m_nodes.hide_snap_annos();
   update_faces_();
+  rec.commit();
 }
 
 Shp_rslt Sketch::revolve_selected(const double angle)
@@ -1493,8 +1536,10 @@ void Sketch::check_dimension_rubber_()
   const size_t b = m_nodes.get_node_exact(*m_last_pt, true);
   clear_all(m_entered_edge_len);
 
-  m_view.push_undo_snapshot();
+  Sketch_op_recorder rec(m_view, *this);
   split_linear_edges_at_node_if_interior_(b);
+  if (m_undo_recorder)
+    m_undo_recorder->note_curr_node(b);
 
   m_tmp_node_idxs.clear();
   clear_tmps_();
@@ -1502,6 +1547,7 @@ void Sketch::check_dimension_rubber_()
   m_tmp_dim_anno.Nullify();
   m_nodes.hide_snap_annos();
   update_faces_();
+  rec.commit();
 }
 
 void Sketch::finalize_add_node_elm_cleanup_()
@@ -1528,6 +1574,9 @@ void Sketch::add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
 {
   if (!unique(pt_a, pt_b))
     return;
+
+  if (m_undo_recorder)
+    m_undo_recorder->note_curr_linear_edge(pt_a, pt_b);
 
   // Find intersections (crossings or T-touches) between this new segment and all *currently existing* linear edges.
   // We will split the existing ones at interior intersections, and subdivide this new one as needed.
@@ -1611,7 +1660,9 @@ void Sketch::add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
   // Endpoint touches (shared corners) are excluded here so we do not invoke snap on known vertices.
   for (const auto& inter_p : inters_to_split)
   {
-    size_t nidx = m_nodes.get_node_exact(inter_p);
+    const size_t nidx = m_nodes.get_node_exact(inter_p);
+    if (m_undo_recorder)
+      m_undo_recorder->note_curr_node(nidx);
     split_linear_edges_at_node_if_interior_(nidx);
   }
 
@@ -1830,20 +1881,25 @@ void Sketch::add_or_toggle_length_dim_between_node_indices_(size_t node_a, size_
   for (auto it = m_length_dimensions.begin(); it != m_length_dimensions.end(); ++it)
     if (it->node_idx_lo == lo && it->node_idx_hi == hi)
     {
-      m_view.push_undo_snapshot();
+      Sketch_op_recorder rec(m_view, *this);
+      rec.note_prev_length_dim(lo, hi, it->visible, it->flyout_offset, it->name);
       if (!it->dim.IsNull())
         m_ctx.Remove(it->dim, true);
 
       m_length_dimensions.erase(it);
+      rec.commit();
       return;
     }
 
-  m_view.push_undo_snapshot();
-  Length_dimension d;
+  Sketch_op_recorder rec(m_view, *this);
+  Length_dimension   d;
   d.node_idx_lo = lo;
   d.node_idx_hi = hi;
   m_length_dimensions.push_back(std::move(d));
   rebuild_length_dimension_display_(m_length_dimensions.back());
+  rec.note_curr_length_dim(lo, hi, m_length_dimensions.back().visible, m_length_dimensions.back().flyout_offset,
+                           m_length_dimensions.back().name);
+  rec.commit();
 }
 
 void Sketch::json_add_length_dimension_(size_t node_a, size_t node_b, const bool visible,
@@ -1913,7 +1969,7 @@ void Sketch::toggle_edge_dim_anno(const ScreenCoords& screen_coords)
 
 void Sketch::finalize_elm()
 {
-  m_view.push_undo_snapshot();
+  Sketch_op_recorder rec(m_view, *this);
   m_show_dim_input     = false;
   m_show_angle_input   = false;
   m_entered_edge_angle = std::nullopt;
@@ -1945,6 +2001,8 @@ void Sketch::finalize_elm()
   default:
     EZY_ASSERT(false);
   }
+
+  rec.commit();
 }
 
 // Cancel related
@@ -2578,9 +2636,19 @@ void Sketch::update_edge_end_pt_(Edge& edge, size_t end_pt_idx)
 
 void Sketch::add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
 {
-  std::vector<size_t> node_idxs{m_nodes.get_node_exact(pt_a), m_nodes.get_node_exact(pt_c), m_nodes.get_node_exact(pt_b)};
+  const size_t node_idx_a = m_nodes.get_node_exact(pt_a);
+  const size_t node_idx_c = m_nodes.get_node_exact(pt_c);
+  const size_t node_idx_b = m_nodes.get_node_exact(pt_b);
 
-  add_arc_circle_(node_idxs);
+  if (m_undo_recorder)
+  {
+    m_undo_recorder->note_curr_arc_edge(pt_a, pt_b, pt_c);
+    m_undo_recorder->note_curr_node(node_idx_a);
+    m_undo_recorder->note_curr_node(node_idx_c);
+    m_undo_recorder->note_curr_node(node_idx_b);
+  }
+
+  add_arc_circle_(std::vector<size_t>{node_idx_a, node_idx_c, node_idx_b});
 }
 
 void Sketch::add_arc_circle_(const std::vector<size_t>& node_idxs)

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -20,6 +20,7 @@
 class Occt_view;
 struct Length_dimension_style;
 class gp_Pln;
+class Sketch_op_recorder;
 class TopoDS_Wire;
 class Sketch;
 class Sketch_underlay;
@@ -199,6 +200,8 @@ public:
   // private:
   friend class Sketch_json;
   friend class Sketch_access;
+  friend class Sketch_delta;
+  friend class Sketch_op_recorder;
   friend class Sketch_test; // TEST_F(Sketch_test, JsonSerializationDeserialization)
 
   static bool s_add_mid_pt_edges;
@@ -425,4 +428,6 @@ public:
   bool                       m_show_dims{true};
 
   std::unique_ptr<Sketch_underlay> m_underlay;
+
+  Sketch_op_recorder* m_undo_recorder{nullptr};
 };

--- a/src/sketch_delta.cpp
+++ b/src/sketch_delta.cpp
@@ -13,6 +13,337 @@
 namespace
 {
 
+// Forward declarations; definitions are at the bottom of this file (reader-first order).
+bool on_closed_segment_2d_(const gp_Pnt2d& p, const gp_Pnt2d& a, const gp_Pnt2d& b);
+bool prev_linear_equal_(const Sketch_delta::Prev_edge_rec& x, const Sketch_delta::Prev_edge_rec& y);
+bool curr_linear_equal_(const Sketch_delta::Curr_linear_edge_record& x, const Sketch_delta::Curr_linear_edge_record& y);
+bool arc_equal_(const Sketch_delta::Arc_edge_record& x, const Sketch_delta::Arc_edge_record& y);
+bool length_dim_equal_(const Sketch_delta::Length_dim_record& x, const Sketch_delta::Length_dim_record& y);
+void remove_linear_edges_on_segment_(Sketch& sketch, const gp_Pnt2d& seg_a, const gp_Pnt2d& seg_b);
+void remove_linear_edges_on_node_segment_(Sketch& sketch, size_t node_a, size_t node_b);
+void remove_arc_edge_(Sketch& sketch, const Sketch_delta::Arc_edge_record& rec);
+void remove_length_dim_(Sketch& sketch, const Sketch_delta::Length_dim_record& rec);
+void tombstone_node_(Sketch& sketch, size_t node_idx);
+void restore_prev_linear_edge_(Sketch& sketch, const Sketch_delta::Prev_edge_rec& rec);
+void restore_length_dim_(Sketch& sketch, const Sketch_delta::Length_dim_record& rec);
+void restore_prev_operation_axis_(Sketch& sketch, const Sketch_delta::Prev_edge_rec& rec);
+bool is_linear_sketch_edge_(const Sketch::Edge& e);
+void capture_linear_edges_at_start_(Sketch& sketch, std::vector<Sketch_delta::Prev_edge_rec>& out);
+bool linear_edge_at_op_start_(const std::vector<Sketch_delta::Prev_edge_rec>& at_start, const Sketch_delta::Prev_edge_rec& rec);
+
+} // namespace
+
+class Sketch_delta::Impl
+{
+public:
+  friend class Sketch_op_recorder;
+
+  Sketch*                                        m_sketch{nullptr};
+  std::string                                    m_sketch_name;
+  std::vector<Sketch_delta::Prev_edge_rec>       prev_linear_edges;
+  std::vector<Sketch_delta::Curr_linear_edge_record> curr_linear_edges;
+  std::vector<Sketch_delta::Arc_edge_record>     prev_arc_edges;
+  std::vector<Sketch_delta::Arc_edge_record>     curr_arc_edges;
+  std::vector<size_t>                            curr_node_idxs;
+  std::vector<Sketch_delta::Length_dim_record>   prev_length_dims;
+  std::vector<Sketch_delta::Length_dim_record>   curr_length_dims;
+  std::optional<Sketch_delta::Prev_edge_rec>     prev_operation_axis;
+  std::optional<Sketch_delta::Curr_linear_edge_record> curr_operation_axis;
+
+  Impl(Sketch& sketch, std::string sketch_name);
+
+  Sketch* resolve_sketch_(Occt_view& view) const;
+  void    apply_forward_(Sketch& sketch) const;
+  void    apply_reverse_(Sketch& sketch) const;
+  std::unique_ptr<Sketch_delta> clone() const;
+};
+
+Sketch_delta::Sketch_delta(Sketch& sketch, std::string sketch_name)
+    : m_impl(std::make_unique<Impl>(sketch, std::move(sketch_name)))
+{
+}
+
+Sketch_delta::~Sketch_delta() = default;
+
+void Sketch_delta::apply_forward(Occt_view& view)
+{
+  Sketch* sketch = m_impl->resolve_sketch_(view);
+  EZY_ASSERT(sketch);
+  m_impl->apply_forward_(*sketch);
+}
+
+void Sketch_delta::apply_reverse(Occt_view& view)
+{
+  Sketch* sketch = m_impl->resolve_sketch_(view);
+  EZY_ASSERT(sketch);
+  m_impl->apply_reverse_(*sketch);
+}
+
+std::unique_ptr<Delta> Sketch_delta::clone() const { return m_impl->clone(); }
+
+Sketch_op_recorder::Sketch_op_recorder(Occt_view& view, Sketch& sketch)
+    : m_view(view)
+    , m_sketch(sketch)
+{
+  for (size_t i = 0, n = sketch.m_nodes.size(); i < n; ++i)
+    if (!sketch.m_nodes[i].deleted)
+      m_live_nodes_at_start.insert(i);
+
+  capture_linear_edges_at_start_(sketch, m_linear_edges_at_start);
+
+  m_delta                = std::make_unique<Sketch_delta>(sketch, sketch.get_name());
+  sketch.m_undo_recorder = this;
+}
+
+Sketch_op_recorder::~Sketch_op_recorder()
+{
+  if (m_sketch.m_undo_recorder == this)
+    m_sketch.m_undo_recorder = nullptr;
+
+  if (m_active && !m_committed)
+    cancel();
+}
+
+void Sketch_op_recorder::note_prev_linear_edge(size_t node_idx_a, size_t node_idx_b, std::optional<size_t> node_idx_mid,
+                                               const std::string& name)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Prev_edge_rec rec{node_idx_a, node_idx_b, node_idx_mid, name};
+  if (!linear_edge_at_op_start_(m_linear_edges_at_start, rec))
+    return;
+
+  Sketch_delta::Impl& d = *m_delta->m_impl;
+  for (const Sketch_delta::Prev_edge_rec& x : d.prev_linear_edges)
+    if (prev_linear_equal_(x, rec))
+      return;
+
+  d.prev_linear_edges.push_back(std::move(rec));
+}
+
+void Sketch_op_recorder::note_curr_linear_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Curr_linear_edge_record rec{pt_a, pt_b};
+  for (const Sketch_delta::Curr_linear_edge_record& x : m_delta->m_impl->curr_linear_edges)
+    if (curr_linear_equal_(x, rec))
+      return;
+
+  m_delta->m_impl->curr_linear_edges.push_back(rec);
+}
+
+void Sketch_op_recorder::note_prev_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Arc_edge_record rec{pt_a, pt_b, pt_c};
+  for (const Sketch_delta::Arc_edge_record& x : m_delta->m_impl->prev_arc_edges)
+    if (arc_equal_(x, rec))
+      return;
+
+  m_delta->m_impl->prev_arc_edges.push_back(rec);
+}
+
+void Sketch_op_recorder::note_curr_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Arc_edge_record rec{pt_a, pt_b, pt_c};
+  for (const Sketch_delta::Arc_edge_record& x : m_delta->m_impl->curr_arc_edges)
+    if (arc_equal_(x, rec))
+      return;
+
+  m_delta->m_impl->curr_arc_edges.push_back(rec);
+}
+
+void Sketch_op_recorder::note_curr_node(size_t node_idx)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  if (m_live_nodes_at_start.count(node_idx))
+    return;
+
+  std::vector<size_t>& nodes = m_delta->m_impl->curr_node_idxs;
+  if (std::find(nodes.begin(), nodes.end(), node_idx) != nodes.end())
+    return;
+
+  nodes.push_back(node_idx);
+}
+
+void Sketch_op_recorder::note_prev_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
+                                              const std::string& name)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Length_dim_record rec{lo, hi, visible, flyout, name};
+  for (const Sketch_delta::Length_dim_record& x : m_delta->m_impl->prev_length_dims)
+    if (length_dim_equal_(x, rec))
+      return;
+
+  m_delta->m_impl->prev_length_dims.push_back(std::move(rec));
+}
+
+void Sketch_op_recorder::note_curr_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
+                                              const std::string& name)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Length_dim_record rec{lo, hi, visible, flyout, name};
+  for (const Sketch_delta::Length_dim_record& x : m_delta->m_impl->curr_length_dims)
+    if (length_dim_equal_(x, rec))
+      return;
+
+  m_delta->m_impl->curr_length_dims.push_back(std::move(rec));
+}
+
+void Sketch_op_recorder::note_prev_operation_axis(size_t node_idx_a, size_t node_idx_b)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  m_delta->m_impl->prev_operation_axis = Sketch_delta::Prev_edge_rec{node_idx_a, node_idx_b, std::nullopt, {}};
+}
+
+void Sketch_op_recorder::note_curr_operation_axis(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  m_delta->m_impl->curr_operation_axis = Sketch_delta::Curr_linear_edge_record{pt_a, pt_b};
+}
+
+bool Sketch_op_recorder::empty_() const
+{
+  if (!m_delta)
+    return true;
+
+  const Sketch_delta::Impl& d = *m_delta->m_impl;
+  return d.prev_linear_edges.empty() && d.curr_linear_edges.empty() && d.prev_arc_edges.empty() &&
+         d.curr_arc_edges.empty() && d.curr_node_idxs.empty() && d.prev_length_dims.empty() &&
+         d.curr_length_dims.empty() && !d.prev_operation_axis.has_value() && !d.curr_operation_axis.has_value();
+}
+
+void Sketch_op_recorder::commit()
+{
+  if (!m_active || m_committed)
+    return;
+
+  m_committed = true;
+  m_active    = false;
+
+  if (m_sketch.m_undo_recorder == this)
+    m_sketch.m_undo_recorder = nullptr;
+
+  if (!empty_())
+    m_view.push_undo_delta(std::move(m_delta));
+}
+
+void Sketch_op_recorder::cancel()
+{
+  m_active    = false;
+  m_committed = true;
+
+  if (m_sketch.m_undo_recorder == this)
+    m_sketch.m_undo_recorder = nullptr;
+}
+
+Sketch_delta::Impl::Impl(Sketch& sketch, std::string sketch_name)
+    : m_sketch(&sketch)
+    , m_sketch_name(std::move(sketch_name))
+{
+}
+
+Sketch* Sketch_delta::Impl::resolve_sketch_(Occt_view& view) const
+{
+  if (m_sketch)
+    return m_sketch;
+
+  for (const Sketch::sptr& s : view.get_sketches())
+    if (s->get_name() == m_sketch_name)
+      return s.get();
+
+  return nullptr;
+}
+
+void Sketch_delta::Impl::apply_forward_(Sketch& sketch) const
+{
+  for (const Sketch_delta::Curr_linear_edge_record& e : curr_linear_edges)
+    sketch.add_edge_(e.pt_a, e.pt_b);
+
+  for (const Sketch_delta::Arc_edge_record& e : curr_arc_edges)
+    sketch.add_arc_circle_(e.pt_a, e.pt_b, e.pt_c);
+
+  for (const Sketch_delta::Length_dim_record& d : curr_length_dims)
+    restore_length_dim_(sketch, d);
+
+  if (curr_operation_axis.has_value())
+    sketch.sketch_json_set_operation_axis_(curr_operation_axis->pt_a, curr_operation_axis->pt_b);
+
+  sketch.m_nodes.hide_snap_annos();
+  sketch.update_faces_();
+}
+
+void Sketch_delta::Impl::apply_reverse_(Sketch& sketch) const
+{
+  if (curr_operation_axis.has_value())
+    sketch.clear_operation_axis();
+
+  for (const Sketch_delta::Length_dim_record& d : curr_length_dims)
+    remove_length_dim_(sketch, d);
+
+  for (const Sketch_delta::Arc_edge_record& e : curr_arc_edges)
+    remove_arc_edge_(sketch, e);
+
+  for (const Sketch_delta::Curr_linear_edge_record& e : curr_linear_edges)
+    remove_linear_edges_on_segment_(sketch, e.pt_a, e.pt_b);
+
+  for (const Sketch_delta::Prev_edge_rec& e : prev_linear_edges)
+    restore_prev_linear_edge_(sketch, e);
+
+  for (const Sketch_delta::Arc_edge_record& e : prev_arc_edges)
+    sketch.add_arc_circle_(e.pt_a, e.pt_b, e.pt_c);
+
+  if (prev_operation_axis.has_value())
+    restore_prev_operation_axis_(sketch, *prev_operation_axis);
+
+  for (const Sketch_delta::Length_dim_record& d : prev_length_dims)
+    restore_length_dim_(sketch, d);
+
+  for (size_t node_idx : curr_node_idxs)
+    tombstone_node_(sketch, node_idx);
+
+  sketch.m_nodes.hide_snap_annos();
+  sketch.update_faces_();
+}
+
+std::unique_ptr<Sketch_delta> Sketch_delta::Impl::clone() const
+{
+  auto copy     = std::make_unique<Sketch_delta>(*m_sketch, m_sketch_name);
+  Impl& copy_impl = *copy->m_impl;
+  copy_impl.m_sketch            = m_sketch;
+  copy_impl.prev_linear_edges   = prev_linear_edges;
+  copy_impl.curr_linear_edges   = curr_linear_edges;
+  copy_impl.prev_arc_edges      = prev_arc_edges;
+  copy_impl.curr_arc_edges      = curr_arc_edges;
+  copy_impl.curr_node_idxs      = curr_node_idxs;
+  copy_impl.prev_length_dims    = prev_length_dims;
+  copy_impl.curr_length_dims    = curr_length_dims;
+  copy_impl.prev_operation_axis = prev_operation_axis;
+  copy_impl.curr_operation_axis = curr_operation_axis;
+  return copy;
+}
+
+namespace
+{
+
 bool on_closed_segment_2d_(const gp_Pnt2d& p, const gp_Pnt2d& a, const gp_Pnt2d& b)
 {
   if (p.SquareDistance(a) <= Precision::SquareConfusion())
@@ -201,274 +532,3 @@ bool linear_edge_at_op_start_(const std::vector<Sketch_delta::Prev_edge_rec>& at
 }
 
 } // namespace
-
-Sketch_op_recorder::Sketch_op_recorder(Occt_view& view, Sketch& sketch)
-    : m_view(view)
-    , m_sketch(sketch)
-{
-  for (size_t i = 0, n = sketch.m_nodes.size(); i < n; ++i)
-    if (!sketch.m_nodes[i].deleted)
-      m_live_nodes_at_start.insert(i);
-
-  capture_linear_edges_at_start_(sketch, m_linear_edges_at_start);
-
-  m_delta                = std::make_unique<Sketch_delta>(sketch, sketch.get_name());
-  sketch.m_undo_recorder = this;
-}
-
-Sketch_op_recorder::~Sketch_op_recorder()
-{
-  if (m_sketch.m_undo_recorder == this)
-    m_sketch.m_undo_recorder = nullptr;
-
-  if (m_active && !m_committed)
-    cancel();
-}
-
-void Sketch_op_recorder::note_prev_linear_edge(size_t node_idx_a, size_t node_idx_b, std::optional<size_t> node_idx_mid,
-                                               const std::string& name)
-{
-  if (!m_active || !m_delta)
-    return;
-
-  Sketch_delta::Prev_edge_rec rec{node_idx_a, node_idx_b, node_idx_mid, name};
-  if (!linear_edge_at_op_start_(m_linear_edges_at_start, rec))
-    return;
-
-  for (const Sketch_delta::Prev_edge_rec& x : m_delta->prev_linear_edges)
-    if (prev_linear_equal_(x, rec))
-      return;
-
-  m_delta->prev_linear_edges.push_back(std::move(rec));
-}
-
-void Sketch_op_recorder::note_curr_linear_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
-{
-  if (!m_active || !m_delta)
-    return;
-
-  Sketch_delta::Curr_linear_edge_record rec{pt_a, pt_b};
-  for (const Sketch_delta::Curr_linear_edge_record& x : m_delta->curr_linear_edges)
-    if (curr_linear_equal_(x, rec))
-      return;
-
-  m_delta->curr_linear_edges.push_back(rec);
-}
-
-void Sketch_op_recorder::note_prev_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
-{
-  if (!m_active || !m_delta)
-    return;
-
-  Sketch_delta::Arc_edge_record rec{pt_a, pt_b, pt_c};
-  for (const Sketch_delta::Arc_edge_record& x : m_delta->prev_arc_edges)
-    if (arc_equal_(x, rec))
-      return;
-
-  m_delta->prev_arc_edges.push_back(rec);
-}
-
-void Sketch_op_recorder::note_curr_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
-{
-  if (!m_active || !m_delta)
-    return;
-
-  Sketch_delta::Arc_edge_record rec{pt_a, pt_b, pt_c};
-  for (const Sketch_delta::Arc_edge_record& x : m_delta->curr_arc_edges)
-    if (arc_equal_(x, rec))
-      return;
-
-  m_delta->curr_arc_edges.push_back(rec);
-}
-
-void Sketch_op_recorder::note_curr_node(size_t node_idx)
-{
-  if (!m_active || !m_delta)
-    return;
-
-  if (m_live_nodes_at_start.count(node_idx))
-    return;
-
-  if (std::find(m_delta->curr_node_idxs.begin(), m_delta->curr_node_idxs.end(), node_idx) != m_delta->curr_node_idxs.end())
-    return;
-
-  m_delta->curr_node_idxs.push_back(node_idx);
-}
-
-void Sketch_op_recorder::note_prev_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
-                                              const std::string& name)
-{
-  if (!m_active || !m_delta)
-    return;
-
-  Sketch_delta::Length_dim_record rec{lo, hi, visible, flyout, name};
-  for (const Sketch_delta::Length_dim_record& x : m_delta->prev_length_dims)
-    if (length_dim_equal_(x, rec))
-      return;
-
-  m_delta->prev_length_dims.push_back(std::move(rec));
-}
-
-void Sketch_op_recorder::note_curr_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
-                                              const std::string& name)
-{
-  if (!m_active || !m_delta)
-    return;
-
-  Sketch_delta::Length_dim_record rec{lo, hi, visible, flyout, name};
-  for (const Sketch_delta::Length_dim_record& x : m_delta->curr_length_dims)
-    if (length_dim_equal_(x, rec))
-      return;
-
-  m_delta->curr_length_dims.push_back(std::move(rec));
-}
-
-void Sketch_op_recorder::note_prev_operation_axis(size_t node_idx_a, size_t node_idx_b)
-{
-  if (!m_active || !m_delta)
-    return;
-
-  m_delta->prev_operation_axis = Sketch_delta::Prev_edge_rec{node_idx_a, node_idx_b, std::nullopt, {}};
-}
-
-void Sketch_op_recorder::note_curr_operation_axis(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
-{
-  if (!m_active || !m_delta)
-    return;
-
-  m_delta->curr_operation_axis = Sketch_delta::Curr_linear_edge_record{pt_a, pt_b};
-}
-
-bool Sketch_op_recorder::empty_() const
-{
-  if (!m_delta)
-    return true;
-
-  return m_delta->prev_linear_edges.empty() && m_delta->curr_linear_edges.empty() && m_delta->prev_arc_edges.empty() &&
-         m_delta->curr_arc_edges.empty() && m_delta->curr_node_idxs.empty() && m_delta->prev_length_dims.empty() &&
-         m_delta->curr_length_dims.empty() && !m_delta->prev_operation_axis.has_value() &&
-         !m_delta->curr_operation_axis.has_value();
-}
-
-void Sketch_op_recorder::commit()
-{
-  if (!m_active || m_committed)
-    return;
-
-  m_committed = true;
-  m_active    = false;
-
-  if (m_sketch.m_undo_recorder == this)
-    m_sketch.m_undo_recorder = nullptr;
-
-  if (!empty_())
-    m_view.push_undo_delta(std::move(m_delta));
-}
-
-void Sketch_op_recorder::cancel()
-{
-  m_active    = false;
-  m_committed = true;
-
-  if (m_sketch.m_undo_recorder == this)
-    m_sketch.m_undo_recorder = nullptr;
-}
-
-Sketch_delta::Sketch_delta(Sketch& sketch, std::string sketch_name)
-    : m_sketch(&sketch)
-    , m_sketch_name(std::move(sketch_name))
-{
-}
-
-Sketch* Sketch_delta::resolve_sketch_(Occt_view& view) const
-{
-  if (m_sketch)
-    return m_sketch;
-
-  for (const Sketch::sptr& s : view.get_sketches())
-    if (s->get_name() == m_sketch_name)
-      return s.get();
-
-  return nullptr;
-}
-
-void Sketch_delta::apply_forward_(Sketch& sketch) const
-{
-  for (const Curr_linear_edge_record& e : curr_linear_edges)
-    sketch.add_edge_(e.pt_a, e.pt_b);
-
-  for (const Arc_edge_record& e : curr_arc_edges)
-    sketch.add_arc_circle_(e.pt_a, e.pt_b, e.pt_c);
-
-  for (const Length_dim_record& d : curr_length_dims)
-    restore_length_dim_(sketch, d);
-
-  if (curr_operation_axis.has_value())
-    sketch.sketch_json_set_operation_axis_(curr_operation_axis->pt_a, curr_operation_axis->pt_b);
-
-  sketch.m_nodes.hide_snap_annos();
-  sketch.update_faces_();
-}
-
-void Sketch_delta::apply_reverse_(Sketch& sketch) const
-{
-  if (curr_operation_axis.has_value())
-    sketch.clear_operation_axis();
-
-  for (const Length_dim_record& d : curr_length_dims)
-    remove_length_dim_(sketch, d);
-
-  for (const Arc_edge_record& e : curr_arc_edges)
-    remove_arc_edge_(sketch, e);
-
-  for (const Curr_linear_edge_record& e : curr_linear_edges)
-    remove_linear_edges_on_segment_(sketch, e.pt_a, e.pt_b);
-
-  for (const Prev_edge_rec& e : prev_linear_edges)
-    restore_prev_linear_edge_(sketch, e);
-
-  for (const Arc_edge_record& e : prev_arc_edges)
-    sketch.add_arc_circle_(e.pt_a, e.pt_b, e.pt_c);
-
-  if (prev_operation_axis.has_value())
-    restore_prev_operation_axis_(sketch, *prev_operation_axis);
-
-  for (const Length_dim_record& d : prev_length_dims)
-    restore_length_dim_(sketch, d);
-
-  for (size_t node_idx : curr_node_idxs)
-    tombstone_node_(sketch, node_idx);
-
-  sketch.m_nodes.hide_snap_annos();
-  sketch.update_faces_();
-}
-
-void Sketch_delta::apply_forward(Occt_view& view)
-{
-  Sketch* sketch = resolve_sketch_(view);
-  EZY_ASSERT(sketch);
-  apply_forward_(*sketch);
-}
-
-void Sketch_delta::apply_reverse(Occt_view& view)
-{
-  Sketch* sketch = resolve_sketch_(view);
-  EZY_ASSERT(sketch);
-  apply_reverse_(*sketch);
-}
-
-std::unique_ptr<Delta> Sketch_delta::clone() const
-{
-  auto copy                 = std::make_unique<Sketch_delta>(*m_sketch, m_sketch_name);
-  copy->m_sketch            = m_sketch;
-  copy->prev_linear_edges   = prev_linear_edges;
-  copy->curr_linear_edges   = curr_linear_edges;
-  copy->prev_arc_edges      = prev_arc_edges;
-  copy->curr_arc_edges      = curr_arc_edges;
-  copy->curr_node_idxs      = curr_node_idxs;
-  copy->prev_length_dims    = prev_length_dims;
-  copy->curr_length_dims    = curr_length_dims;
-  copy->prev_operation_axis = prev_operation_axis;
-  copy->curr_operation_axis = curr_operation_axis;
-  return copy;
-}

--- a/src/sketch_delta.cpp
+++ b/src/sketch_delta.cpp
@@ -2,6 +2,7 @@
 
 #include <Precision.hxx>
 #include <algorithm>
+#include <set>
 #include <utility>
 
 #include "dbg.h"
@@ -13,49 +14,114 @@
 namespace
 {
 
-// Forward declarations; definitions are at the bottom of this file (reader-first order).
 bool on_closed_segment_2d_(const gp_Pnt2d& p, const gp_Pnt2d& a, const gp_Pnt2d& b);
-bool prev_linear_equal_(const Sketch_delta::Prev_edge_rec& x, const Sketch_delta::Prev_edge_rec& y);
-bool curr_linear_equal_(const Sketch_delta::Curr_linear_edge_record& x, const Sketch_delta::Curr_linear_edge_record& y);
-bool arc_equal_(const Sketch_delta::Arc_edge_record& x, const Sketch_delta::Arc_edge_record& y);
-bool length_dim_equal_(const Sketch_delta::Length_dim_record& x, const Sketch_delta::Length_dim_record& y);
-void remove_linear_edges_on_segment_(Sketch& sketch, const gp_Pnt2d& seg_a, const gp_Pnt2d& seg_b);
-void remove_linear_edges_on_node_segment_(Sketch& sketch, size_t node_a, size_t node_b);
-void remove_arc_edge_(Sketch& sketch, const Sketch_delta::Arc_edge_record& rec);
-void remove_length_dim_(Sketch& sketch, const Sketch_delta::Length_dim_record& rec);
-void tombstone_node_(Sketch& sketch, size_t node_idx);
-void restore_prev_linear_edge_(Sketch& sketch, const Sketch_delta::Prev_edge_rec& rec);
-void restore_length_dim_(Sketch& sketch, const Sketch_delta::Length_dim_record& rec);
-void restore_prev_operation_axis_(Sketch& sketch, const Sketch_delta::Prev_edge_rec& rec);
 bool is_linear_sketch_edge_(const Sketch::Edge& e);
-void capture_linear_edges_at_start_(Sketch& sketch, std::vector<Sketch_delta::Prev_edge_rec>& out);
-bool linear_edge_at_op_start_(const std::vector<Sketch_delta::Prev_edge_rec>& at_start, const Sketch_delta::Prev_edge_rec& rec);
 
 } // namespace
 
 class Sketch_delta::Impl
 {
 public:
-  friend class Sketch_op_recorder;
+  friend class Sketch_op_recorder::Impl;
 
-  Sketch*                                        m_sketch{nullptr};
-  std::string                                    m_sketch_name;
-  std::vector<Sketch_delta::Prev_edge_rec>       prev_linear_edges;
-  std::vector<Sketch_delta::Curr_linear_edge_record> curr_linear_edges;
-  std::vector<Sketch_delta::Arc_edge_record>     prev_arc_edges;
-  std::vector<Sketch_delta::Arc_edge_record>     curr_arc_edges;
-  std::vector<size_t>                            curr_node_idxs;
-  std::vector<Sketch_delta::Length_dim_record>   prev_length_dims;
-  std::vector<Sketch_delta::Length_dim_record>   curr_length_dims;
-  std::optional<Sketch_delta::Prev_edge_rec>     prev_operation_axis;
-  std::optional<Sketch_delta::Curr_linear_edge_record> curr_operation_axis;
+  struct Prev_edge_rec
+  {
+    size_t                node_idx_a{};
+    size_t                node_idx_b{};
+    std::optional<size_t> node_idx_mid;
+    std::string           name;
+  };
+
+  struct Curr_linear_edge_record
+  {
+    gp_Pnt2d pt_a;
+    gp_Pnt2d pt_b;
+  };
+
+  struct Arc_edge_record
+  {
+    gp_Pnt2d pt_a;
+    gp_Pnt2d pt_b;
+    gp_Pnt2d pt_c;
+  };
+
+  struct Length_dim_record
+  {
+    size_t                node_idx_lo{};
+    size_t                node_idx_hi{};
+    bool                  visible{true};
+    std::optional<double> flyout_offset;
+    std::string           name;
+  };
+
+  Sketch*                                m_sketch{nullptr};
+  std::string                            m_sketch_name;
+  std::vector<Prev_edge_rec>             prev_linear_edges;
+  std::vector<Curr_linear_edge_record>   curr_linear_edges;
+  std::vector<Arc_edge_record>           prev_arc_edges;
+  std::vector<Arc_edge_record>           curr_arc_edges;
+  std::vector<size_t>                    curr_node_idxs;
+  std::vector<Length_dim_record>         prev_length_dims;
+  std::vector<Length_dim_record>         curr_length_dims;
+  std::optional<Prev_edge_rec>           prev_operation_axis;
+  std::optional<Curr_linear_edge_record> curr_operation_axis;
 
   Impl(Sketch& sketch, std::string sketch_name);
 
-  Sketch* resolve_sketch_(Occt_view& view) const;
-  void    apply_forward_(Sketch& sketch) const;
-  void    apply_reverse_(Sketch& sketch) const;
+  Sketch*                       resolve_sketch_(Occt_view& view) const;
+  void                          apply_forward_(Sketch& sketch) const;
+  void                          apply_reverse_(Sketch& sketch) const;
   std::unique_ptr<Sketch_delta> clone() const;
+
+  static bool prev_linear_equal_(const Prev_edge_rec& x, const Prev_edge_rec& y);
+  static bool curr_linear_equal_(const Curr_linear_edge_record& x, const Curr_linear_edge_record& y);
+  static bool arc_equal_(const Arc_edge_record& x, const Arc_edge_record& y);
+  static bool length_dim_equal_(const Length_dim_record& x, const Length_dim_record& y);
+  static void remove_linear_edges_on_segment_(Sketch& sketch, const gp_Pnt2d& seg_a, const gp_Pnt2d& seg_b);
+  static void remove_linear_edges_on_node_segment_(Sketch& sketch, size_t node_a, size_t node_b);
+  static void remove_arc_edge_(Sketch& sketch, const Arc_edge_record& rec);
+  static void remove_length_dim_(Sketch& sketch, const Length_dim_record& rec);
+  static void tombstone_node_(Sketch& sketch, size_t node_idx);
+  static void restore_prev_linear_edge_(Sketch& sketch, const Prev_edge_rec& rec);
+  static void restore_length_dim_(Sketch& sketch, const Length_dim_record& rec);
+  static void restore_prev_operation_axis_(Sketch& sketch, const Prev_edge_rec& rec);
+  static void capture_linear_edges_at_start_(Sketch& sketch, std::vector<Prev_edge_rec>& out);
+  static bool linear_edge_at_op_start_(const std::vector<Prev_edge_rec>& at_start, const Prev_edge_rec& rec);
+};
+
+class Sketch_op_recorder::Impl
+{
+public:
+  Occt_view&                                     m_view;
+  Sketch&                                        m_sketch;
+  Sketch_op_recorder*                            m_owner{nullptr};
+  bool                                           m_active{true};
+  bool                                           m_committed{false};
+  std::set<size_t>                               m_live_nodes_at_start;
+  std::vector<Sketch_delta::Impl::Prev_edge_rec> m_linear_edges_at_start;
+  std::unique_ptr<Sketch_delta>                  m_delta;
+
+  Impl(Occt_view& view, Sketch& sketch);
+
+  void register_owner_(Sketch_op_recorder& owner);
+  void on_destroy_();
+
+  void note_prev_linear_edge(size_t node_idx_a, size_t node_idx_b, std::optional<size_t> node_idx_mid, const std::string& name);
+  void note_curr_linear_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
+  void note_prev_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c);
+  void note_curr_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c);
+  void note_curr_node(size_t node_idx);
+  void note_prev_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout, const std::string& name);
+  void note_curr_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout, const std::string& name);
+  void note_prev_operation_axis(size_t node_idx_a, size_t node_idx_b);
+  void note_curr_operation_axis(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
+
+  void commit();
+  void cancel();
+
+private:
+  bool empty_() const;
+  void unregister_owner_();
 };
 
 Sketch_delta::Sketch_delta(Sketch& sketch, std::string sketch_name)
@@ -82,6 +148,67 @@ void Sketch_delta::apply_reverse(Occt_view& view)
 std::unique_ptr<Delta> Sketch_delta::clone() const { return m_impl->clone(); }
 
 Sketch_op_recorder::Sketch_op_recorder(Occt_view& view, Sketch& sketch)
+    : m_impl(std::make_unique<Impl>(view, sketch))
+{
+  m_impl->register_owner_(*this);
+}
+
+Sketch_op_recorder::~Sketch_op_recorder()
+{
+  if (m_impl)
+    m_impl->on_destroy_();
+}
+
+void Sketch_op_recorder::note_prev_linear_edge(size_t node_idx_a, size_t node_idx_b, std::optional<size_t> node_idx_mid,
+                                               const std::string& name)
+{
+  m_impl->note_prev_linear_edge(node_idx_a, node_idx_b, node_idx_mid, name);
+}
+
+void Sketch_op_recorder::note_curr_linear_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  m_impl->note_curr_linear_edge(pt_a, pt_b);
+}
+
+void Sketch_op_recorder::note_prev_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
+{
+  m_impl->note_prev_arc_edge(pt_a, pt_b, pt_c);
+}
+
+void Sketch_op_recorder::note_curr_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
+{
+  m_impl->note_curr_arc_edge(pt_a, pt_b, pt_c);
+}
+
+void Sketch_op_recorder::note_curr_node(size_t node_idx) { m_impl->note_curr_node(node_idx); }
+
+void Sketch_op_recorder::note_prev_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
+                                              const std::string& name)
+{
+  m_impl->note_prev_length_dim(lo, hi, visible, flyout, name);
+}
+
+void Sketch_op_recorder::note_curr_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
+                                              const std::string& name)
+{
+  m_impl->note_curr_length_dim(lo, hi, visible, flyout, name);
+}
+
+void Sketch_op_recorder::note_prev_operation_axis(size_t node_idx_a, size_t node_idx_b)
+{
+  m_impl->note_prev_operation_axis(node_idx_a, node_idx_b);
+}
+
+void Sketch_op_recorder::note_curr_operation_axis(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  m_impl->note_curr_operation_axis(pt_a, pt_b);
+}
+
+void Sketch_op_recorder::commit() { m_impl->commit(); }
+
+void Sketch_op_recorder::cancel() { m_impl->cancel(); }
+
+Sketch_op_recorder::Impl::Impl(Occt_view& view, Sketch& sketch)
     : m_view(view)
     , m_sketch(sketch)
 {
@@ -89,79 +216,87 @@ Sketch_op_recorder::Sketch_op_recorder(Occt_view& view, Sketch& sketch)
     if (!sketch.m_nodes[i].deleted)
       m_live_nodes_at_start.insert(i);
 
-  capture_linear_edges_at_start_(sketch, m_linear_edges_at_start);
-
-  m_delta                = std::make_unique<Sketch_delta>(sketch, sketch.get_name());
-  sketch.m_undo_recorder = this;
+  Sketch_delta::Impl::capture_linear_edges_at_start_(sketch, m_linear_edges_at_start);
+  m_delta = std::make_unique<Sketch_delta>(sketch, sketch.get_name());
 }
 
-Sketch_op_recorder::~Sketch_op_recorder()
+void Sketch_op_recorder::Impl::register_owner_(Sketch_op_recorder& owner)
 {
-  if (m_sketch.m_undo_recorder == this)
-    m_sketch.m_undo_recorder = nullptr;
+  m_owner                  = &owner;
+  m_sketch.m_undo_recorder = &owner;
+}
 
+void Sketch_op_recorder::Impl::unregister_owner_()
+{
+  if (m_sketch.m_undo_recorder == m_owner)
+    m_sketch.m_undo_recorder = nullptr;
+}
+
+void Sketch_op_recorder::Impl::on_destroy_()
+{
+  unregister_owner_();
   if (m_active && !m_committed)
     cancel();
 }
 
-void Sketch_op_recorder::note_prev_linear_edge(size_t node_idx_a, size_t node_idx_b, std::optional<size_t> node_idx_mid,
-                                               const std::string& name)
+void Sketch_op_recorder::Impl::note_prev_linear_edge(size_t node_idx_a, size_t node_idx_b, std::optional<size_t> node_idx_mid,
+                                                     const std::string& name)
 {
   if (!m_active || !m_delta)
     return;
 
-  Sketch_delta::Prev_edge_rec rec{node_idx_a, node_idx_b, node_idx_mid, name};
-  if (!linear_edge_at_op_start_(m_linear_edges_at_start, rec))
+  Sketch_delta::Impl::Prev_edge_rec rec{node_idx_a, node_idx_b, node_idx_mid, name};
+  if (!Sketch_delta::Impl::linear_edge_at_op_start_(m_linear_edges_at_start, rec))
     return;
 
   Sketch_delta::Impl& d = *m_delta->m_impl;
-  for (const Sketch_delta::Prev_edge_rec& x : d.prev_linear_edges)
-    if (prev_linear_equal_(x, rec))
+  for (const Sketch_delta::Impl::Prev_edge_rec& x : d.prev_linear_edges)
+    if (Sketch_delta::Impl::prev_linear_equal_(x, rec))
       return;
 
   d.prev_linear_edges.push_back(std::move(rec));
 }
 
-void Sketch_op_recorder::note_curr_linear_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+void Sketch_op_recorder::Impl::note_curr_linear_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
 {
   if (!m_active || !m_delta)
     return;
 
-  Sketch_delta::Curr_linear_edge_record rec{pt_a, pt_b};
-  for (const Sketch_delta::Curr_linear_edge_record& x : m_delta->m_impl->curr_linear_edges)
-    if (curr_linear_equal_(x, rec))
+  Sketch_delta::Impl::Curr_linear_edge_record rec{pt_a, pt_b};
+  for (const Sketch_delta::Impl::Curr_linear_edge_record& x : m_delta->m_impl->curr_linear_edges)
+    if (Sketch_delta::Impl::curr_linear_equal_(x, rec))
       return;
 
   m_delta->m_impl->curr_linear_edges.push_back(rec);
 }
 
-void Sketch_op_recorder::note_prev_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
+void Sketch_op_recorder::Impl::note_prev_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
 {
   if (!m_active || !m_delta)
     return;
 
-  Sketch_delta::Arc_edge_record rec{pt_a, pt_b, pt_c};
-  for (const Sketch_delta::Arc_edge_record& x : m_delta->m_impl->prev_arc_edges)
-    if (arc_equal_(x, rec))
+  Sketch_delta::Impl::Arc_edge_record rec{pt_a, pt_b, pt_c};
+  for (const Sketch_delta::Impl::Arc_edge_record& x : m_delta->m_impl->prev_arc_edges)
+    if (Sketch_delta::Impl::arc_equal_(x, rec))
       return;
 
   m_delta->m_impl->prev_arc_edges.push_back(rec);
 }
 
-void Sketch_op_recorder::note_curr_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
+void Sketch_op_recorder::Impl::note_curr_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
 {
   if (!m_active || !m_delta)
     return;
 
-  Sketch_delta::Arc_edge_record rec{pt_a, pt_b, pt_c};
-  for (const Sketch_delta::Arc_edge_record& x : m_delta->m_impl->curr_arc_edges)
-    if (arc_equal_(x, rec))
+  Sketch_delta::Impl::Arc_edge_record rec{pt_a, pt_b, pt_c};
+  for (const Sketch_delta::Impl::Arc_edge_record& x : m_delta->m_impl->curr_arc_edges)
+    if (Sketch_delta::Impl::arc_equal_(x, rec))
       return;
 
   m_delta->m_impl->curr_arc_edges.push_back(rec);
 }
 
-void Sketch_op_recorder::note_curr_node(size_t node_idx)
+void Sketch_op_recorder::Impl::note_curr_node(size_t node_idx)
 {
   if (!m_active || !m_delta)
     return;
@@ -176,62 +311,62 @@ void Sketch_op_recorder::note_curr_node(size_t node_idx)
   nodes.push_back(node_idx);
 }
 
-void Sketch_op_recorder::note_prev_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
-                                              const std::string& name)
+void Sketch_op_recorder::Impl::note_prev_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
+                                                    const std::string& name)
 {
   if (!m_active || !m_delta)
     return;
 
-  Sketch_delta::Length_dim_record rec{lo, hi, visible, flyout, name};
-  for (const Sketch_delta::Length_dim_record& x : m_delta->m_impl->prev_length_dims)
-    if (length_dim_equal_(x, rec))
+  Sketch_delta::Impl::Length_dim_record rec{lo, hi, visible, flyout, name};
+  for (const Sketch_delta::Impl::Length_dim_record& x : m_delta->m_impl->prev_length_dims)
+    if (Sketch_delta::Impl::length_dim_equal_(x, rec))
       return;
 
   m_delta->m_impl->prev_length_dims.push_back(std::move(rec));
 }
 
-void Sketch_op_recorder::note_curr_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
-                                              const std::string& name)
+void Sketch_op_recorder::Impl::note_curr_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
+                                                    const std::string& name)
 {
   if (!m_active || !m_delta)
     return;
 
-  Sketch_delta::Length_dim_record rec{lo, hi, visible, flyout, name};
-  for (const Sketch_delta::Length_dim_record& x : m_delta->m_impl->curr_length_dims)
-    if (length_dim_equal_(x, rec))
+  Sketch_delta::Impl::Length_dim_record rec{lo, hi, visible, flyout, name};
+  for (const Sketch_delta::Impl::Length_dim_record& x : m_delta->m_impl->curr_length_dims)
+    if (Sketch_delta::Impl::length_dim_equal_(x, rec))
       return;
 
   m_delta->m_impl->curr_length_dims.push_back(std::move(rec));
 }
 
-void Sketch_op_recorder::note_prev_operation_axis(size_t node_idx_a, size_t node_idx_b)
+void Sketch_op_recorder::Impl::note_prev_operation_axis(size_t node_idx_a, size_t node_idx_b)
 {
   if (!m_active || !m_delta)
     return;
 
-  m_delta->m_impl->prev_operation_axis = Sketch_delta::Prev_edge_rec{node_idx_a, node_idx_b, std::nullopt, {}};
+  m_delta->m_impl->prev_operation_axis = Sketch_delta::Impl::Prev_edge_rec{node_idx_a, node_idx_b, std::nullopt, {}};
 }
 
-void Sketch_op_recorder::note_curr_operation_axis(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+void Sketch_op_recorder::Impl::note_curr_operation_axis(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
 {
   if (!m_active || !m_delta)
     return;
 
-  m_delta->m_impl->curr_operation_axis = Sketch_delta::Curr_linear_edge_record{pt_a, pt_b};
+  m_delta->m_impl->curr_operation_axis = Sketch_delta::Impl::Curr_linear_edge_record{pt_a, pt_b};
 }
 
-bool Sketch_op_recorder::empty_() const
+bool Sketch_op_recorder::Impl::empty_() const
 {
   if (!m_delta)
     return true;
 
   const Sketch_delta::Impl& d = *m_delta->m_impl;
-  return d.prev_linear_edges.empty() && d.curr_linear_edges.empty() && d.prev_arc_edges.empty() &&
-         d.curr_arc_edges.empty() && d.curr_node_idxs.empty() && d.prev_length_dims.empty() &&
-         d.curr_length_dims.empty() && !d.prev_operation_axis.has_value() && !d.curr_operation_axis.has_value();
+  return d.prev_linear_edges.empty() && d.curr_linear_edges.empty() && d.prev_arc_edges.empty() && d.curr_arc_edges.empty() &&
+         d.curr_node_idxs.empty() && d.prev_length_dims.empty() && d.curr_length_dims.empty() &&
+         !d.prev_operation_axis.has_value() && !d.curr_operation_axis.has_value();
 }
 
-void Sketch_op_recorder::commit()
+void Sketch_op_recorder::Impl::commit()
 {
   if (!m_active || m_committed)
     return;
@@ -239,20 +374,18 @@ void Sketch_op_recorder::commit()
   m_committed = true;
   m_active    = false;
 
-  if (m_sketch.m_undo_recorder == this)
-    m_sketch.m_undo_recorder = nullptr;
+  unregister_owner_();
 
   if (!empty_())
     m_view.push_undo_delta(std::move(m_delta));
 }
 
-void Sketch_op_recorder::cancel()
+void Sketch_op_recorder::Impl::cancel()
 {
   m_active    = false;
   m_committed = true;
 
-  if (m_sketch.m_undo_recorder == this)
-    m_sketch.m_undo_recorder = nullptr;
+  unregister_owner_();
 }
 
 Sketch_delta::Impl::Impl(Sketch& sketch, std::string sketch_name)
@@ -275,13 +408,13 @@ Sketch* Sketch_delta::Impl::resolve_sketch_(Occt_view& view) const
 
 void Sketch_delta::Impl::apply_forward_(Sketch& sketch) const
 {
-  for (const Sketch_delta::Curr_linear_edge_record& e : curr_linear_edges)
+  for (const Curr_linear_edge_record& e : curr_linear_edges)
     sketch.add_edge_(e.pt_a, e.pt_b);
 
-  for (const Sketch_delta::Arc_edge_record& e : curr_arc_edges)
+  for (const Arc_edge_record& e : curr_arc_edges)
     sketch.add_arc_circle_(e.pt_a, e.pt_b, e.pt_c);
 
-  for (const Sketch_delta::Length_dim_record& d : curr_length_dims)
+  for (const Length_dim_record& d : curr_length_dims)
     restore_length_dim_(sketch, d);
 
   if (curr_operation_axis.has_value())
@@ -296,25 +429,25 @@ void Sketch_delta::Impl::apply_reverse_(Sketch& sketch) const
   if (curr_operation_axis.has_value())
     sketch.clear_operation_axis();
 
-  for (const Sketch_delta::Length_dim_record& d : curr_length_dims)
+  for (const Length_dim_record& d : curr_length_dims)
     remove_length_dim_(sketch, d);
 
-  for (const Sketch_delta::Arc_edge_record& e : curr_arc_edges)
+  for (const Arc_edge_record& e : curr_arc_edges)
     remove_arc_edge_(sketch, e);
 
-  for (const Sketch_delta::Curr_linear_edge_record& e : curr_linear_edges)
+  for (const Curr_linear_edge_record& e : curr_linear_edges)
     remove_linear_edges_on_segment_(sketch, e.pt_a, e.pt_b);
 
-  for (const Sketch_delta::Prev_edge_rec& e : prev_linear_edges)
+  for (const Prev_edge_rec& e : prev_linear_edges)
     restore_prev_linear_edge_(sketch, e);
 
-  for (const Sketch_delta::Arc_edge_record& e : prev_arc_edges)
+  for (const Arc_edge_record& e : prev_arc_edges)
     sketch.add_arc_circle_(e.pt_a, e.pt_b, e.pt_c);
 
   if (prev_operation_axis.has_value())
     restore_prev_operation_axis_(sketch, *prev_operation_axis);
 
-  for (const Sketch_delta::Length_dim_record& d : prev_length_dims)
+  for (const Length_dim_record& d : prev_length_dims)
     restore_length_dim_(sketch, d);
 
   for (size_t node_idx : curr_node_idxs)
@@ -326,8 +459,8 @@ void Sketch_delta::Impl::apply_reverse_(Sketch& sketch) const
 
 std::unique_ptr<Sketch_delta> Sketch_delta::Impl::clone() const
 {
-  auto copy     = std::make_unique<Sketch_delta>(*m_sketch, m_sketch_name);
-  Impl& copy_impl = *copy->m_impl;
+  auto  copy                    = std::make_unique<Sketch_delta>(*m_sketch, m_sketch_name);
+  Impl& copy_impl               = *copy->m_impl;
   copy_impl.m_sketch            = m_sketch;
   copy_impl.prev_linear_edges   = prev_linear_edges;
   copy_impl.curr_linear_edges   = curr_linear_edges;
@@ -341,44 +474,30 @@ std::unique_ptr<Sketch_delta> Sketch_delta::Impl::clone() const
   return copy;
 }
 
-namespace
-{
-
-bool on_closed_segment_2d_(const gp_Pnt2d& p, const gp_Pnt2d& a, const gp_Pnt2d& b)
-{
-  if (p.SquareDistance(a) <= Precision::SquareConfusion())
-    return true;
-
-  if (p.SquareDistance(b) <= Precision::SquareConfusion())
-    return true;
-
-  return point_on_open_segment_2d(p, a, b);
-}
-
-bool prev_linear_equal_(const Sketch_delta::Prev_edge_rec& x, const Sketch_delta::Prev_edge_rec& y)
+bool Sketch_delta::Impl::prev_linear_equal_(const Prev_edge_rec& x, const Prev_edge_rec& y)
 {
   return x.node_idx_a == y.node_idx_a && x.node_idx_b == y.node_idx_b && x.node_idx_mid == y.node_idx_mid;
 }
 
-bool curr_linear_equal_(const Sketch_delta::Curr_linear_edge_record& x, const Sketch_delta::Curr_linear_edge_record& y)
+bool Sketch_delta::Impl::curr_linear_equal_(const Curr_linear_edge_record& x, const Curr_linear_edge_record& y)
 {
   return x.pt_a.SquareDistance(y.pt_a) <= Precision::SquareConfusion() &&
          x.pt_b.SquareDistance(y.pt_b) <= Precision::SquareConfusion();
 }
 
-bool arc_equal_(const Sketch_delta::Arc_edge_record& x, const Sketch_delta::Arc_edge_record& y)
+bool Sketch_delta::Impl::arc_equal_(const Arc_edge_record& x, const Arc_edge_record& y)
 {
   return x.pt_a.SquareDistance(y.pt_a) <= Precision::SquareConfusion() &&
          x.pt_b.SquareDistance(y.pt_b) <= Precision::SquareConfusion() &&
          x.pt_c.SquareDistance(y.pt_c) <= Precision::SquareConfusion();
 }
 
-bool length_dim_equal_(const Sketch_delta::Length_dim_record& x, const Sketch_delta::Length_dim_record& y)
+bool Sketch_delta::Impl::length_dim_equal_(const Length_dim_record& x, const Length_dim_record& y)
 {
   return x.node_idx_lo == y.node_idx_lo && x.node_idx_hi == y.node_idx_hi;
 }
 
-void remove_linear_edges_on_segment_(Sketch& sketch, const gp_Pnt2d& seg_a, const gp_Pnt2d& seg_b)
+void Sketch_delta::Impl::remove_linear_edges_on_segment_(Sketch& sketch, const gp_Pnt2d& seg_a, const gp_Pnt2d& seg_b)
 {
   for (auto itr = sketch.m_edges.begin(); itr != sketch.m_edges.end();)
   {
@@ -400,12 +519,12 @@ void remove_linear_edges_on_segment_(Sketch& sketch, const gp_Pnt2d& seg_a, cons
   }
 }
 
-void remove_linear_edges_on_node_segment_(Sketch& sketch, size_t node_a, size_t node_b)
+void Sketch_delta::Impl::remove_linear_edges_on_node_segment_(Sketch& sketch, size_t node_a, size_t node_b)
 {
   remove_linear_edges_on_segment_(sketch, sketch.m_nodes[node_a], sketch.m_nodes[node_b]);
 }
 
-void remove_arc_edge_(Sketch& sketch, const Sketch_delta::Arc_edge_record& rec)
+void Sketch_delta::Impl::remove_arc_edge_(Sketch& sketch, const Arc_edge_record& rec)
 {
   std::vector<Sketch_AIS_edge_ptr> shps_to_remove;
 
@@ -455,7 +574,7 @@ void remove_arc_edge_(Sketch& sketch, const Sketch_delta::Arc_edge_record& rec)
   }
 }
 
-void remove_length_dim_(Sketch& sketch, const Sketch_delta::Length_dim_record& rec)
+void Sketch_delta::Impl::remove_length_dim_(Sketch& sketch, const Length_dim_record& rec)
 {
   for (auto it = sketch.m_length_dimensions.begin(); it != sketch.m_length_dimensions.end(); ++it)
     if (it->node_idx_lo == rec.node_idx_lo && it->node_idx_hi == rec.node_idx_hi)
@@ -468,7 +587,7 @@ void remove_length_dim_(Sketch& sketch, const Sketch_delta::Length_dim_record& r
     }
 }
 
-void tombstone_node_(Sketch& sketch, size_t node_idx)
+void Sketch_delta::Impl::tombstone_node_(Sketch& sketch, size_t node_idx)
 {
   EZY_ASSERT(node_idx < sketch.m_nodes.size());
   sketch.m_nodes[node_idx].deleted = true;
@@ -480,7 +599,7 @@ void tombstone_node_(Sketch& sketch, size_t node_idx)
   }
 }
 
-void restore_prev_linear_edge_(Sketch& sketch, const Sketch_delta::Prev_edge_rec& rec)
+void Sketch_delta::Impl::restore_prev_linear_edge_(Sketch& sketch, const Prev_edge_rec& rec)
 {
   remove_linear_edges_on_node_segment_(sketch, rec.node_idx_a, rec.node_idx_b);
   sketch.sketch_json_add_linear_edge_(rec.node_idx_a, rec.node_idx_b, rec.node_idx_mid);
@@ -494,41 +613,54 @@ void restore_prev_linear_edge_(Sketch& sketch, const Sketch_delta::Prev_edge_rec
       }
 }
 
-void restore_length_dim_(Sketch& sketch, const Sketch_delta::Length_dim_record& rec)
+void Sketch_delta::Impl::restore_length_dim_(Sketch& sketch, const Length_dim_record& rec)
 {
   sketch.json_add_length_dimension_(rec.node_idx_lo, rec.node_idx_hi, rec.visible, rec.flyout_offset, rec.name);
 }
 
-void restore_prev_operation_axis_(Sketch& sketch, const Sketch_delta::Prev_edge_rec& rec)
+void Sketch_delta::Impl::restore_prev_operation_axis_(Sketch& sketch, const Prev_edge_rec& rec)
 {
   const gp_Pnt2d pt_a = sketch.m_nodes[rec.node_idx_a];
   const gp_Pnt2d pt_b = sketch.m_nodes[rec.node_idx_b];
   sketch.sketch_json_set_operation_axis_(pt_a, pt_b);
 }
 
-bool is_linear_sketch_edge_(const Sketch::Edge& e)
-{
-  return !e.circle_arc && e.node_idx_b.has_value() && !e.node_idx_arc.has_value();
-}
-
-void capture_linear_edges_at_start_(Sketch& sketch, std::vector<Sketch_delta::Prev_edge_rec>& out)
+void Sketch_delta::Impl::capture_linear_edges_at_start_(Sketch& sketch, std::vector<Prev_edge_rec>& out)
 {
   for (const Sketch::Edge& e : sketch.m_edges)
   {
     if (!is_linear_sketch_edge_(e))
       continue;
 
-    Sketch_delta::Prev_edge_rec rec{e.node_idx_a, *e.node_idx_b, e.node_idx_mid, e.name};
-    if (std::find_if(out.begin(), out.end(),
-                     [&](const Sketch_delta::Prev_edge_rec& x) { return prev_linear_equal_(x, rec); }) == out.end())
+    Prev_edge_rec rec{e.node_idx_a, *e.node_idx_b, e.node_idx_mid, e.name};
+    if (std::find_if(out.begin(), out.end(), [&](const Prev_edge_rec& x) { return prev_linear_equal_(x, rec); }) == out.end())
       out.push_back(std::move(rec));
   }
 }
 
-bool linear_edge_at_op_start_(const std::vector<Sketch_delta::Prev_edge_rec>& at_start, const Sketch_delta::Prev_edge_rec& rec)
+bool Sketch_delta::Impl::linear_edge_at_op_start_(const std::vector<Prev_edge_rec>& at_start, const Prev_edge_rec& rec)
 {
-  return std::find_if(at_start.begin(), at_start.end(),
-                      [&](const Sketch_delta::Prev_edge_rec& x) { return prev_linear_equal_(x, rec); }) != at_start.end();
+  return std::find_if(at_start.begin(), at_start.end(), [&](const Prev_edge_rec& x) { return prev_linear_equal_(x, rec); }) !=
+         at_start.end();
+}
+
+namespace
+{
+
+bool on_closed_segment_2d_(const gp_Pnt2d& p, const gp_Pnt2d& a, const gp_Pnt2d& b)
+{
+  if (p.SquareDistance(a) <= Precision::SquareConfusion())
+    return true;
+
+  if (p.SquareDistance(b) <= Precision::SquareConfusion())
+    return true;
+
+  return point_on_open_segment_2d(p, a, b);
+}
+
+bool is_linear_sketch_edge_(const Sketch::Edge& e)
+{
+  return !e.circle_arc && e.node_idx_b.has_value() && !e.node_idx_arc.has_value();
 }
 
 } // namespace

--- a/src/sketch_delta.cpp
+++ b/src/sketch_delta.cpp
@@ -1,0 +1,474 @@
+#include "sketch_delta.h"
+
+#include <Precision.hxx>
+#include <algorithm>
+#include <utility>
+
+#include "dbg.h"
+#include "geom.h"
+#include "occt_view.h"
+#include "sketch.h"
+#include "sketch_nodes.h"
+
+namespace
+{
+
+bool on_closed_segment_2d_(const gp_Pnt2d& p, const gp_Pnt2d& a, const gp_Pnt2d& b)
+{
+  if (p.SquareDistance(a) <= Precision::SquareConfusion())
+    return true;
+
+  if (p.SquareDistance(b) <= Precision::SquareConfusion())
+    return true;
+
+  return point_on_open_segment_2d(p, a, b);
+}
+
+bool prev_linear_equal_(const Sketch_delta::Prev_edge_rec& x, const Sketch_delta::Prev_edge_rec& y)
+{
+  return x.node_idx_a == y.node_idx_a && x.node_idx_b == y.node_idx_b && x.node_idx_mid == y.node_idx_mid;
+}
+
+bool curr_linear_equal_(const Sketch_delta::Curr_linear_edge_record& x, const Sketch_delta::Curr_linear_edge_record& y)
+{
+  return x.pt_a.SquareDistance(y.pt_a) <= Precision::SquareConfusion() &&
+         x.pt_b.SquareDistance(y.pt_b) <= Precision::SquareConfusion();
+}
+
+bool arc_equal_(const Sketch_delta::Arc_edge_record& x, const Sketch_delta::Arc_edge_record& y)
+{
+  return x.pt_a.SquareDistance(y.pt_a) <= Precision::SquareConfusion() &&
+         x.pt_b.SquareDistance(y.pt_b) <= Precision::SquareConfusion() &&
+         x.pt_c.SquareDistance(y.pt_c) <= Precision::SquareConfusion();
+}
+
+bool length_dim_equal_(const Sketch_delta::Length_dim_record& x, const Sketch_delta::Length_dim_record& y)
+{
+  return x.node_idx_lo == y.node_idx_lo && x.node_idx_hi == y.node_idx_hi;
+}
+
+void remove_linear_edges_on_segment_(Sketch& sketch, const gp_Pnt2d& seg_a, const gp_Pnt2d& seg_b)
+{
+  for (auto itr = sketch.m_edges.begin(); itr != sketch.m_edges.end();)
+  {
+    if (itr->circle_arc || !itr->node_idx_b.has_value())
+    {
+      ++itr;
+      continue;
+    }
+
+    const gp_Pnt2d& pa = sketch.m_nodes[itr->node_idx_a];
+    const gp_Pnt2d& pb = sketch.m_nodes[*itr->node_idx_b];
+    if (on_closed_segment_2d_(pa, seg_a, seg_b) && on_closed_segment_2d_(pb, seg_a, seg_b))
+    {
+      sketch.m_ctx.Remove(itr->shp, false);
+      itr = sketch.m_edges.erase(itr);
+    }
+    else
+      ++itr;
+  }
+}
+
+void remove_linear_edges_on_node_segment_(Sketch& sketch, size_t node_a, size_t node_b)
+{
+  remove_linear_edges_on_segment_(sketch, sketch.m_nodes[node_a], sketch.m_nodes[node_b]);
+}
+
+void remove_arc_edge_(Sketch& sketch, const Sketch_delta::Arc_edge_record& rec)
+{
+  std::vector<Sketch_AIS_edge_ptr> shps_to_remove;
+
+  for (auto itr = sketch.m_edges.begin(); itr != sketch.m_edges.end(); ++itr)
+  {
+    if (!itr->circle_arc || itr->shp.IsNull())
+      continue;
+
+    const Sketch::Edge* e1 = &*itr;
+    const Sketch::Edge* e2 = nullptr;
+
+    for (auto itr2 = sketch.m_edges.begin(); itr2 != sketch.m_edges.end(); ++itr2)
+      if (itr2 != itr && itr2->shp == e1->shp)
+      {
+        e2 = &*itr2;
+        break;
+      }
+
+    if (!e2)
+      continue;
+
+    const Sketch::Edge* first  = e1->node_idx_arc.has_value() ? e1 : (e2->node_idx_arc.has_value() ? e2 : nullptr);
+    const Sketch::Edge* second = first == e1 ? e2 : e1;
+    if (!first || !first->node_idx_arc.has_value() || !second->node_idx_b.has_value())
+      continue;
+
+    const gp_Pnt2d start = sketch.m_nodes[first->node_idx_a];
+    const gp_Pnt2d arc   = sketch.m_nodes[*first->node_idx_arc];
+    const gp_Pnt2d end   = sketch.m_nodes[*second->node_idx_b];
+
+    if (!arc_equal_({start, arc, end}, rec))
+      continue;
+
+    const Sketch_AIS_edge_ptr& shp = e1->shp;
+    if (std::find(shps_to_remove.begin(), shps_to_remove.end(), shp) == shps_to_remove.end())
+      shps_to_remove.push_back(shp);
+  }
+
+  for (const Sketch_AIS_edge_ptr& shp : shps_to_remove)
+  {
+    sketch.m_ctx.Remove(shp, false);
+    for (auto itr = sketch.m_edges.begin(); itr != sketch.m_edges.end();)
+      if (itr->shp == shp)
+        itr = sketch.m_edges.erase(itr);
+      else
+        ++itr;
+  }
+}
+
+void remove_length_dim_(Sketch& sketch, const Sketch_delta::Length_dim_record& rec)
+{
+  for (auto it = sketch.m_length_dimensions.begin(); it != sketch.m_length_dimensions.end(); ++it)
+    if (it->node_idx_lo == rec.node_idx_lo && it->node_idx_hi == rec.node_idx_hi)
+    {
+      if (!it->dim.IsNull())
+        sketch.m_ctx.Remove(it->dim, true);
+
+      sketch.m_length_dimensions.erase(it);
+      return;
+    }
+}
+
+void tombstone_node_(Sketch& sketch, size_t node_idx)
+{
+  EZY_ASSERT(node_idx < sketch.m_nodes.size());
+  sketch.m_nodes[node_idx].deleted = true;
+  sketch.remove_length_dimensions_referencing_node_(node_idx);
+  if (node_idx < sketch.m_permanent_node_marks.size() && sketch.m_permanent_node_marks[node_idx])
+  {
+    sketch.m_ctx.Remove(sketch.m_permanent_node_marks[node_idx], false);
+    sketch.m_permanent_node_marks[node_idx].Nullify();
+  }
+}
+
+void restore_prev_linear_edge_(Sketch& sketch, const Sketch_delta::Prev_edge_rec& rec)
+{
+  remove_linear_edges_on_node_segment_(sketch, rec.node_idx_a, rec.node_idx_b);
+  sketch.sketch_json_add_linear_edge_(rec.node_idx_a, rec.node_idx_b, rec.node_idx_mid);
+  if (!rec.name.empty())
+    for (Sketch::Edge& e : sketch.m_edges)
+      if (!e.circle_arc && e.node_idx_a == rec.node_idx_a && e.node_idx_b.has_value() && *e.node_idx_b == rec.node_idx_b &&
+          e.node_idx_mid == rec.node_idx_mid)
+      {
+        e.name = rec.name;
+        break;
+      }
+}
+
+void restore_length_dim_(Sketch& sketch, const Sketch_delta::Length_dim_record& rec)
+{
+  sketch.json_add_length_dimension_(rec.node_idx_lo, rec.node_idx_hi, rec.visible, rec.flyout_offset, rec.name);
+}
+
+void restore_prev_operation_axis_(Sketch& sketch, const Sketch_delta::Prev_edge_rec& rec)
+{
+  const gp_Pnt2d pt_a = sketch.m_nodes[rec.node_idx_a];
+  const gp_Pnt2d pt_b = sketch.m_nodes[rec.node_idx_b];
+  sketch.sketch_json_set_operation_axis_(pt_a, pt_b);
+}
+
+bool is_linear_sketch_edge_(const Sketch::Edge& e)
+{
+  return !e.circle_arc && e.node_idx_b.has_value() && !e.node_idx_arc.has_value();
+}
+
+void capture_linear_edges_at_start_(Sketch& sketch, std::vector<Sketch_delta::Prev_edge_rec>& out)
+{
+  for (const Sketch::Edge& e : sketch.m_edges)
+  {
+    if (!is_linear_sketch_edge_(e))
+      continue;
+
+    Sketch_delta::Prev_edge_rec rec{e.node_idx_a, *e.node_idx_b, e.node_idx_mid, e.name};
+    if (std::find_if(out.begin(), out.end(),
+                     [&](const Sketch_delta::Prev_edge_rec& x) { return prev_linear_equal_(x, rec); }) == out.end())
+      out.push_back(std::move(rec));
+  }
+}
+
+bool linear_edge_at_op_start_(const std::vector<Sketch_delta::Prev_edge_rec>& at_start, const Sketch_delta::Prev_edge_rec& rec)
+{
+  return std::find_if(at_start.begin(), at_start.end(),
+                      [&](const Sketch_delta::Prev_edge_rec& x) { return prev_linear_equal_(x, rec); }) != at_start.end();
+}
+
+} // namespace
+
+Sketch_op_recorder::Sketch_op_recorder(Occt_view& view, Sketch& sketch)
+    : m_view(view)
+    , m_sketch(sketch)
+{
+  for (size_t i = 0, n = sketch.m_nodes.size(); i < n; ++i)
+    if (!sketch.m_nodes[i].deleted)
+      m_live_nodes_at_start.insert(i);
+
+  capture_linear_edges_at_start_(sketch, m_linear_edges_at_start);
+
+  m_delta                = std::make_unique<Sketch_delta>(sketch, sketch.get_name());
+  sketch.m_undo_recorder = this;
+}
+
+Sketch_op_recorder::~Sketch_op_recorder()
+{
+  if (m_sketch.m_undo_recorder == this)
+    m_sketch.m_undo_recorder = nullptr;
+
+  if (m_active && !m_committed)
+    cancel();
+}
+
+void Sketch_op_recorder::note_prev_linear_edge(size_t node_idx_a, size_t node_idx_b, std::optional<size_t> node_idx_mid,
+                                               const std::string& name)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Prev_edge_rec rec{node_idx_a, node_idx_b, node_idx_mid, name};
+  if (!linear_edge_at_op_start_(m_linear_edges_at_start, rec))
+    return;
+
+  for (const Sketch_delta::Prev_edge_rec& x : m_delta->prev_linear_edges)
+    if (prev_linear_equal_(x, rec))
+      return;
+
+  m_delta->prev_linear_edges.push_back(std::move(rec));
+}
+
+void Sketch_op_recorder::note_curr_linear_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Curr_linear_edge_record rec{pt_a, pt_b};
+  for (const Sketch_delta::Curr_linear_edge_record& x : m_delta->curr_linear_edges)
+    if (curr_linear_equal_(x, rec))
+      return;
+
+  m_delta->curr_linear_edges.push_back(rec);
+}
+
+void Sketch_op_recorder::note_prev_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Arc_edge_record rec{pt_a, pt_b, pt_c};
+  for (const Sketch_delta::Arc_edge_record& x : m_delta->prev_arc_edges)
+    if (arc_equal_(x, rec))
+      return;
+
+  m_delta->prev_arc_edges.push_back(rec);
+}
+
+void Sketch_op_recorder::note_curr_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Arc_edge_record rec{pt_a, pt_b, pt_c};
+  for (const Sketch_delta::Arc_edge_record& x : m_delta->curr_arc_edges)
+    if (arc_equal_(x, rec))
+      return;
+
+  m_delta->curr_arc_edges.push_back(rec);
+}
+
+void Sketch_op_recorder::note_curr_node(size_t node_idx)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  if (m_live_nodes_at_start.count(node_idx))
+    return;
+
+  if (std::find(m_delta->curr_node_idxs.begin(), m_delta->curr_node_idxs.end(), node_idx) != m_delta->curr_node_idxs.end())
+    return;
+
+  m_delta->curr_node_idxs.push_back(node_idx);
+}
+
+void Sketch_op_recorder::note_prev_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
+                                              const std::string& name)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Length_dim_record rec{lo, hi, visible, flyout, name};
+  for (const Sketch_delta::Length_dim_record& x : m_delta->prev_length_dims)
+    if (length_dim_equal_(x, rec))
+      return;
+
+  m_delta->prev_length_dims.push_back(std::move(rec));
+}
+
+void Sketch_op_recorder::note_curr_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
+                                              const std::string& name)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  Sketch_delta::Length_dim_record rec{lo, hi, visible, flyout, name};
+  for (const Sketch_delta::Length_dim_record& x : m_delta->curr_length_dims)
+    if (length_dim_equal_(x, rec))
+      return;
+
+  m_delta->curr_length_dims.push_back(std::move(rec));
+}
+
+void Sketch_op_recorder::note_prev_operation_axis(size_t node_idx_a, size_t node_idx_b)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  m_delta->prev_operation_axis = Sketch_delta::Prev_edge_rec{node_idx_a, node_idx_b, std::nullopt, {}};
+}
+
+void Sketch_op_recorder::note_curr_operation_axis(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  if (!m_active || !m_delta)
+    return;
+
+  m_delta->curr_operation_axis = Sketch_delta::Curr_linear_edge_record{pt_a, pt_b};
+}
+
+bool Sketch_op_recorder::empty_() const
+{
+  if (!m_delta)
+    return true;
+
+  return m_delta->prev_linear_edges.empty() && m_delta->curr_linear_edges.empty() && m_delta->prev_arc_edges.empty() &&
+         m_delta->curr_arc_edges.empty() && m_delta->curr_node_idxs.empty() && m_delta->prev_length_dims.empty() &&
+         m_delta->curr_length_dims.empty() && !m_delta->prev_operation_axis.has_value() &&
+         !m_delta->curr_operation_axis.has_value();
+}
+
+void Sketch_op_recorder::commit()
+{
+  if (!m_active || m_committed)
+    return;
+
+  m_committed = true;
+  m_active    = false;
+
+  if (m_sketch.m_undo_recorder == this)
+    m_sketch.m_undo_recorder = nullptr;
+
+  if (!empty_())
+    m_view.push_undo_delta(std::move(m_delta));
+}
+
+void Sketch_op_recorder::cancel()
+{
+  m_active    = false;
+  m_committed = true;
+
+  if (m_sketch.m_undo_recorder == this)
+    m_sketch.m_undo_recorder = nullptr;
+}
+
+Sketch_delta::Sketch_delta(Sketch& sketch, std::string sketch_name)
+    : m_sketch(&sketch)
+    , m_sketch_name(std::move(sketch_name))
+{
+}
+
+Sketch* Sketch_delta::resolve_sketch_(Occt_view& view) const
+{
+  if (m_sketch)
+    return m_sketch;
+
+  for (const Sketch::sptr& s : view.get_sketches())
+    if (s->get_name() == m_sketch_name)
+      return s.get();
+
+  return nullptr;
+}
+
+void Sketch_delta::apply_forward_(Sketch& sketch) const
+{
+  for (const Curr_linear_edge_record& e : curr_linear_edges)
+    sketch.add_edge_(e.pt_a, e.pt_b);
+
+  for (const Arc_edge_record& e : curr_arc_edges)
+    sketch.add_arc_circle_(e.pt_a, e.pt_b, e.pt_c);
+
+  for (const Length_dim_record& d : curr_length_dims)
+    restore_length_dim_(sketch, d);
+
+  if (curr_operation_axis.has_value())
+    sketch.sketch_json_set_operation_axis_(curr_operation_axis->pt_a, curr_operation_axis->pt_b);
+
+  sketch.m_nodes.hide_snap_annos();
+  sketch.update_faces_();
+}
+
+void Sketch_delta::apply_reverse_(Sketch& sketch) const
+{
+  if (curr_operation_axis.has_value())
+    sketch.clear_operation_axis();
+
+  for (const Length_dim_record& d : curr_length_dims)
+    remove_length_dim_(sketch, d);
+
+  for (const Arc_edge_record& e : curr_arc_edges)
+    remove_arc_edge_(sketch, e);
+
+  for (const Curr_linear_edge_record& e : curr_linear_edges)
+    remove_linear_edges_on_segment_(sketch, e.pt_a, e.pt_b);
+
+  for (const Prev_edge_rec& e : prev_linear_edges)
+    restore_prev_linear_edge_(sketch, e);
+
+  for (const Arc_edge_record& e : prev_arc_edges)
+    sketch.add_arc_circle_(e.pt_a, e.pt_b, e.pt_c);
+
+  if (prev_operation_axis.has_value())
+    restore_prev_operation_axis_(sketch, *prev_operation_axis);
+
+  for (const Length_dim_record& d : prev_length_dims)
+    restore_length_dim_(sketch, d);
+
+  for (size_t node_idx : curr_node_idxs)
+    tombstone_node_(sketch, node_idx);
+
+  sketch.m_nodes.hide_snap_annos();
+  sketch.update_faces_();
+}
+
+void Sketch_delta::apply_forward(Occt_view& view)
+{
+  Sketch* sketch = resolve_sketch_(view);
+  EZY_ASSERT(sketch);
+  apply_forward_(*sketch);
+}
+
+void Sketch_delta::apply_reverse(Occt_view& view)
+{
+  Sketch* sketch = resolve_sketch_(view);
+  EZY_ASSERT(sketch);
+  apply_reverse_(*sketch);
+}
+
+std::unique_ptr<Delta> Sketch_delta::clone() const
+{
+  auto copy                 = std::make_unique<Sketch_delta>(*m_sketch, m_sketch_name);
+  copy->m_sketch            = m_sketch;
+  copy->prev_linear_edges   = prev_linear_edges;
+  copy->curr_linear_edges   = curr_linear_edges;
+  copy->prev_arc_edges      = prev_arc_edges;
+  copy->curr_arc_edges      = curr_arc_edges;
+  copy->curr_node_idxs      = curr_node_idxs;
+  copy->prev_length_dims    = prev_length_dims;
+  copy->curr_length_dims    = curr_length_dims;
+  copy->prev_operation_axis = prev_operation_axis;
+  copy->curr_operation_axis = curr_operation_axis;
+  return copy;
+}

--- a/src/sketch_delta.h
+++ b/src/sketch_delta.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include "delta.h"
+
+#include <gp_Pnt2d.hxx>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+class Occt_view;
+class Sketch;
+
+/// One sketch undo step: `prev_*` is restored on undo; `curr_*` is re-applied on redo.
+/// Node indices are never compacted; undo tombstones `curr_node_idxs` and redo revives them
+/// through the normal node lookup when edges are added again.
+class Sketch_delta : public Delta
+{
+public:
+  struct Prev_edge_rec
+  {
+    size_t                node_idx_a{};
+    size_t                node_idx_b{};
+    std::optional<size_t> node_idx_mid;
+    std::string           name;
+  };
+
+  struct Curr_linear_edge_record
+  {
+    gp_Pnt2d pt_a;
+    gp_Pnt2d pt_b;
+  };
+
+  struct Arc_edge_record
+  {
+    gp_Pnt2d pt_a;
+    gp_Pnt2d pt_b;
+    gp_Pnt2d pt_c;
+  };
+
+  struct Length_dim_record
+  {
+    size_t                node_idx_lo{};
+    size_t                node_idx_hi{};
+    bool                  visible{true};
+    std::optional<double> flyout_offset;
+    std::string           name;
+  };
+
+  Sketch_delta(Sketch& sketch, std::string sketch_name);
+
+  void                   apply_forward(Occt_view& view) override;
+  void                   apply_reverse(Occt_view& view) override;
+  std::unique_ptr<Delta> clone() const override;
+
+  std::vector<Prev_edge_rec>             prev_linear_edges;
+  std::vector<Curr_linear_edge_record>   curr_linear_edges;
+  std::vector<Arc_edge_record>           prev_arc_edges;
+  std::vector<Arc_edge_record>           curr_arc_edges;
+  std::vector<size_t>                    curr_node_idxs;
+  std::vector<Length_dim_record>         prev_length_dims;
+  std::vector<Length_dim_record>         curr_length_dims;
+  std::optional<Prev_edge_rec>           prev_operation_axis;
+  std::optional<Curr_linear_edge_record> curr_operation_axis;
+
+private:
+  Sketch* resolve_sketch_(Occt_view& view) const;
+  void    apply_forward_(Sketch& sketch) const;
+  void    apply_reverse_(Sketch& sketch) const;
+
+  Sketch*     m_sketch{nullptr};
+  std::string m_sketch_name;
+};
+
+class Sketch_op_recorder;
+
+/// Records `prev`/`curr` lists during one sketch edit; pushes a `Sketch_delta` on commit.
+class Sketch_op_recorder
+{
+public:
+  Sketch_op_recorder(Occt_view& view, Sketch& sketch);
+  ~Sketch_op_recorder();
+
+  Sketch_op_recorder(const Sketch_op_recorder&)            = delete;
+  Sketch_op_recorder& operator=(const Sketch_op_recorder&) = delete;
+
+  void note_prev_linear_edge(size_t node_idx_a, size_t node_idx_b, std::optional<size_t> node_idx_mid, const std::string& name);
+  void note_curr_linear_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
+  void note_prev_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c);
+  void note_curr_arc_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c);
+  void note_curr_node(size_t node_idx);
+  void note_prev_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout, const std::string& name);
+  void note_curr_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout, const std::string& name);
+  void note_prev_operation_axis(size_t node_idx_a, size_t node_idx_b);
+  void note_curr_operation_axis(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
+
+  void commit();
+  void cancel();
+
+private:
+  friend class Sketch;
+
+  bool empty_() const;
+
+  Occt_view&                               m_view;
+  Sketch&                                  m_sketch;
+  bool                                     m_active{true};
+  bool                                     m_committed{false};
+  std::set<size_t>                         m_live_nodes_at_start;
+  std::vector<Sketch_delta::Prev_edge_rec> m_linear_edges_at_start;
+  std::unique_ptr<Sketch_delta>            m_delta;
+};

--- a/src/sketch_delta.h
+++ b/src/sketch_delta.h
@@ -7,70 +7,17 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
-#include <set>
 #include <string>
-#include <vector>
 
 class Occt_view;
 class Sketch;
-
-/// One sketch undo step: `prev_*` is restored on undo; `curr_*` is re-applied on redo.
-/// Node indices are never compacted; undo tombstones `curr_node_idxs` and redo revives them
-/// through the normal node lookup when edges are added again.
-class Sketch_delta : public Delta
-{
-public:
-  struct Prev_edge_rec
-  {
-    size_t                node_idx_a{};
-    size_t                node_idx_b{};
-    std::optional<size_t> node_idx_mid;
-    std::string           name;
-  };
-
-  struct Curr_linear_edge_record
-  {
-    gp_Pnt2d pt_a;
-    gp_Pnt2d pt_b;
-  };
-
-  struct Arc_edge_record
-  {
-    gp_Pnt2d pt_a;
-    gp_Pnt2d pt_b;
-    gp_Pnt2d pt_c;
-  };
-
-  struct Length_dim_record
-  {
-    size_t                node_idx_lo{};
-    size_t                node_idx_hi{};
-    bool                  visible{true};
-    std::optional<double> flyout_offset;
-    std::string           name;
-  };
-
-  Sketch_delta(Sketch& sketch, std::string sketch_name);
-  ~Sketch_delta() override;
-
-  Sketch_delta(const Sketch_delta&)            = delete;
-  Sketch_delta& operator=(const Sketch_delta&) = delete;
-
-  void                   apply_forward(Occt_view& view) override;
-  void                   apply_reverse(Occt_view& view) override;
-  std::unique_ptr<Delta> clone() const override;
-
-private:
-  friend class Sketch_op_recorder;
-
-  class Impl;
-  std::unique_ptr<Impl> m_impl;
-};
 
 /// Records `prev`/`curr` lists during one sketch edit; pushes a `Sketch_delta` on commit.
 class Sketch_op_recorder
 {
 public:
+  class Impl;
+
   Sketch_op_recorder(Occt_view& view, Sketch& sketch);
   ~Sketch_op_recorder();
 
@@ -91,15 +38,28 @@ public:
   void cancel();
 
 private:
-  friend class Sketch;
+  std::unique_ptr<Impl> m_impl;
+};
 
-  bool empty_() const;
+/// One sketch undo step: `prev_*` is restored on undo; `curr_*` is re-applied on redo.
+/// Node indices are never compacted; undo tombstones `curr_node_idxs` and redo revives them
+/// through the normal node lookup when edges are added again.
+class Sketch_delta : public Delta
+{
+public:
+  Sketch_delta(Sketch& sketch, std::string sketch_name);
+  ~Sketch_delta() override;
 
-  Occt_view&                               m_view;
-  Sketch&                                  m_sketch;
-  bool                                     m_active{true};
-  bool                                     m_committed{false};
-  std::set<size_t>                         m_live_nodes_at_start;
-  std::vector<Sketch_delta::Prev_edge_rec> m_linear_edges_at_start;
-  std::unique_ptr<Sketch_delta>            m_delta;
+  Sketch_delta(const Sketch_delta&)            = delete;
+  Sketch_delta& operator=(const Sketch_delta&) = delete;
+
+  void                   apply_forward(Occt_view& view) override;
+  void                   apply_reverse(Occt_view& view) override;
+  std::unique_ptr<Delta> clone() const override;
+
+private:
+  friend class Sketch_op_recorder::Impl;
+
+  class Impl;
+  std::unique_ptr<Impl> m_impl;
 };

--- a/src/sketch_delta.h
+++ b/src/sketch_delta.h
@@ -51,28 +51,20 @@ public:
   };
 
   Sketch_delta(Sketch& sketch, std::string sketch_name);
+  ~Sketch_delta() override;
+
+  Sketch_delta(const Sketch_delta&)            = delete;
+  Sketch_delta& operator=(const Sketch_delta&) = delete;
 
   void                   apply_forward(Occt_view& view) override;
   void                   apply_reverse(Occt_view& view) override;
   std::unique_ptr<Delta> clone() const override;
 
-  std::vector<Prev_edge_rec>             prev_linear_edges;
-  std::vector<Curr_linear_edge_record>   curr_linear_edges;
-  std::vector<Arc_edge_record>           prev_arc_edges;
-  std::vector<Arc_edge_record>           curr_arc_edges;
-  std::vector<size_t>                    curr_node_idxs;
-  std::vector<Length_dim_record>         prev_length_dims;
-  std::vector<Length_dim_record>         curr_length_dims;
-  std::optional<Prev_edge_rec>           prev_operation_axis;
-  std::optional<Curr_linear_edge_record> curr_operation_axis;
-
 private:
-  Sketch* resolve_sketch_(Occt_view& view) const;
-  void    apply_forward_(Sketch& sketch) const;
-  void    apply_reverse_(Sketch& sketch) const;
+  friend class Sketch_op_recorder;
 
-  Sketch*     m_sketch{nullptr};
-  std::string m_sketch_name;
+  class Impl;
+  std::unique_ptr<Impl> m_impl;
 };
 
 /// Records `prev`/`curr` lists during one sketch edit; pushes a `Sketch_delta` on commit.

--- a/src/sketch_delta.h
+++ b/src/sketch_delta.h
@@ -75,8 +75,6 @@ private:
   std::string m_sketch_name;
 };
 
-class Sketch_op_recorder;
-
 /// Records `prev`/`curr` lists during one sketch edit; pushes a `Sketch_delta` on commit.
 class Sketch_op_recorder
 {

--- a/src/sketch_json.cpp
+++ b/src/sketch_json.cpp
@@ -54,21 +54,21 @@ json node_to_json_(const Sketch_nodes::Node& nd)
 void Sketch_json::load_nodes_(Sketch& sketch, const json& nodes_json)
 {
   EZY_ASSERT(nodes_json.is_array());
-  sketch.get_nodes().json_resize(nodes_json.size());
+  sketch.get_nodes().resize(nodes_json.size());
   for (size_t i = 0; i < nodes_json.size(); ++i)
   {
     const json& el = nodes_json[i];
     if (el.is_null())
     {
-      sketch.get_nodes().json_set_node(i, gp_Pnt2d(0., 0.), true, false, false, "");
+      sketch.get_nodes().set_node(i, gp_Pnt2d(0., 0.), true, false, false, "");
       continue;
     }
     EZY_ASSERT(el.is_object());
     const gp_Pnt2d pt        = ::from_json_pnt2d(el);
     const bool     midpoint  = el.contains("midpoint") && el["midpoint"].is_boolean() && el["midpoint"].get<bool>();
     const bool     permanent = el.contains("permanent") && el["permanent"].is_boolean() && el["permanent"].get<bool>();
-    sketch.get_nodes().json_set_node(i, pt, false, midpoint, permanent,
-                                     el.contains("name") && el["name"].is_string() ? el["name"].get<std::string>() : "");
+    sketch.get_nodes().set_node(i, pt, false, midpoint, permanent,
+                                el.contains("name") && el["name"].is_string() ? el["name"].get<std::string>() : "");
   }
 }
 

--- a/src/sketch_nodes.cpp
+++ b/src/sketch_nodes.cpp
@@ -56,8 +56,9 @@ public:
   bool        empty() const;
   size_t      size() const;
 
-  void json_resize(size_t count);
-  void json_set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent, const std::string& name);
+  void resize(size_t count);
+  void set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent, const std::string& name);
+  void restore_node_at(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent, const std::string& name);
 
   void finalize();
   void cancel();
@@ -694,10 +695,10 @@ bool Sketch_nodes::Impl::empty() const { return m_nodes.empty(); }
 
 size_t Sketch_nodes::Impl::size() const { return m_nodes.size(); }
 
-void Sketch_nodes::Impl::json_resize(size_t count) { m_nodes.assign(count, Node{}); }
+void Sketch_nodes::Impl::resize(size_t count) { m_nodes.assign(count, Node{}); }
 
-void Sketch_nodes::Impl::json_set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent,
-                                       const std::string& name)
+void Sketch_nodes::Impl::set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent,
+                                  const std::string& name)
 {
   EZY_ASSERT(idx < m_nodes.size());
   Node& n = m_nodes[idx];
@@ -707,6 +708,15 @@ void Sketch_nodes::Impl::json_set_node(size_t idx, const gp_Pnt2d& pt, bool dele
   n.midpoint  = midpoint;
   n.permanent = permanent;
   n.name      = name;
+}
+
+void Sketch_nodes::Impl::restore_node_at(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent,
+                                         const std::string& name)
+{
+  if (idx >= size())
+    resize(idx + 1);
+
+  set_node(idx, pt, deleted, midpoint, permanent, name);
 }
 
 void Sketch_nodes::Impl::finalize() { m_prev_num_nodes = m_nodes.size(); }
@@ -788,17 +798,23 @@ bool Sketch_nodes::empty() const { return m_impl->empty(); }
 
 size_t Sketch_nodes::size() const { return m_impl->size(); }
 
-void Sketch_nodes::json_resize(size_t count) { m_impl->json_resize(count); }
+void Sketch_nodes::resize(size_t count) { m_impl->resize(count); }
 
-void Sketch_nodes::json_set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent,
-                                 const std::string& name)
+void Sketch_nodes::set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent,
+                            const std::string& name)
 {
-  m_impl->json_set_node(idx, pt, deleted, midpoint, permanent, name);
+  m_impl->set_node(idx, pt, deleted, midpoint, permanent, name);
 }
 
 void Sketch_nodes::finalize() { m_impl->finalize(); }
 
 void Sketch_nodes::cancel() { m_impl->cancel(); }
+
+void Sketch_nodes::restore_node_at(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent,
+                                   const std::string& name)
+{
+  m_impl->restore_node_at(idx, pt, deleted, midpoint, permanent, name);
+}
 
 void Sketch_nodes::clear_outside_snap_pnts() { m_impl->clear_outside_snap_pnts(); }
 

--- a/src/sketch_nodes.h
+++ b/src/sketch_nodes.h
@@ -64,6 +64,10 @@ public:
   void        finalize();
   void        cancel();
 
+  /// Restores node slot `idx` for undo/redo (appends tombstone slots as needed).
+  void restore_node_at(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent,
+                       const std::string& name = {});
+
   void clear_outside_snap_pnts();
   void add_outside_snap_pnt(const gp_Pnt& pt3d);
 
@@ -95,9 +99,9 @@ private:
   friend class Sketch_json;
 
   /// Resize storage so indices `0..count-1` exist (JSON load).
-  void json_resize(size_t count);
-  /// Assign slot `idx` (used after `json_resize`).
-  void json_set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent, const std::string& name = {});
+  void resize(size_t count);
+  /// Assign slot `idx` (used after `resize`).
+  void set_node(size_t idx, const gp_Pnt2d& pt, bool deleted, bool midpoint, bool permanent, const std::string& name = {});
 
   class Impl;
   std::unique_ptr<Impl> m_impl;

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -25,9 +25,11 @@ using namespace glm;
 class GUI_access
 {
  public:
-  static void       set_view(GUI& gui, std::unique_ptr<Occt_view>& view);
-  static Occt_view& get_view(GUI& gui);
+  static void        set_view(GUI& gui, std::unique_ptr<Occt_view>& view);
+  static Occt_view&  get_view(GUI& gui);
   static std::string get_message(const GUI& gui);
+  static void        sketch_left_click(GUI& gui, const ScreenCoords& screen_coords);
+  static void        mirror_selected_edges(GUI& gui);
 };
 
 // Test fixture for Sketch tests
@@ -162,6 +164,16 @@ Occt_view& GUI_access::get_view(GUI& gui)
 std::string GUI_access::get_message(const GUI& gui)
 {
   return gui.m_message;
+}
+
+void GUI_access::sketch_left_click(GUI& gui, const ScreenCoords& screen_coords)
+{
+  gui.sketch_left_click(screen_coords);
+}
+
+void GUI_access::mirror_selected_edges(GUI& gui)
+{
+  gui.mirror_selected_sketch_edges();
 }
 
 inline void Sketch_access::get_originating_face_snp_pts_3d_(Sketch& sketch, std::vector<gp_Pnt>& out)
@@ -2157,40 +2169,41 @@ TEST_F(Sketch_test, OperationAxis_JSON_RoundTrip)
   EXPECT_NEAR(j2["operation_axis"][1]["y"].get<double>(), axis_end.Y(), 1e-8);
 }
 
-// Test mirror_selected_edges error handling when no edges are selected
+// Mirror with no selection: error message and Sketch_op_recorder::cancel() via headless GUI
+// (operation axis clicks + Options panel Mirror button).
 TEST_F(Sketch_test, MirrorSelectedEdges_NoEdgesSelected)
 {
-  gp_Pln default_plane(gp::Origin(), gp::DZ());
-  Sketch sketch("TestSketch", view(), default_plane);
+  struct Headless_guard
+  {
+    Occt_view& m_v;
+    explicit Headless_guard(Occt_view& v)
+        : m_v(v)
+    {
+      View_access::set_headless(m_v, true);
+    }
+    ~Headless_guard()
+    {
+      View_access::set_headless(m_v, false);
+    }
+  } guard(view());
 
-  // Set mode to operation axis
+  Sketch& sketch = view().curr_sketch();
+
   gui().set_mode(Mode::Sketch_operation_axis);
+  GUI_access::sketch_left_click(gui(), ScreenCoords(dvec2(0.0, 0.0)));
+  GUI_access::sketch_left_click(gui(), ScreenCoords(dvec2(10.0, 0.0)));
 
-  // Create an operation axis by adding two points
-  // Note: The second point automatically finalizes the operation axis (Single linestring type)
-  gp_Pnt2d axis_start(0.0, 0.0);
-  gp_Pnt2d axis_end(10.0, 0.0);
-  
-  ScreenCoords screen_coords_start(dvec2(axis_start.X(), axis_start.Y()));
-  sketch.add_sketch_pt(screen_coords_start);
-  
-  ScreenCoords screen_coords_end(dvec2(axis_end.X(), axis_end.Y()));
-  sketch.add_sketch_pt(screen_coords_end);
-  // finalize_elm() is called automatically when the second point is added for Single linestring type
-
-  // Verify operation axis was created
   EXPECT_TRUE(sketch.has_operation_axis()) << "Operation axis should be created";
 
-  // Clear any existing message
   gui().show_message("");
+  const size_t undo_steps_before = view().undo_stack_size();
 
-  // Try to mirror without selecting any edges
-  sketch.mirror_selected_edges();
+  GUI_access::mirror_selected_edges(gui());
 
-  // Verify error message was shown
-  std::string message = GUI_access::get_message(gui());
-  EXPECT_EQ(message, Sketch::ERROR_NO_EDGES_SELECTED)
+  EXPECT_EQ(GUI_access::get_message(gui()), Sketch::ERROR_NO_EDGES_SELECTED)
       << "Error message should be displayed when no edges are selected";
+  EXPECT_EQ(view().undo_stack_size(), undo_steps_before)
+      << "Mirror with no selection must not push an undo step";
 }
 
 // Positive test: mirror a simple straight edge across a horizontal axis.

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -14,6 +14,7 @@
 #include "gui.h"
 #include "occt_view.h"
 #include "sketch.h"
+#include "sketch_delta.h"
 #include "sketch_json.h"
 #include "utl_occt.h"
 
@@ -94,6 +95,7 @@ class Sketch_access
 
   static const std::vector<Sketch_face_shp_ptr>& get_faces(const Sketch& sketch);
   static size_t                                 get_linear_edge_count(const Sketch& sketch);
+  static size_t                                 get_arc_internal_edge_count(const Sketch& sketch);
 
   /// Exact replay of a saved linear edge (with its pre-existing midpoint node index).
   /// Used for regression tests of specific .ezy cases (e.g. bridge + hole topologies).
@@ -116,6 +118,17 @@ size_t Sketch_access::get_linear_edge_count(const Sketch& sketch)
   for (const auto& edge : sketch.m_edges)
   {
     if (edge.node_idx_b.has_value() && !edge.circle_arc)
+      ++count;
+  }
+  return count;
+}
+
+size_t Sketch_access::get_arc_internal_edge_count(const Sketch& sketch)
+{
+  size_t count = 0;
+  for (const auto& edge : sketch.m_edges)
+  {
+    if (edge.circle_arc)
       ++count;
   }
   return count;
@@ -469,6 +482,87 @@ TEST_F(Sketch_test, AddTwoCrossingEdges_ThroughMidpoint_ProducesFourEdges)
 
   EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 4)
       << "Vertical through existing horizontal's midpoint (GUI finalize path) must still cause splits on both, yielding four edges";
+}
+
+TEST_F(Sketch_test, Undo_single_arc_via_recorder)
+{
+  gp_Pln default_plane(gp::Origin(), gp::DZ());
+  Sketch sketch("TestSketch", view(), default_plane);
+
+  const gp_Pnt2d start(0.0, 0.0);
+  const gp_Pnt2d end(10.0, 0.0);
+  const gp_Pnt2d arc_mid(5.0, 5.0);
+
+  {
+    Sketch_op_recorder rec(view(), sketch);
+    Sketch_access::add_arc_circle_(sketch, start, arc_mid, end);
+    rec.commit();
+  }
+
+  EXPECT_EQ(Sketch_access::get_arc_internal_edge_count(sketch), 2);
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_EQ(Sketch_access::get_arc_internal_edge_count(sketch), 0)
+      << "Undo should remove both internal arc edges";
+
+  EXPECT_TRUE(view().redo());
+  EXPECT_EQ(Sketch_access::get_arc_internal_edge_count(sketch), 2)
+      << "Redo should restore the arc";
+}
+
+TEST_F(Sketch_test, Undo_circle_via_recorder)
+{
+  gp_Pln default_plane(gp::Origin(), gp::DZ());
+  Sketch sketch("TestSketch", view(), default_plane);
+
+  const gp_Pnt2d center(0.0, 0.0);
+  const gp_Pnt2d edge_pt(5.0, 0.0);
+  const std::array<gp_Pnt2d, 4> points = xy_stencil_pnts(center, edge_pt);
+
+  {
+    Sketch_op_recorder rec(view(), sketch);
+    Sketch_access::add_arc_circle_(sketch, points[0], points[2], points[1]);
+    Sketch_access::add_arc_circle_(sketch, points[0], points[3], points[1]);
+    rec.commit();
+  }
+
+  EXPECT_EQ(Sketch_access::get_arc_internal_edge_count(sketch), 4);
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_EQ(Sketch_access::get_arc_internal_edge_count(sketch), 0)
+      << "Undo should remove both semicircles (four internal edges)";
+
+  EXPECT_TRUE(view().redo());
+  EXPECT_EQ(Sketch_access::get_arc_internal_edge_count(sketch), 4)
+      << "Redo should restore the circle";
+}
+
+TEST_F(Sketch_test, Undo_two_crossing_edges_via_finalize)
+{
+  gp_Pln default_plane(gp::Origin(), gp::DZ());
+  Sketch sketch("TestSketch", view(), default_plane);
+
+  {
+    Sketch_op_recorder rec(view(), sketch);
+    Sketch_access::add_edge_(sketch, gp_Pnt2d(0.0, 0.0), gp_Pnt2d(10.0, 0.0));
+    rec.commit();
+  }
+
+  {
+    Sketch_op_recorder rec(view(), sketch);
+    Sketch_access::add_edge_(sketch, gp_Pnt2d(3.0, -2.0), gp_Pnt2d(3.0, 4.0));
+    rec.commit();
+  }
+
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 4);
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 1)
+      << "Undo of the second edge should remove it and restore the unsplit first edge";
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 0)
+      << "Undo of the first edge should remove it";
 }
 
 // Test T-junction case (one edge's endpoint touches the interior of another).


### PR DESCRIPTION
## Summary

- **Delta undo for sketches:** New `Delta` base and `Sketch_delta` record explicit `prev_*` / `curr_*` state (linear edges, arcs, length dims, operation axis, node tombstones) instead of full JSON snapshots for sketch operations.
- **`Sketch_op_recorder`:** RAII scope records changes during one edit; `commit()` pushes a delta, `cancel()` drops it (e.g. mirror with no selection). Destructor cancels if still uncommitted.
- **Arc/circle undo:** Fixed internal-edge removal/restoration; circle undo covers both semicircles (four internal edges).
- **PIMPL:** `Sketch_delta` and `Sketch_op_recorder` hide implementation in `.cpp`; record types live in `Sketch_delta::Impl`. `Sketch_nodes::restore_node_at` moved to `Sketch_nodes::Impl`.
- **Tests / GUI hooks:** Headless tests for undo (arc, circle, crossing edges) and mirror-with-no-selection cancel path; `GUI::sketch_left_click()` and `GUI::mirror_selected_sketch_edges()` for testability.
- **Code style doc:** Reader-first `.cpp` order, helpers at file bottom, PIMPL examples.

Closes #144

## Test plan

- [x] Build `EzyCad_lib` and `EzyCad_tests` (Release).
- [x] Run: `EzyCad_tests.exe --gtest_filter=Sketch_test.Undo*:Sketch_test.MirrorSelectedEdges_NoEdgesSelected` (4 tests)
- [x] Manual: sketch linear edge add + undo/redo; arc/circle + undo/redo; mirror with axis and selected edges; mirror with no selection (error, undo stack unchanged).
- [x] Smoke: shape fuse/cut/chamfer undo still uses JSON snapshots.

Draft: `agents/prs/009-sketch-delta-undo-redo.md`