### PR TITLE
Sketch undo: stable sketch ids for delta resolve, operation-axis undo, and undo stack byte budget

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -21,7 +21,7 @@
 * Add concept of dim or dimension, use with node, a measurement, but does not participate in generating faces.
 * Vendor and commit `third_party/ImGuiColorTextEdit/` into this repository; it has not been maintained upstream for a long time and we should pin a known-good copy.
 * ~~After an edge is split by its midpoint, the split edges do not have midpoints to snap to~~ - FIXED 
-* Operation axis, after adding undo does not work correctly.
+* ~~Operation axis, after adding undo does not work correctly. - FIXED (clear axis is undoable; redo clear works)~~
 * Add rectangle two points, with angle constraint, preview does not honor it.
 * Add rectangle with center point behaves like the two point version.
 * Add circle from three points is broken.

--- a/src/delta.h
+++ b/src/delta.h
@@ -14,4 +14,6 @@ public:
   virtual void                   apply_forward(Occt_view& view) = 0;
   virtual void                   apply_reverse(Occt_view& view) = 0;
   virtual std::unique_ptr<Delta> clone() const                  = 0;
+  /// Rough stored size for undo-stack byte budgeting (not exact).
+  virtual size_t approximate_undo_bytes() const { return 256; }
 };

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2380,7 +2380,13 @@ void GUI::dbg_()
     return;
   }
   // Undo / redo stack
-  ImGui::Text("Undo: %zu (Ctrl+Z)  |  Redo: %zu (Ctrl+Y)  [max 50]", m_view->undo_stack_size(), m_view->redo_stack_size());
+  ImGui::Text("Undo: %zu (%.2f MB)  |  Redo: %zu (%.2f MB)  [%zu steps max, %zu MB cap]",
+              m_view->undo_stack_size(),
+              static_cast<double>(m_view->undo_stack_footprint_bytes()) / (1024.0 * 1024.0),
+              m_view->redo_stack_size(),
+              static_cast<double>(m_view->redo_stack_footprint_bytes()) / (1024.0 * 1024.0),
+              Occt_view::k_max_undo,
+              Occt_view::k_max_undo_bytes / (1024u * 1024u));
   ImGui::Separator();
   // Get the available content region width
   float available_width = ImGui::GetContentRegionAvail().x;

--- a/src/gui_mode.cpp
+++ b/src/gui_mode.cpp
@@ -806,7 +806,7 @@ void GUI::options_sketch_operation_axis_mode_()
                   doc_urls::k_revolve_solid_conversion);
 
     if (ImGui::Button("Clear axis"))
-      m_view->curr_sketch().clear_operation_axis();
+      m_view->curr_sketch().clear_operation_axis_undoable();
   }
 
   options_sketch_len_angle_hotkeys_();

--- a/src/occt_view.cpp
+++ b/src/occt_view.cpp
@@ -1859,6 +1859,14 @@ Aspect_VKeyFlags Occt_view::key_flags_from_glfw_(int theFlags)
 
 Occt_view::Sketch_list& Occt_view::get_sketches() { return m_sketches; }
 
+uint64_t Occt_view::allocate_sketch_id() { return m_next_sketch_id++; }
+
+void Occt_view::note_loaded_sketch_id(uint64_t id)
+{
+  if (id >= m_next_sketch_id)
+    m_next_sketch_id = id + 1;
+}
+
 void Occt_view::remove_sketch(const Sketch_ptr& sketch)
 {
   push_undo_snapshot();
@@ -1926,6 +1934,48 @@ Shp_extrude&   Occt_view::shp_extrude()   { return m_shp_extrude;    }
 
 // ---------------------------------------------------------------------------
 // Undo / redo: sketch edits use element deltas; other operations use full JSON snapshots.
+size_t Occt_view::stack_footprint_bytes_(const std::vector<Undo_entry>& stack)
+{
+  size_t total = 0;
+  for (const Undo_entry& entry : stack)
+    total += entry.footprint_bytes;
+  return total;
+}
+
+void Occt_view::trim_undo_stack_()
+{
+  while (m_undo_stack.size() > k_max_undo)
+    m_undo_stack.erase(m_undo_stack.begin());
+
+  while (m_undo_stack.size() > 1 && stack_footprint_bytes_(m_undo_stack) > k_max_undo_bytes)
+  {
+    auto snapshot_it =
+        std::find_if(m_undo_stack.begin(), m_undo_stack.end(),
+                     [](const Undo_entry& entry) { return entry.kind == Undo_entry_kind::Document_snapshot; });
+    if (snapshot_it != m_undo_stack.end())
+      m_undo_stack.erase(snapshot_it);
+    else
+      m_undo_stack.erase(m_undo_stack.begin());
+  }
+}
+
+void Occt_view::trim_redo_stack_()
+{
+  while (m_redo_stack.size() > k_max_undo)
+    m_redo_stack.erase(m_redo_stack.begin());
+
+  while (m_redo_stack.size() > 1 && stack_footprint_bytes_(m_redo_stack) > k_max_undo_bytes)
+  {
+    auto snapshot_it =
+        std::find_if(m_redo_stack.begin(), m_redo_stack.end(),
+                     [](const Undo_entry& entry) { return entry.kind == Undo_entry_kind::Document_snapshot; });
+    if (snapshot_it != m_redo_stack.end())
+      m_redo_stack.erase(snapshot_it);
+    else
+      m_redo_stack.erase(m_redo_stack.begin());
+  }
+}
+
 void Occt_view::push_undo_snapshot()
 {
   if (m_restoring)
@@ -1933,11 +1983,12 @@ void Occt_view::push_undo_snapshot()
 
   m_redo_stack.clear();
   Undo_entry entry;
-  entry.json = to_json();
-  entry.mode = m_gui.get_mode();
+  entry.kind   = Undo_entry_kind::Document_snapshot;
+  entry.json   = to_json();
+  entry.mode   = m_gui.get_mode();
+  entry.footprint_bytes = entry.json.size();
   m_undo_stack.push_back(std::move(entry));
-  if (m_undo_stack.size() > k_max_undo)
-    m_undo_stack.erase(m_undo_stack.begin());
+  trim_undo_stack_();
 }
 
 void Occt_view::push_undo_delta(std::unique_ptr<Delta> delta)
@@ -1947,11 +1998,12 @@ void Occt_view::push_undo_delta(std::unique_ptr<Delta> delta)
 
   m_redo_stack.clear();
   Undo_entry entry;
-  entry.delta = std::move(delta);
-  entry.mode  = m_gui.get_mode();
+  entry.kind            = Undo_entry_kind::Sketch_delta;
+  entry.delta           = std::move(delta);
+  entry.mode            = m_gui.get_mode();
+  entry.footprint_bytes = entry.delta->approximate_undo_bytes();
   m_undo_stack.push_back(std::move(entry));
-  if (m_undo_stack.size() > k_max_undo)
-    m_undo_stack.erase(m_undo_stack.begin());
+  trim_undo_stack_();
 }
 
 void Occt_view::pop_undo_snapshot()
@@ -1974,18 +2026,23 @@ bool Occt_view::undo()
   Undo_entry redo_entry;
   redo_entry.mode = m_gui.get_mode();
 
-  if (state.delta)
+  if (state.kind == Undo_entry_kind::Sketch_delta && state.delta)
   {
-    redo_entry.delta = state.delta->clone();
+    redo_entry.kind            = Undo_entry_kind::Sketch_delta;
+    redo_entry.delta           = state.delta->clone();
+    redo_entry.footprint_bytes = redo_entry.delta->approximate_undo_bytes();
     state.delta->apply_reverse(*this);
   }
   else
   {
-    redo_entry.json = to_json();
+    redo_entry.kind            = Undo_entry_kind::Document_snapshot;
+    redo_entry.json            = to_json();
+    redo_entry.footprint_bytes = redo_entry.json.size();
     load(state.json, false); // Keep current view so undo/redo keeps a single perspective
   }
 
   m_redo_stack.push_back(std::move(redo_entry));
+  trim_redo_stack_();
   m_gui.set_mode(state.mode);
   if (state.mode == Mode::Sketch_inspection_mode)
     m_gui.set_show_sketch_list(true);
@@ -2006,18 +2063,23 @@ bool Occt_view::redo()
   Undo_entry undo_entry;
   undo_entry.mode = m_gui.get_mode();
 
-  if (state.delta)
+  if (state.kind == Undo_entry_kind::Sketch_delta && state.delta)
   {
-    undo_entry.delta = state.delta->clone();
+    undo_entry.kind            = Undo_entry_kind::Sketch_delta;
+    undo_entry.delta           = state.delta->clone();
+    undo_entry.footprint_bytes = undo_entry.delta->approximate_undo_bytes();
     state.delta->apply_forward(*this);
   }
   else
   {
-    undo_entry.json = to_json();
+    undo_entry.kind            = Undo_entry_kind::Document_snapshot;
+    undo_entry.json            = to_json();
+    undo_entry.footprint_bytes = undo_entry.json.size();
     load(state.json, false); // Keep current view so undo/redo keeps a single perspective
   }
 
   m_undo_stack.push_back(std::move(undo_entry));
+  trim_undo_stack_();
   m_gui.set_mode(state.mode);
   if (state.mode == Mode::Sketch_inspection_mode)
     m_gui.set_show_sketch_list(true);
@@ -2031,6 +2093,10 @@ bool Occt_view::can_redo() const { return !m_redo_stack.empty(); }
 
 size_t Occt_view::undo_stack_size() const { return m_undo_stack.size(); }
 size_t Occt_view::redo_stack_size() const { return m_redo_stack.size(); }
+
+size_t Occt_view::undo_stack_footprint_bytes() const { return stack_footprint_bytes_(m_undo_stack); }
+
+size_t Occt_view::redo_stack_footprint_bytes() const { return stack_footprint_bytes_(m_redo_stack); }
 
 // ---------------------------------------------------------------------------
 // Document format: 1 = legacy sketch edges could carry a 4th "dim" flag; 2 = length_dimensions array + 3-tuple edges.

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -5,6 +5,7 @@
 #include <AIS_ViewController.hxx>
 #include <Graphic3d_MaterialAspect.hxx>
 #include <glm/glm.hpp>
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <optional>
@@ -103,6 +104,13 @@ public:
   bool   can_redo() const;
   size_t undo_stack_size() const;
   size_t redo_stack_size() const;
+  /// Approximate total bytes retained by undo / redo entries (for debug and budgeting).
+  size_t undo_stack_footprint_bytes() const;
+  size_t redo_stack_footprint_bytes() const;
+
+  static constexpr size_t k_max_undo{50};
+  /// Drop oldest document snapshots first when total retained undo data exceeds this budget.
+  static constexpr size_t k_max_undo_bytes{32 * 1024 * 1024};
 
   void do_frame();
   /// Apply pending navigation (pan/zoom/rotate) to the camera before UI uses view projection (e.g. underlay slider bounds).
@@ -133,21 +141,26 @@ public:
   // Sketch related
   Sketch_list& get_sketches();
   void         remove_sketch(const Sketch_ptr& sketch);
-  /// Empty sketch on \a pln; \a base_name is uniquified (e.g. Sketch_xy, Sketch_xy.001).
-  void       add_sketch(const gp_Pln& pln, const std::string& base_name);
-  Sketch&    curr_sketch();
-  Sketch_ptr curr_sketch_shared() const;
-  void       set_curr_sketch(const Sketch_ptr& sketch);
-  void       sketch_face_extrude(const ScreenCoords& screen_coords, bool is_mouse_move);
+  void         add_sketch(const gp_Pln& pln, const std::string& base_name);
+  /// Allocates a new stable sketch id (monotonic for this view session / document).
+  uint64_t     allocate_sketch_id();
+  /// After loading a sketch with a persisted id, keep the allocator above all loaded ids.
+  void         note_loaded_sketch_id(uint64_t id);
+  Sketch&      curr_sketch();
+  Sketch_ptr   curr_sketch_shared() const;
+  void         set_curr_sketch(const Sketch_ptr& sketch);
+  void         sketch_face_extrude(const ScreenCoords& screen_coords, bool is_mouse_move);
 
   std::list<Shp_ptr>& get_shapes();
   std::string         get_unique_shape_name(const char* base_name) const;
-  void                add_box(double ox, double oy, double oz, double width, double length, double height);
-  void                add_pyramid(double ox, double oy, double oz, double side);
-  void                add_sphere(double ox, double oy, double oz, double radius);
-  void                add_cylinder(double ox, double oy, double oz, double radius, double height);
-  void                add_cone(double ox, double oy, double oz, double R1, double R2, double height);
-  void                add_torus(double ox, double oy, double oz, double R1, double R2);
+
+  // Basic shape creation
+  void add_box(double ox, double oy, double oz, double width, double length, double height);
+  void add_pyramid(double ox, double oy, double oz, double side);
+  void add_sphere(double ox, double oy, double oz, double radius);
+  void add_cylinder(double ox, double oy, double oz, double radius, double height);
+  void add_cone(double ox, double oy, double oz, double R1, double R2, double height);
+  void add_torus(double ox, double oy, double oz, double R1, double R2);
 
   // Shape related
   Shp_move&      shp_move();
@@ -313,18 +326,28 @@ private:
   V3d_View_ptr               m_view;
   Occt_glfw_win_ptr          m_occt_window;
   // Undo / redo
-  static constexpr size_t k_max_undo{50};
+  enum class Undo_entry_kind
+  {
+    Sketch_delta,
+    Document_snapshot,
+  };
 
   struct Undo_entry
   {
+    Undo_entry_kind        kind{Undo_entry_kind::Document_snapshot};
     std::unique_ptr<Delta> delta;
-    std::string            json; // Full-document snapshot when `delta` is null
+    std::string            json; // Full-document snapshot when `kind` is Document_snapshot
     Mode                   mode; // Mode at time of operation; restored when navigating stacks
+    size_t                 footprint_bytes{};
   };
 
   std::vector<Undo_entry> m_undo_stack;
   std::vector<Undo_entry> m_redo_stack;
   bool                    m_restoring{false};
+
+  static size_t stack_footprint_bytes_(const std::vector<Undo_entry>& stack);
+  void          trim_undo_stack_();
+  void          trim_redo_stack_();
 
   // --------------------------------------------------------------------
   // Dimension related
@@ -334,6 +357,7 @@ private:
   std::list<Shp_ptr>                m_shps;
   Sketch_list                       m_sketches;
   std::shared_ptr<Sketch>           m_cur_sketch;
+  uint64_t                          m_next_sketch_id{1};
   TopAbs_ShapeEnum                  m_shp_selection_mode{TopAbs_SHAPE};
   Shp_ptr                           m_shape_list_hover;
   PrsDim_LengthDimension_ptr        m_sketch_list_measurement_hover;

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -67,22 +67,30 @@ std::optional<Symmetric_edge_span> symmetric_edge_from_center_and_hint(const gp_
 }
 } // namespace
 
-Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln)
+Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, std::optional<uint64_t> id)
     : m_view(view)
     , m_ctx(view.ctx())
     , m_pln(pln)
     , m_name(name)
+    , m_id(id ? *id : view.allocate_sketch_id())
     , m_nodes(view, pln)
 {
+  if (id)
+    view.note_loaded_sketch_id(*id);
 }
 
-Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, const TopoDS_Wire& outer_wire)
+Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, const TopoDS_Wire& outer_wire,
+               std::optional<uint64_t> id)
     : m_view(view)
     , m_ctx(view.ctx())
     , m_pln(pln)
     , m_name(name)
+    , m_id(id ? *id : view.allocate_sketch_id())
     , m_nodes(view, pln)
 {
+  if (id)
+    view.note_loaded_sketch_id(*id);
+
   m_originating_face = new AIS_Shape(outer_wire);
   m_ctx.Display(m_originating_face, true);
   update_originating_face_style();
@@ -111,7 +119,11 @@ Sketch::~Sketch()
     m_ctx.Remove(f, false);
 
   if (m_operation_axis.has_value())
-    remove_edge(*m_operation_axis);
+    if (!m_operation_axis->shp.IsNull())
+    {
+      m_ctx.Remove(m_operation_axis->shp, false);
+      m_operation_axis->shp.Nullify();
+    }
 
   remove_all_permanent_node_marks_();
 
@@ -1196,7 +1208,11 @@ void Sketch::finalize_operation_axis_(Sketch_op_recorder& rec)
 {
   m_operation_axis = std::move(m_tmp_edges.back());
   if (m_operation_axis->node_idx_b.has_value())
+  {
     rec.note_curr_operation_axis(m_nodes[m_operation_axis->node_idx_a], m_nodes[*m_operation_axis->node_idx_b]);
+    rec.note_curr_node(m_operation_axis->node_idx_a);
+    rec.note_curr_node(*m_operation_axis->node_idx_b);
+  }
 
   cancel_elm(); // Reset state, we have the operation axis
   sync_operation_axis_display_();
@@ -1207,11 +1223,31 @@ void Sketch::finalize_operation_axis_(Sketch_op_recorder& rec)
 void Sketch::clear_operation_axis()
 {
   if (m_operation_axis.has_value())
-    m_ctx.Remove(m_operation_axis->shp, false);
+  {
+    if (!m_operation_axis->shp.IsNull())
+    {
+      m_ctx.Remove(m_operation_axis->shp, false);
+      m_operation_axis->shp.Nullify();
+    }
+  }
 
-  m_operation_axis = std::nullopt;
+  m_operation_axis.reset();
   sync_permanent_node_annos_();
   m_nodes.hide_snap_annos();
+}
+
+void Sketch::clear_operation_axis_undoable()
+{
+  if (!m_operation_axis.has_value())
+    return;
+
+  Sketch_op_recorder rec(m_view, *this);
+  {
+    EZY_ASSERT(m_operation_axis->node_idx_b.has_value());
+    rec.note_prev_operation_axis(m_operation_axis->node_idx_a, *m_operation_axis->node_idx_b);
+    clear_operation_axis();
+    rec.commit();
+  }
 }
 
 bool Sketch::has_operation_axis() const { return m_operation_axis.has_value(); }
@@ -3018,6 +3054,8 @@ gp_Pnt Sketch::to_3d_(const std::optional<size_t>& node_idx) const
 const std::string& Sketch::get_name() const { return m_name; }
 
 void Sketch::set_name(const std::string& name) { m_name = name; }
+
+uint64_t Sketch::get_id() const { return m_id; }
 
 bool Sketch::has_edges() const { return !m_edges.empty(); }
 

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -4,6 +4,7 @@
 #include <gp_Pnt.hxx>
 #include <gp_Pnt2d.hxx>
 #include <gp_Vec2d.hxx>
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <optional>
@@ -45,9 +46,11 @@ public:
   DECL_PTR(Sketch);
   using Sketch_ptr = sptr; // Compatibility alias for existing code.
 
-  // `view` must exist for the lifetime of this `Sketch`
-  Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln);
-  Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, const TopoDS_Wire& outer_wire);
+  // `view` must exist for the lifetime of this `Sketch`.
+  // Pass `id` when restoring from JSON; omit to allocate a new stable id from `view`.
+  Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, std::optional<uint64_t> id = std::nullopt);
+  Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, const TopoDS_Wire& outer_wire,
+         std::optional<uint64_t> id = std::nullopt);
 
   ~Sketch();
 
@@ -66,6 +69,8 @@ public:
   void finalize_elm();
   bool cancel_elm();
   void clear_operation_axis();
+  /// Clears the operation axis and pushes an undo step (Options "Clear axis").
+  void clear_operation_axis_undoable();
   bool has_operation_axis() const;
   void on_enter(); // For finalizing manual distance input.
 
@@ -111,6 +116,7 @@ public:
   // Sketch name related.
   const std::string& get_name() const;
   void               set_name(const std::string& name);
+  uint64_t           get_id() const;
 
   /// True if this sketch has at least one edge (used e.g. to pick mode after undo/redo).
   bool   has_edges() const;
@@ -377,6 +383,7 @@ public:
 
   std::string m_dbg_str;
   std::string m_name;
+  uint64_t    m_id{};
   bool        m_visible{true};
 
   // Extrusion related.

--- a/src/sketch_delta.cpp
+++ b/src/sketch_delta.cpp
@@ -54,8 +54,8 @@ public:
     std::string           name;
   };
 
-  Sketch*                                m_sketch{nullptr};
-  std::string                            m_sketch_name;
+  std::string                            m_sketch_name; // debug / legacy only; not used for resolve
+  uint64_t                               m_sketch_id{};
   std::vector<Prev_edge_rec>             prev_linear_edges;
   std::vector<Curr_linear_edge_record>   curr_linear_edges;
   std::vector<Arc_edge_record>           prev_arc_edges;
@@ -66,7 +66,7 @@ public:
   std::optional<Prev_edge_rec>           prev_operation_axis;
   std::optional<Curr_linear_edge_record> curr_operation_axis;
 
-  Impl(Sketch& sketch, std::string sketch_name);
+  Impl(uint64_t sketch_id, std::string sketch_name);
 
   Sketch*                       resolve_sketch_(Occt_view& view) const;
   void                          apply_forward_(Sketch& sketch) const;
@@ -124,8 +124,8 @@ private:
   void unregister_owner_();
 };
 
-Sketch_delta::Sketch_delta(Sketch& sketch, std::string sketch_name)
-    : m_impl(std::make_unique<Impl>(sketch, std::move(sketch_name)))
+Sketch_delta::Sketch_delta(uint64_t sketch_id, std::string sketch_name)
+    : m_impl(std::make_unique<Impl>(sketch_id, std::move(sketch_name)))
 {
 }
 
@@ -146,6 +146,24 @@ void Sketch_delta::apply_reverse(Occt_view& view)
 }
 
 std::unique_ptr<Delta> Sketch_delta::clone() const { return m_impl->clone(); }
+
+size_t Sketch_delta::approximate_undo_bytes() const
+{
+  const Impl& d = *m_impl;
+  size_t      n = 264;
+  n += d.prev_linear_edges.size() * 80;
+  n += d.curr_linear_edges.size() * 48;
+  n += d.prev_arc_edges.size() * 72;
+  n += d.curr_arc_edges.size() * 72;
+  n += d.curr_node_idxs.size() * 8;
+  n += d.prev_length_dims.size() * 96;
+  n += d.curr_length_dims.size() * 96;
+  if (d.prev_operation_axis.has_value())
+    n += 80;
+  if (d.curr_operation_axis.has_value())
+    n += 48;
+  return n;
+}
 
 Sketch_op_recorder::Sketch_op_recorder(Occt_view& view, Sketch& sketch)
     : m_impl(std::make_unique<Impl>(view, sketch))
@@ -217,7 +235,7 @@ Sketch_op_recorder::Impl::Impl(Occt_view& view, Sketch& sketch)
       m_live_nodes_at_start.insert(i);
 
   Sketch_delta::Impl::capture_linear_edges_at_start_(sketch, m_linear_edges_at_start);
-  m_delta = std::make_unique<Sketch_delta>(sketch, sketch.get_name());
+  m_delta = std::make_unique<Sketch_delta>(sketch.get_id(), sketch.get_name());
 }
 
 void Sketch_op_recorder::Impl::register_owner_(Sketch_op_recorder& owner)
@@ -386,19 +404,16 @@ void Sketch_op_recorder::Impl::cancel()
   unregister_owner_();
 }
 
-Sketch_delta::Impl::Impl(Sketch& sketch, std::string sketch_name)
-    : m_sketch(&sketch)
-    , m_sketch_name(std::move(sketch_name))
+Sketch_delta::Impl::Impl(uint64_t sketch_id, std::string sketch_name)
+    : m_sketch_name(std::move(sketch_name))
+    , m_sketch_id(sketch_id)
 {
 }
 
 Sketch* Sketch_delta::Impl::resolve_sketch_(Occt_view& view) const
 {
-  if (m_sketch)
-    return m_sketch;
-
   for (const Sketch::sptr& s : view.get_sketches())
-    if (s->get_name() == m_sketch_name)
+    if (s->get_id() == m_sketch_id)
       return s.get();
 
   return nullptr;
@@ -417,6 +432,9 @@ void Sketch_delta::Impl::apply_forward_(Sketch& sketch) const
 
   if (curr_operation_axis.has_value())
     sketch.sketch_json_set_operation_axis_(curr_operation_axis->pt_a, curr_operation_axis->pt_b);
+
+  else if (prev_operation_axis.has_value() && !curr_operation_axis.has_value())
+    sketch.clear_operation_axis();
 
   sketch.m_nodes.hide_snap_annos();
   sketch.update_faces_();
@@ -457,9 +475,8 @@ void Sketch_delta::Impl::apply_reverse_(Sketch& sketch) const
 
 std::unique_ptr<Sketch_delta> Sketch_delta::Impl::clone() const
 {
-  auto  copy                    = std::make_unique<Sketch_delta>(*m_sketch, m_sketch_name);
-  Impl& copy_impl               = *copy->m_impl;
-  copy_impl.m_sketch            = m_sketch;
+  auto  copy              = std::make_unique<Sketch_delta>(m_sketch_id, m_sketch_name);
+  Impl& copy_impl         = *copy->m_impl;
   copy_impl.prev_linear_edges   = prev_linear_edges;
   copy_impl.curr_linear_edges   = curr_linear_edges;
   copy_impl.prev_arc_edges      = prev_arc_edges;

--- a/src/sketch_delta.h
+++ b/src/sketch_delta.h
@@ -44,10 +44,11 @@ private:
 /// One sketch undo step: `prev_*` is restored on undo; `curr_*` is re-applied on redo.
 /// Node indices are never compacted; undo tombstones `curr_node_idxs` and redo revives them
 /// through the normal node lookup when edges are added again.
+/// Target sketch is resolved by stable id (not display name).
 class Sketch_delta : public Delta
 {
 public:
-  Sketch_delta(Sketch& sketch, std::string sketch_name);
+  explicit Sketch_delta(uint64_t sketch_id, std::string sketch_name = {});
   ~Sketch_delta() override;
 
   Sketch_delta(const Sketch_delta&)            = delete;
@@ -56,6 +57,7 @@ public:
   void                   apply_forward(Occt_view& view) override;
   void                   apply_reverse(Occt_view& view) override;
   std::unique_ptr<Delta> clone() const override;
+  size_t                 approximate_undo_bytes() const override;
 
 private:
   friend class Sketch_op_recorder::Impl;

--- a/src/sketch_json.cpp
+++ b/src/sketch_json.cpp
@@ -139,6 +139,7 @@ nlohmann::json Sketch_json::to_json(const Sketch& sketch)
 {
   json j;
   j["isCurrent"] = sketch.is_current();
+  j["id"]        = sketch.get_id();
   j["name"]      = sketch.get_name();
   j["plane"]     = ::to_json(sketch.m_pln);
 
@@ -246,6 +247,10 @@ Sketch::sptr Sketch_json::from_json(Occt_view& view, const nlohmann::json& j)
 
   Sketch::sptr ret;
 
+  std::optional<uint64_t> sketch_id;
+  if (j.contains("id") && j["id"].is_number_unsigned())
+    sketch_id = j["id"].get<uint64_t>();
+
   if (j.contains("originating_face"))
   {
     TopoDS_Shape       shape;
@@ -255,10 +260,10 @@ Sketch::sptr Sketch_json::from_json(Occt_view& view, const nlohmann::json& j)
     EZY_ASSERT(shape.ShapeType() == TopAbs_WIRE);
     const TopoDS_Wire& face = TopoDS::Wire(shape);
 
-    ret = std::make_shared<Sketch>(j["name"], view, from_json_pln(j["plane"]), face);
+    ret = std::make_shared<Sketch>(j["name"], view, from_json_pln(j["plane"]), face, sketch_id);
   }
   else
-    ret = std::make_shared<Sketch>(j["name"], view, from_json_pln(j["plane"]));
+    ret = std::make_shared<Sketch>(j["name"], view, from_json_pln(j["plane"]), sketch_id);
 
   std::vector<std::pair<std::size_t, std::size_t>> legacy_length_dim_endpoints;
 

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -512,8 +512,7 @@ TEST_F(Sketch_test, AddTwoCrossingEdges_ThroughMidpoint_ProducesFourEdges)
 
 TEST_F(Sketch_test, Undo_single_arc_via_recorder)
 {
-  gp_Pln default_plane(gp::Origin(), gp::DZ());
-  Sketch sketch("TestSketch", view(), default_plane);
+  Sketch& sketch = view().curr_sketch();
 
   const gp_Pnt2d start(0.0, 0.0);
   const gp_Pnt2d end(10.0, 0.0);
@@ -538,8 +537,7 @@ TEST_F(Sketch_test, Undo_single_arc_via_recorder)
 
 TEST_F(Sketch_test, Undo_circle_via_recorder)
 {
-  gp_Pln default_plane(gp::Origin(), gp::DZ());
-  Sketch sketch("TestSketch", view(), default_plane);
+  Sketch& sketch = view().curr_sketch();
 
   const gp_Pnt2d center(0.0, 0.0);
   const gp_Pnt2d edge_pt(5.0, 0.0);
@@ -565,8 +563,7 @@ TEST_F(Sketch_test, Undo_circle_via_recorder)
 
 TEST_F(Sketch_test, Undo_two_crossing_edges_via_finalize)
 {
-  gp_Pln default_plane(gp::Origin(), gp::DZ());
-  Sketch sketch("TestSketch", view(), default_plane);
+  Sketch& sketch = view().curr_sketch();
 
   {
     Sketch_op_recorder rec(view(), sketch);
@@ -589,6 +586,100 @@ TEST_F(Sketch_test, Undo_two_crossing_edges_via_finalize)
   EXPECT_TRUE(view().undo());
   EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 0)
       << "Undo of the first edge should remove it";
+}
+
+TEST_F(Sketch_test, Undo_operation_axis_add_clear_redo)
+{
+  Sketch& sketch = view().curr_sketch();
+
+  gui().set_mode(Mode::Sketch_operation_axis);
+  sketch.add_sketch_pt(ScreenCoords(dvec2(0.0, 0.0)));
+  sketch.add_sketch_pt(ScreenCoords(dvec2(10.0, 0.0)));
+  EXPECT_TRUE(sketch.has_operation_axis()) << "Operation axis should be created";
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_FALSE(sketch.has_operation_axis()) << "Undo add should remove axis";
+
+  EXPECT_TRUE(view().redo());
+  EXPECT_TRUE(sketch.has_operation_axis()) << "Redo add should restore axis";
+
+  sketch.clear_operation_axis_undoable();
+  EXPECT_FALSE(sketch.has_operation_axis()) << "Clear should remove axis";
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_TRUE(sketch.has_operation_axis()) << "Undo clear should restore axis";
+
+  EXPECT_TRUE(view().redo());
+  EXPECT_FALSE(sketch.has_operation_axis()) << "Redo clear should remove axis again";
+}
+
+// GUI path: add edge, define operation axis, undo four times, redo twice.
+// Regression: redo must resolve the live sketch by name (not a stale raw pointer).
+TEST_F(Sketch_test, Gui_UndoRedo_edge_then_operation_axis_four_undo_two_redo)
+{
+  struct Headless_guard
+  {
+    Occt_view& m_v;
+    explicit Headless_guard(Occt_view& v)
+        : m_v(v)
+    {
+      View_access::set_headless(m_v, true);
+    }
+    ~Headless_guard()
+    {
+      View_access::set_headless(m_v, false);
+    }
+  } guard(view());
+
+  Sketch& sketch = view().curr_sketch();
+
+  gui().set_mode(Mode::Sketch_add_edge);
+  GUI_access::sketch_left_click(gui(), ScreenCoords(dvec2(0.0, 0.0)));
+  GUI_access::sketch_left_click(gui(), ScreenCoords(dvec2(10.0, 0.0)));
+  EXPECT_GE(Sketch_access::get_linear_edge_count(sketch), 1u) << "Edge should be added via GUI";
+
+  gui().set_mode(Mode::Sketch_operation_axis);
+  GUI_access::sketch_left_click(gui(), ScreenCoords(dvec2(0.0, 0.0)));
+  GUI_access::sketch_left_click(gui(), ScreenCoords(dvec2(10.0, 3.0)));
+  EXPECT_TRUE(sketch.has_operation_axis()) << "Operation axis should be defined via GUI";
+
+  const size_t undo_steps_after_setup = view().undo_stack_size();
+  EXPECT_GE(undo_steps_after_setup, 2u) << "Edge and axis should each push an undo step";
+
+  for (int i = 0; i < 4; ++i)
+    view().undo();
+
+  for (int i = 0; i < 2; ++i)
+    view().redo();
+
+  EXPECT_TRUE(sketch.has_operation_axis()) << "Second redo should restore the operation axis";
+  EXPECT_GE(Sketch_access::get_linear_edge_count(sketch), 1u) << "First redo should restore the edge";
+}
+
+TEST_F(Sketch_test, Undo_delta_resolves_sketch_by_id_after_reload)
+{
+  Sketch& sketch = view().curr_sketch();
+
+  {
+    Sketch_op_recorder rec(view(), sketch);
+    Sketch_access::add_edge_(sketch, gp_Pnt2d(0.0, 0.0), gp_Pnt2d(10.0, 0.0), rec);
+    rec.commit();
+  }
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 0u);
+
+  const uint64_t    sketch_id    = sketch.get_id();
+  const std::string saved_json   = view().to_json();
+  view().load(saved_json, false);
+
+  Sketch& reloaded = view().curr_sketch();
+  EXPECT_EQ(reloaded.get_id(), sketch_id);
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(reloaded), 0u);
+
+  EXPECT_TRUE(view().redo());
+  EXPECT_GE(Sketch_access::get_linear_edge_count(reloaded), 1u)
+      << "Redo after JSON reload must apply to the sketch with the same id";
 }
 
 // Test T-junction case (one edge's endpoint touches the interior of another).
@@ -1596,6 +1687,7 @@ TEST_F(Sketch_test, JsonSerializationDeserialization)
 
   // Verify JSON structure
   EXPECT_TRUE(json_data.contains("name"));
+  EXPECT_TRUE(json_data.contains("id"));
   EXPECT_TRUE(json_data.contains("edges"));
   EXPECT_TRUE(json_data.contains("arc_edges"));
   EXPECT_TRUE(json_data.contains("plane"));
@@ -1604,6 +1696,7 @@ TEST_F(Sketch_test, JsonSerializationDeserialization)
   EXPECT_EQ(json_data["length_dimensions"].size(), 0u);
 
   EXPECT_EQ(json_data["name"], "TestSketch");
+  EXPECT_EQ(json_data["id"].get<uint64_t>(), sketch.get_id());
   EXPECT_TRUE(json_data.contains("nodes"));
   size_t live_nodes = 0;
   for (size_t i = 0; i < sketch.get_nodes().size(); ++i)
@@ -1618,6 +1711,7 @@ TEST_F(Sketch_test, JsonSerializationDeserialization)
 
   // Verify deserialized sketch (compact save drops deleted tombstones; loaded sketch is dense)
   EXPECT_EQ(deserialized_sketch->get_name(), "TestSketch");
+  EXPECT_EQ(deserialized_sketch->get_id(), sketch.get_id());
   EXPECT_EQ(deserialized_sketch->get_nodes().size(), live_nodes);
 
   // Count edges in deserialized sketch


### PR DESCRIPTION
## Summary

- **Stable sketch ids:** Each sketch gets a monotonic `uint64_t` id (persisted in JSON). `Sketch_delta` resolves the target sketch by id, not display name — fixes Release redo crash from dangling `Sketch*` after reload/recreation.
- **Operation axis undo:** `clear_operation_axis_undoable()` for Options **Clear axis**; axis node recording on finalize; redo-clear via `apply_forward_`. OCCT handle `Nullify()` after `Remove` in `clear_operation_axis()`.
- **Undo stack hygiene:** `Undo_entry_kind`, per-entry `footprint_bytes`, 32 MB cap trimming oldest document snapshots first; debug panel shows stack MB (Debug builds).
- **Tests:** GUI undo/redo regression; reload-by-id redo test; undo tests on `curr_sketch()`.

Closes #150

## Test plan

- [x] Build Release: `EzyCad_tests`
- [x] Run: `EzyCad_tests.exe --gtest_filter=Sketch_test.Undo*:Sketch_test.Gui_UndoRedo*`
- [x] Manual: edge + operation axis; undo 4x, redo 2x (Release — former crash)
- [x] Manual: Clear axis → undo → redo
- [x] Manual: save document, reload, redo sketch delta

Draft: `agents/prs/012-sketch-undo-stable-ids.md`