### PR TITLE
Wasm: OCCT 7.9.3 build scripts and GLES shading regression docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ set(OpenCASCADE_LIBS
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Emscripten")
     # Advanced DataExchange modules (STEP, IGES, GLTF, etc.) are only linked for
     # native/desktop builds. The minimal WASM OCCT build from
-    # scripts/build-occt-v8-wasm.ps1 does not include them (to avoid Emscripten
+    # scripts/build-occt-793-wasm.ps1 / build-occt-wasm.ps1 does not include them (to avoid Emscripten
     # incompatibilities with full DE + 3rd-party parsers). If you need them in WASM,
     # rebuild OCCT with more modules and add the missing TKDE* libs here conditionally.
     list(APPEND OpenCASCADE_LIBS TKDEGLTF)

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ Full guide: **[docs/building-occt.md](docs/building-occt.md)** (Windows prebuilt
 
 ### Notes for Emscripten Builds
 - Install Emscripten and activate its environment (`emsdk_env`).
-- **OCCT 8.0.0 for wasm (recommended, current default):** Use the automated script `scripts\build-occt-v8-wasm.ps1` (or .cmd) after `emsdk_env` — see [docs/building-occt.md](docs/building-occt.md#webassembly-emscripten). 
-- Configure the EzyCad project with Emscripten (Ninja recommended now):
-  - `mkdir build_em` then `cd build_em`
-  - Add **-Wno-dev** to suppress any remaining CMake developer warnings.  
-    `emcmake cmake .. -Wno-dev -G Ninja -DOpenCASCADE_DIR=C:/path/to/occt-wasm-build/install/lib/cmake/opencascade -DCMAKE_BUILD_TYPE=Release`
+- **OCCT 7.9.3 for wasm (recommended):** `scripts\build-occt-793-wasm.ps1` (or `.cmd`) after `emsdk_env` — see [docs/building-occt.md](docs/building-occt.md#webassembly-emscripten). OCCT 8.x has a GLES shading regression on wasm (see [docs/bugs.md](docs/bugs.md)).
+- **OCCT 8.0.0.p1 for wasm:** `scripts\build-occt-v8-wasm.ps1` for regression testing against upstream.
+- Configure the EzyCad project with Emscripten (Ninja recommended):
+  - `emcmake cmake -S . -B build-em-7-9-3 -Wno-dev -G Ninja -DOpenCASCADE_DIR=C:/Users/you/occt-wasm-build/V7_9_3/install/lib/cmake/opencascade -DCMAKE_BUILD_TYPE=Release`
+  - Add **-Wno-dev** to suppress any remaining CMake developer warnings.
   - If configure **freezes** after that warning, the hang is often in `find_package(OpenCASCADE)` or Emscripten compiler detection. Run with `--debug-output` to see where it stops.
   - Build:
-    - `ninja` (or `emmake cmake --build . --config Release`)
+    - `ninja -C build-em-7-9-3` (or `emmake cmake --build . --config Release`)
 - Build the project.
 - Serve the WebAssembly: `python.exe -m http.server 8000` from the build output directory (look for `EzyCad.html` + `EzyCad.wasm` + `EzyCad.data`).
 - Or build and serve: `ninja && python.exe -m http.server 8000`

--- a/agents/dev.md
+++ b/agents/dev.md
@@ -58,22 +58,28 @@ Full OCCT + EzyCad wasm instructions live in [docs/building-occt.md](../docs/bui
 
 High-level flow (after `emsdk_env`):
 
-1. Build the OCCT 8.0.0 wasm package (if not already done):
+1. Build the OCCT wasm package (if not already done):
 
    ```powershell
-   .\scripts\build-occt-v8-wasm.ps1 -RootDir C:\bin\occt-wasm-build
+   # Recommended (7.9.3)
+   .\scripts\build-occt-793-wasm.ps1
+
+   # OCCT 8.0.0.p1 (upstream regression compare)
+   .\scripts\build-occt-v8-wasm.ps1
    ```
+
+   Default install trees: `%USERPROFILE%\occt-wasm-build\V7_9_3\install` and `...\V8_0_0_p1\install`.
 
 2. Configure + build EzyCad (Ninja generator recommended):
 
    ```powershell
-   mkdir build-em
-   cd build-em
-   emcmake cmake .. -G Ninja -Wno-dev `
-     -DOpenCASCADE_DIR=C:\bin\occt-wasm-build\install\lib\cmake\opencascade `
+   emcmake cmake -S . -B build-em-7-9-3 -G Ninja -Wno-dev `
+     -DOpenCASCADE_DIR=$env:USERPROFILE\occt-wasm-build\V7_9_3\install\lib\cmake\opencascade `
      -DCMAKE_BUILD_TYPE=Release
-   ninja
+   ninja -C build-em-7-9-3
    ```
+
+   **Wasm GLES bisection:** uncomment one toggle in `src/occt_view_wasm_bisect.h`, then `ninja`.
 
 3. Serve locally:
 
@@ -83,7 +89,7 @@ High-level flow (after `emsdk_env`):
 
    Load `EzyCad.html` (or the copy under `web/`) in a browser.
 
-See `scripts/build-occt-v8-wasm.ps1` (and .cmd wrapper) for script options.
+See `scripts/build-occt-793-wasm.ps1`, `scripts/build-occt-v8-wasm.ps1`, and shared `scripts/build-occt-wasm.ps1` (with `.cmd` wrappers) for script options.
 
 ## Code Quality & Pre-commit Checks
 
@@ -108,7 +114,9 @@ See `scripts/build-occt-v8-wasm.ps1` (and .cmd wrapper) for script options.
 
 - `scripts/sync-github-pages-html.ps1` — Sync `web/` changes (EzyCad.html etc.) to the GitHub Pages wasm demo site.
 - `scripts/pbf-to-png.ps1` / `.py` — Icon / asset conversion helpers.
-- `scripts/build-occt-v8-wasm.ps1` — As shown above.
+- `scripts/build-occt-793-wasm.ps1` — OCCT 7.9.3 wasm (recommended).
+- `scripts/build-occt-v8-wasm.ps1` — OCCT 8.0.0.p1 wasm.
+- `scripts/build-occt-wasm.ps1` — Shared implementation (advanced `-OcctTag` use).
 
 ## Working with AI Coding Assistants
 
@@ -168,14 +176,13 @@ See also the comment in `src/version.h`, the project declaration in `CHANGELOG.m
 10. (Optional) If you want the raw MSVC build tree as a direct `.zip` asset on the Releases page too, the workflow can be extended (see the packaging step). For now the portable x64 zip is the primary end-user download.
 11. **Rebuild and publish the public WebAssembly demo** (critical after any C++ change or release):
     - Activate Emscripten: run the emsdk_env (see docs/building-occt.md).
-    - (Re)build OCCT wasm if needed: `.\scripts\build-occt-v8-wasm.ps1 -RootDir C:\bin\occt-wasm-build`
+    - (Re)build OCCT wasm if needed: `.\scripts\build-occt-793-wasm.ps1`
     - Configure + build (from repo root):
       ```powershell
-      # Use a dir like build-em (or clean it)
-      emcmake cmake -S . -B build-em -G Ninja -Wno-dev `
-        -DOpenCASCADE_DIR=C:\bin\occt-wasm-build\install\lib\cmake\opencascade `
+      emcmake cmake -S . -B build-em-7-9-3 -G Ninja -Wno-dev `
+        -DOpenCASCADE_DIR=$env:USERPROFILE\occt-wasm-build\V7_9_3\install\lib\cmake\opencascade `
         -DCMAKE_BUILD_TYPE=Release
-      ninja -C build-em
+      ninja -C build-em-7-9-3
       ```
     - This produces (in build-em/): `EzyCad.html`, `EzyCad.js`, `EzyCad.wasm`, `EzyCad.data`.
     - **Bump cache** (already done in this release prep for 0.2.0): edit `web/EzyCad.html` (var EZYCAD_WEB_CACHE) — the build-em/ copy will be updated on next full build.

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -37,3 +37,4 @@
 * Arc function needs to accept tab for radius. 
 * Dist tab dialog should state if it is a radius or diameter for arc.*
 * Dist tab dialog should state if it is a 1/2 dist or full, for edge tool.
+* **Wasm / OCCT 8.x GLES shading regression:** With OCCT **8.0.0.p1** (`V8_0_0_p1`) and `TKOpenGles`, new solids and extrude previews often render wireframe-only or with partial face shading in the browser. Native desktop (OCCT 8 + `TKOpenGl`) is unaffected. Rebuilding against **7.9.3** (`scripts/build-occt-793-wasm.ps1`) restores correct shading. Workarounds in EzyCad (`SetMaterial` + `Redisplay`, `refresh_shape_shading_`, bisect toggles in `occt_view_wasm_bisect.h`) do not fix the root cause on OCCT 8. Use 7.9.3 for wasm builds and demo publishing until upstream fixes GLES presentation.

--- a/docs/building-occt.md
+++ b/docs/building-occt.md
@@ -15,9 +15,7 @@ EzyCad does **not** vendor OCCT; builds live **outside** the tree. Point CMake a
 | Target | Documented / tested | CMake variables |
 | --- | --- | --- |
 | **Windows desktop** | OCCT **8.0.0** prebuilt | `OpenCASCADE_DIR`, `OCCT_3RD_PARTY_DIR` |
-| **WebAssembly** | OCCT **8.0.0** via `scripts/build-occt-v8-wasm.ps1` | `OpenCASCADE_DIR` only (static install) |
-
-After upgrading OCCT, retest **sketch dimensions**, **grid**, **fillet/chamfer/boolean**, and **STEP/STL** export. OCCT 8.0 changes grid rendering and many modeling paths.
+| **WebAssembly** | OCCT **7.9.3** (`V7_9_3`) recommended; **8.0.0.p1** (`V8_0_0_p1`) has regressions | `OpenCASCADE_DIR` only (static install) |
 
 ---
 
@@ -73,51 +71,51 @@ Prefer **prebuilt** packages unless you need a custom source build.
 
 EzyCad’s wasm target links **`TKOpenGles`** (not `TKOpenGl`), static OCCT, and **`-fexceptions`** (see `CMakeLists.txt` Emscripten block).
 
-### Automated: `scripts/build-occt-v8-wasm.ps1`
+### Automated wasm scripts
 
-Builds **FreeType 2.13.3** + **OCCT `V8_0_0`** static with GLES2 into a single install prefix.
+EzyCad links **`TKOpenGles`** (not `TKOpenGl`), static OCCT, and **`-fexceptions`** (see `CMakeLists.txt` Emscripten block).
+
+| Script | OCCT tag | Default tree root |
+| --- | --- | --- |
+| `scripts/build-occt-793-wasm.ps1` (`.cmd`) | **V7_9_3** (recommended) | `%USERPROFILE%\occt-wasm-build\V7_9_3` |
+| `scripts/build-occt-v8-wasm.ps1` (`.cmd`) | V8_0_0_p1 | `%USERPROFILE%\occt-wasm-build\V8_0_0_p1` |
+
+Both wrap the shared implementation `scripts/build-occt-wasm.ps1`. Each version gets its own `src/`, `build/`, and `install/` under the versioned root (flat layout).
 
 **Prerequisites:** Git, CMake 3.16+, [Emscripten emsdk](https://emscripten.org/docs/getting_started/downloads.html) 3.0+ with `emsdk_env` active (`emcc`, `emcmake`, `emmake` on `PATH`).
-
-**Layout created** (default `RootDir` = `%USERPROFILE%\occt-wasm-build`):
-
-```text
-occt-wasm-build/
-  src/OCCT/                    git clone V8_0_0
-  src/freetype-2.13.3/         from .tar.gz (not .tar.xz on Windows)
-  build/freetype/
-  build/occt/
-  install/                     CMAKE_INSTALL_PREFIX
-    lib/cmake/opencascade/     → OpenCASCADE_DIR
-    freetype/                  FreeType install (used at OCCT configure time)
-```
 
 **PowerShell (repo root, after `emsdk_env`):**
 
 ```powershell
-.\scripts\build-occt-v8-wasm.ps1 -RootDir C:\bin\occt-wasm-build
+# Recommended for wasm (7.9.3)
+.\scripts\build-occt-793-wasm.ps1
+
+# OCCT 8.0.0.p1 (for upstream regression testing)
+.\scripts\build-occt-v8-wasm.ps1
 ```
 
-Or use `scripts\build-occt-v8-wasm.cmd` if PowerShell script execution is restricted.
+Or use the matching `.cmd` wrappers if PowerShell script execution is restricted.
 
-**Script flags:** `-SkipDownload`, `-SkipFreeType`, `-SkipOcct`, `-ReconfigureOnly`, `-Jobs 8`, `-OcctTag V8_0_0`, `-BuildType Release`.
+**Script flags** (both wrappers): `-SkipDownload`, `-SkipFreeType`, `-SkipOcct`, `-ReconfigureOnly`, `-Jobs 8`, `-BuildType Release`, `-RootDir` (override versioned default).
 
-**Expect:** 1–3+ hours compile, large disk use. Success prints `OpenCASCADE_DIR=...`.
+**Advanced:** call `build-occt-wasm.ps1` directly with `-OcctTag` and optional `-VersionDir` (defaults to tag name under `-RootDir` for side-by-side trees under one parent).
 
-**Configure EzyCad wasm** (Ninja generator works well with OCCT V8):
+**Expect:** 1-3+ hours compile, large disk use. Success prints `OpenCASCADE_DIR=...`.
+
+**Configure EzyCad wasm** (match OCCT version in path and build dir):
 
 ```text
-mkdir build_em
-cd build_em
-emcmake cmake C:\src\EzyCad -Wno-dev -G Ninja -DOpenCASCADE_DIR=C:\src\occt-wasm-build\install\lib\cmake\opencascade -DCMAKE_BUILD_TYPE=Release
-ninja
+emcmake cmake C:\src\EzyCad -Wno-dev -G Ninja -B build-em-7-9-3 ^
+  -DOpenCASCADE_DIR=%USERPROFILE%\occt-wasm-build\V7_9_3\install\lib\cmake\opencascade ^
+  -DCMAKE_BUILD_TYPE=Release
+ninja -C build-em-7-9-3
 ```
 
 Serve: `python -m http.server 8000` from the build output directory (the `.html` + `.wasm` + `.data` files).
 
 ### OCCT wasm CMake flags (reference)
 
-Used by `build-occt-v8-wasm.ps1` — keep in sync if editing the script:
+Used by `build-occt-wasm.ps1` — keep in sync if editing the script:
 
 | Variable | Value | Why |
 | --- | --- | --- |
@@ -136,16 +134,17 @@ FreeType wasm configure also disables optional zlib/png/harfbuzz finds to simpli
 
 | Symptom | Fix |
 | --- | --- |
-| `running scripts is disabled` | `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned` **or** use `build-occt-v8-wasm.cmd` **or** `powershell -ExecutionPolicy Bypass -File ...` |
+| `running scripts is disabled` | `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned` **or** use `build-occt-793-wasm.cmd` / `build-occt-v8-wasm.cmd` **or** `powershell -ExecutionPolicy Bypass -File ...` |
 | `Can't initialize filter; xz` | Script uses `.tar.gz` for FreeType; delete stale `*.tar.xz` under `src/` and re-run |
 | `source directory .../build/freetype does not contain CMakeLists.txt` | Fixed: do not name a PowerShell function parameter `$Args` (shadows automatic `$Args`) |
 | `emcc` not found | Run `emsdk_env.bat` / `emsdk_env.ps1` in the same shell |
 | EzyCad configure hangs on `find_package(OpenCASCADE)` | `emcmake cmake ... --debug-output`; verify `OpenCASCADE_DIR` path |
 | OCCT 8 + ghosted dimension labels | Retest `gui.edge_dim_text_render_mode` (Z-layer Topmost); grid compositing changed in 8.0 |
+| Shaded faces missing / wireframe-only solids (wasm, OCCT 8.x) | Use **7.9.3** (`build-occt-793-wasm.ps1`); see [bugs.md](bugs.md). Bisect toggles in `src/occt_view_wasm_bisect.h` do not fix the OCCT 8 GLES regression |
 
 ---
 
-**Note:** Older OCCT builds (prior to 8.0) are no longer supported or documented. Use the V8 script above for WebAssembly.
+**Note:** Desktop builds remain on OCCT **8.0.0**. Wasm currently targets **7.9.3** until OCCT 8.x GLES shading is fixed upstream.
 
 ## Wrapper scripts and automation
 
@@ -153,11 +152,11 @@ When adding helper scripts under `scripts/`, follow existing repo conventions.
 
 ### Windows `.cmd` (ExecutionPolicy bypass)
 
-`scripts/build-occt-v8-wasm.cmd` wraps the PowerShell script (same pattern as `check-nonascii-src.cmd`):
+`scripts/build-occt-793-wasm.cmd` and `scripts/build-occt-v8-wasm.cmd` wrap the PowerShell scripts (same pattern as `check-nonascii-src.cmd`):
 
 ```bat
 @echo off
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0build-occt-v8-wasm.ps1" %*
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0build-occt-793-wasm.ps1" %*
 if errorlevel 1 exit /b 1
 ```
 
@@ -166,16 +165,16 @@ if errorlevel 1 exit /b 1
 ```bat
 call C:\src\emsdk\emsdk_env.bat
 cd /d C:\src\EzyCad
-scripts\build-occt-v8-wasm.cmd -RootDir C:\src\occt-wasm-build
+scripts\build-occt-793-wasm.cmd
 ```
 
 ### Unix `.sh`
 
-No first-party wasm shell script yet; a `scripts/build-occt-v8-wasm.sh` may mirror the PowerShell logic:
+No first-party wasm shell script yet; a `scripts/build-occt-wasm.sh` may mirror `build-occt-wasm.ps1`:
 
 - `set -euo pipefail`
 - Require `emcc`, `git`, `cmake`
-- `ROOT="${ROOT:-$HOME/occt-wasm-build}"`
+- `ROOT="${ROOT:-$HOME/occt-wasm-build/V7_9_3}"`
 - Download `freetype-$VER.tar.gz` (gzip portable; avoid `.tar.xz` if `xz` missing)
 - `emcmake cmake -S ... -B ...` with the same `-D` flags as the `.ps1`
 - `emmake cmake --build ... --target install -j"$(nproc)"`
@@ -186,7 +185,7 @@ Use forward slashes in cmake paths on Unix.
 ### PowerShell one-liner (no policy change)
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File C:\src\EzyCad\scripts\build-occt-v8-wasm.ps1 -RootDir C:\src\occt-wasm-build
+powershell -NoProfile -ExecutionPolicy Bypass -File C:\src\EzyCad\scripts\build-occt-793-wasm.ps1
 ```
 
 ### curl downloads (CI)
@@ -210,7 +209,9 @@ OCCT 8 supports vcpkg (`USE_VTK=ON` only if needed). EzyCad’s `CMakeLists.txt`
 | `README.md` | Pin version, download URLs, example `OpenCASCADE_DIR` |
 | `CMakeLists.txt` | `OCCT_3RD_PARTY_DIR` paths (freetype/tbb/ffmpeg versions in `DLLS_COMMON`) |
 | `.github/workflows/windows-msvc.yml` | Prebuilt download URL, cache key, `OpenCASCADE_DIR`/`OCCT_3RD_PARTY_DIR` in CI configure |
-| `scripts/build-occt-v8-wasm.ps1` | `$OcctTag`, `$FreeTypeVersion`, cmake flags |
+| `scripts/build-occt-wasm.ps1` | Shared wasm build; `$OcctTag`, `$FreeTypeVersion`, cmake flags |
+| `scripts/build-occt-793-wasm.ps1` | Wrapper defaulting to `V7_9_3` |
+| `scripts/build-occt-v8-wasm.ps1` | Wrapper defaulting to `V8_0_0_p1` |
 | `docs/building-occt.md` | This document |
 | `src/ply_io.cpp` | Comments if triangulation API changes |
 

--- a/python
+++ b/python
@@ -1,0 +1,123 @@
+# EzyCad
+
+[![GitHub](https://img.shields.io/github/stars/trailcode/EzyCad?style=social)](https://github.com/trailcode/EzyCad)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/trailcode/EzyCad)](https://github.com/trailcode/EzyCad/releases/latest)
+[![Documentation](https://img.shields.io/badge/docs-readthedocs-blue)](https://ezycad.readthedocs.io/en/latest/usage.html)
+[![WebAssembly](https://img.shields.io/badge/run%20in%20browser-wasm-green)](https://trailcode.github.io/EzyCad/EzyCad.html)
+
+**Repository:** [https://github.com/trailcode/EzyCad](https://github.com/trailcode/EzyCad)
+
+![EzyCad splash screen](docs/images/AI-gen-splashscreen_05_01_2026_512.png)
+
+EzyCad (Easy CAD) is an open-source CAD application for hobbyist machinists to design and edit 2D and 3D models for machining projects. It supports creating precise parts with tools for sketching, extruding, and applying geometric operations, using OpenGL, Dear ImGui, and Open CASCADE Technology (OCCT). Export models to formats like STEP or STL for CNC machines or 3D printers, or [run EzyCad in your browser (WebAssembly)](https://trailcode.github.io/EzyCad/EzyCad.html). Project home: [trailcode.github.io/EzyCad](https://trailcode.github.io/EzyCad/).
+
+> **Not EZCAD laser software:** [EzyCad](https://github.com/trailcode/EzyCad) (with a **y**) is hobbyist mechanical CAD built on OCCT — unrelated to EZCAD2/EZCAD3 laser marking products.
+
+## Downloads
+
+Prebuilt **Windows** binaries (portable .zip containing `EzyCad.exe` + all required DLLs and assets) are published on the [GitHub Releases page](https://github.com/trailcode/EzyCad/releases).
+
+- Go to [Releases](https://github.com/trailcode/EzyCad/releases) → expand "Assets" under the latest version.
+- Download `EzyCad-vX.Y.Z-windows-x64.zip` (or the equivalent name), unzip, and run `EzyCad.exe`.
+- No installer is required; the zip is self-contained.
+
+**WebAssembly (browser) version:** [Run EzyCad directly in your browser](https://trailcode.github.io/EzyCad/EzyCad.html) (no download needed).
+
+For source builds or other platforms, see the [Building Instructions](#building-instructions) below.
+
+## Features
+- 2D and 3D modeling capabilities.
+- Integration with Open CASCADE for geometric operations.
+- Cross-platform support with Emscripten for WebAssembly builds.
+- Interactive GUI built with ImGui.
+
+## Usage Guide
+**Online:** [ezycad.readthedocs.io](https://ezycad.readthedocs.io/en/latest/usage.html) (built from this repo on [Read the Docs](https://readthedocs.org/)).
+
+**Source:** [usage.md](docs/usage.md) and related guides in `docs/` (`usage-sketch.md`, `usage-settings.md`, `usage-occt-view.md`, etc.). They cover the user interface, modeling tools, keyboard shortcuts, and view controls.
+
+## Changelog
+Release history is in [CHANGELOG.md](CHANGELOG.md) (repository root). The user guides now live in the `docs/` folder (together with `building-occt.md`, style guides, etc.). With the CMake Visual Studio generator, documentation files appear under a `docs` folder (and the two root docs at project root) on the EzyCad / EzyCad_lib targets in Solution Explorer.
+
+## Building Instructions
+
+### Prerequisites
+Ensure the following dependencies are installed:
+- CMake (minimum version 3.14.0)
+- Nuget command line utility
+- A C++ 20 compatible compiler (e.g., MSVC, GCC, or Clang)
+- OpenGL development libraries
+- Open CASCADE Technology (OCCT 8.0.0) https://github.com/Open-Cascade-SAS/OCCT
+
+### OCCT Build
+
+Full guide: **[docs/building-occt.md](docs/building-occt.md)** (Windows prebuilts, wasm/Emscripten, troubleshooting).
+
+#### For VS2022 (summary)
+- See: https://dev.opencascade.org/doc/overview/html/build_upgrade__building_occt.html
+- OCCT 3rd-party binaries: https://github.com/Open-Cascade-SAS/OCCT/releases/download/V8_0_0/3rdparty-vc14-64.zip
+- Currently building EzyCad has only been tested with the Release build of OCCT.
+- Or download pre-built binaries: https://github.com/Open-Cascade-SAS/OCCT/releases/tag/V8_0_0
+
+### Steps to Build
+1. Clone the repository.
+2. Create a build directory, e.g., `C:\src\EzyCad_build`.
+3. Configure the project in the build directory using CMake:
+   - E.g., `cmake C:\src\EzyCad -DOpenCASCADE_DIR=C:\bin\OCCT-8_0_0_install\cmake -DOCCT_3RD_PARTY_DIR=C:\bin\3rdparty-vc14-64`
+   - `OCCT_3RD_PARTY_DIR` should point to the OCCT 3rd-party distribution.
+   - CMake will use `nuget` to download additional dependencies.
+4. Build the project.
+
+### Notes for Windows Users
+- Ensure `nuget` is installed for fetching dependencies like GLFW and GLEW.
+- Use Visual Studio as the IDE for debugging and building.
+
+### Notes for Emscripten Builds
+- Install Emscripten and activate its environment (`emsdk_env`).
+- **OCCT 7.9.3 for wasm (recommended):** `scripts\build-occt-793-wasm.ps1` (or `.cmd`) after `emsdk_env` — see [docs/building-occt.md](docs/building-occt.md#webassembly-emscripten). OCCT 8.x has a GLES shading regression on wasm (see [docs/bugs.md](docs/bugs.md)).
+- **OCCT 8.0.0.p1 for wasm:** `scripts\build-occt-v8-wasm.ps1` for regression testing against upstream.
+- Configure the EzyCad project with Emscripten (Ninja recommended):
+  - `emcmake cmake -S . -B build-em-7-9-3 -Wno-dev -G Ninja -DOpenCASCADE_DIR=C:/Users/you/occt-wasm-build/V7_9_3/install/lib/cmake/opencascade -DCMAKE_BUILD_TYPE=Release`
+  - Add **-Wno-dev** to suppress any remaining CMake developer warnings.
+  - If configure **freezes** after that warning, the hang is often in `find_package(OpenCASCADE)` or Emscripten compiler detection. Run with `--debug-output` to see where it stops.
+  - Build:
+    - `ninja -C build-em-7-9-3` (or `emmake cmake --build . --config Release`)
+- Build the project.
+- Serve the WebAssembly: `python.exe -m http.server 8000` from the build output directory (look for `EzyCad.html` + `EzyCad.wasm` + `EzyCad.data`).
+- Or build and serve: `ninja && python.exe -m http.server 8000`
+- **GitHub Pages HTML:** After changing `web/index.html` or `web/EzyCad.html`, sync to [trailcode.github.io](https://github.com/trailcode/trailcode.github.io) with `scripts/sync-github-pages-html.ps1` (see script header).
+- Dear ImGui under `third_party/imgui/` carries EzyCad-specific changes (font rendering); see [In-tree third-party libraries](#in-tree-third-party-libraries) at the end of this README.
+
+### Artwork
+- Icons from: https://wiki.freecad.org/Artwork
+
+## Support and Contributions
+- **Project home:** [trailcode.github.io/EzyCad](https://trailcode.github.io/EzyCad/)
+- Report issues or suggest features on the [GitHub repository](https://github.com/trailcode/EzyCad).
+- Contribute by developing features and fixing bugs. Pull requests are welcome!
+- Additional resources, including video tutorials and online documentation, are linked in [usage.md](docs/usage.md).
+- Outreach draft posts (forums, Reddit, awesome lists): [agents/discoverability-outreach.md](agents/discoverability-outreach.md).
+
+### We need development help
+EzyCad is maintained by a small team and we would love more contributors. If you can help with features, bug fixes, documentation, or testing - please jump in. Every contribution helps move the project forward.
+
+**Style guides:** [ezycad_code_style.md](docs/ezycad_code_style.md) for C++ in `src/`; [ezycad_doc_style.md](docs/ezycad_doc_style.md) for user guides and [Read the Docs](https://ezycad.readthedocs.io/). Both human developers and AI coding agents should follow the relevant guide.
+
+**AI / agent instructions:** Short repo-local notes for coding assistants live under [agents/](agents/). Root-level discovery markers are `AGENTS.md` and `agents.md`. See [agents/README.md](agents/README.md) for the index (including local dev commands in `agents/dev.md`).
+
+## In-tree third-party libraries
+
+**Open CASCADE (OCCT) is not vendored here.** You build or install OCCT (and its binary redistributables) **outside** this tree and pass `OpenCASCADE_DIR` / `OCCT_3RD_PARTY_DIR` into CMake, as in [Building Instructions](#building-instructions) above.
+
+The **`third_party/`** folder holds other libraries **shipped inside the EzyCad repository** (typically committed as a vendored snapshot, not fetched by CMake except where noted):
+
+| Component | Location | Role |
+| --- | --- | --- |
+| **Dear ImGui** | `third_party/imgui/` | Immediate-mode UI used by the application. This tree includes **project-specific changes** for font rendering; see [imgui#7519 (comment)](https://github.com/ocornut/imgui/issues/7519#issuecomment-2629628233). |
+| **nlohmann/json** | `third_party/json/` (headers under `include/`) | JSON used by the project; CMake adds `third_party/json/include`. |
+| **tinyfiledialogs** | `third_party/tinyfiledialogs/` | Small C helper for native file dialogs on desktop. |
+| **ImGuiColorTextEdit** | `third_party/ImGuiColorTextEdit/` | Syntax-highlighted editor widget for the **Lua** and **Python** script consoles ([upstream](https://github.com/BalazsJako/ImGuiColorTextEdit)). |
+
+**ImGuiColorTextEdit:** Prefer a full checkout under `third_party/ImGuiColorTextEdit/` (see `third_party/README.md`). If that folder is missing, CMake **FetchContent** downloads upstream at a **fixed commit** (`ca2f9f1462e3b60e56351bc466acda448c5ea50d`) because the upstream repo has **no release tags**. To upgrade the editor, bump that SHA in `CMakeLists.txt` and refresh any vendored copy.
+
+**Windows note:** GLFW and GLEW for MSVC are **not** stored under `third_party/`; NuGet installs them into **`${CMAKE_BINARY_DIR}/thirdParty`** when you configure (see [Notes for Windows Users](#notes-for-windows-users)).

--- a/scripts/build-occt-793-wasm.cmd
+++ b/scripts/build-occt-793-wasm.cmd
@@ -1,0 +1,5 @@
+@echo off
+REM Build OCCT V7_9_3 for WebAssembly (see docs/building-occt.md).
+REM Activate Emscripten first, e.g. call C:\src\emsdk\emsdk_env.bat
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0build-occt-793-wasm.ps1" %*
+if errorlevel 1 exit /b 1

--- a/scripts/build-occt-793-wasm.ps1
+++ b/scripts/build-occt-793-wasm.ps1
@@ -1,14 +1,15 @@
-# Build OCCT V8_0_0_p1 (8.0.0.p1) for WebAssembly.
+# Build OCCT V7_9_3 (7.9.3) for WebAssembly.
+# Recommended for EzyCad wasm until OCCT 8.x GLES shading regressions are resolved.
 # Wrapper around scripts/build-occt-wasm.ps1 with versioned default paths.
 #
 # Usage (from repo root, after emsdk_env):
-#   .\scripts\build-occt-v8-wasm.ps1
-#   .\scripts\build-occt-v8-wasm.ps1 -RootDir C:\bin\occt-wasm-build\V8_0_0_p1
+#   .\scripts\build-occt-793-wasm.ps1
+#   .\scripts\build-occt-793-wasm.ps1 -RootDir C:\bin\occt-wasm-build\V7_9_3
 
 #Requires -Version 5.1
 [CmdletBinding()]
 param(
-    [string] $RootDir = (Join-Path $env:USERPROFILE "occt-wasm-build\V8_0_0_p1"),
+    [string] $RootDir = (Join-Path $env:USERPROFILE "occt-wasm-build\V7_9_3"),
     [string] $FreeTypeVersion = "2.13.3",
     [ValidateSet("Release", "Debug", "RelWithDebInfo")]
     [string] $BuildType = "Release",
@@ -22,7 +23,7 @@ param(
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 & "$scriptDir\build-occt-wasm.ps1" `
     -RootDir $RootDir `
-    -OcctTag "V8_0_0_p1" `
+    -OcctTag "V7_9_3" `
     -VersionDir "." `
     -FreeTypeVersion $FreeTypeVersion `
     -BuildType $BuildType `

--- a/scripts/build-occt-v8-wasm.cmd
+++ b/scripts/build-occt-v8-wasm.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM Build OCCT V8.0.0 for WebAssembly (see docs/building-occt.md).
+REM Build OCCT V8_0_0_p1 for WebAssembly (see docs/building-occt.md).
 REM Activate Emscripten first, e.g. call C:\src\emsdk\emsdk_env.bat
 powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0build-occt-v8-wasm.ps1" %*
 if errorlevel 1 exit /b 1

--- a/scripts/build-occt-wasm.ps1
+++ b/scripts/build-occt-wasm.ps1
@@ -1,0 +1,234 @@
+# Download and build Open CASCADE Technology (OCCT) for WebAssembly (Emscripten).
+#
+# Builds FreeType static libs, then OCCT static libs with GLES2 (TKOpenGles) for EzyCad's wasm target.
+#
+# Prerequisites: Git, CMake 3.16+, Emscripten SDK on PATH (run emsdk_env first).
+#
+# Prefer the version-specific wrappers:
+#   .\scripts\build-occt-793-wasm.ps1
+#   .\scripts\build-occt-v8-wasm.ps1
+#
+# Install layout (default VersionDir = OcctTag under RootDir):
+#   <RootDir>\<VersionDir>\install\lib\cmake\opencascade  -> OpenCASCADE_DIR
+#
+# Flat layout (VersionDir = "."): src/build/install directly under RootDir.
+# Version wrappers default RootDir to %USERPROFILE%\occt-wasm-build\<OcctTag>.
+
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [string] $RootDir = (Join-Path $env:USERPROFILE "occt-wasm-build"),
+    [Parameter(Mandatory = $true)]
+    [string] $OcctTag,
+    # Subdirectory under RootDir for src/build/install. Default: OcctTag. Use "." for flat layout.
+    [string] $VersionDir = "",
+    [string] $FreeTypeVersion = "2.13.3",
+    [ValidateSet("Release", "Debug", "RelWithDebInfo")]
+    [string] $BuildType = "Release",
+    [int] $Jobs = 0,
+    [switch] $SkipDownload,
+    [switch] $SkipFreeType,
+    [switch] $SkipOcct,
+    [switch] $ReconfigureOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Require-Command([string]$Name) {
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command not found on PATH: $Name (is emsdk_env active?)"
+    }
+}
+
+function Invoke-EmCMake {
+    param([string[]]$CmakeArguments)
+    & emcmake cmake @CmakeArguments
+    if ($LASTEXITCODE -ne 0) { throw "emcmake cmake failed (exit $LASTEXITCODE)" }
+}
+
+function Invoke-EmInstall {
+    param([string]$BuildDir, [int]$Parallel)
+    Push-Location $BuildDir
+    try {
+        if ($Parallel -gt 0) {
+            & emmake cmake --build . --target install --parallel $Parallel
+        }
+        else {
+            & emmake cmake --build . --target install
+        }
+        if ($LASTEXITCODE -ne 0) { throw "install failed (exit $LASTEXITCODE)" }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+Require-Command git
+Require-Command cmake
+Require-Command emcc
+Require-Command emcmake
+Require-Command emmake
+
+if ($Jobs -le 0) {
+    $Jobs = [Environment]::ProcessorCount
+    if ($Jobs -lt 2) { $Jobs = 2 }
+}
+
+if ([string]::IsNullOrWhiteSpace($VersionDir)) {
+    $VersionDir = $OcctTag
+}
+
+$RootDir = [System.IO.Path]::GetFullPath($RootDir)
+if ($VersionDir -eq ".") {
+    $VersionRoot = $RootDir
+}
+else {
+    $VersionRoot = Join-Path $RootDir $VersionDir
+}
+$SrcDir = Join-Path $VersionRoot "src"
+$BuildDir = Join-Path $VersionRoot "build"
+$InstallDir = Join-Path $VersionRoot "install"
+$OcctSrc = Join-Path $SrcDir "OCCT"
+$FtSrc = Join-Path $SrcDir "freetype-$FreeTypeVersion"
+$FtBuild = Join-Path $BuildDir "freetype"
+$FtInstall = Join-Path $InstallDir "freetype"
+$OcctBuild = Join-Path $BuildDir "occt"
+$OcctInstall = $InstallDir
+
+$ExceptionFlags = "-fexceptions"
+
+Write-Host "=== OCCT $OcctTag WebAssembly build ===" -ForegroundColor Cyan
+Write-Host "Root:       $RootDir"
+Write-Host "VersionDir: $VersionDir"
+Write-Host "Tree:       $VersionRoot"
+Write-Host "Install:    $OcctInstall"
+Write-Host "Jobs:       $Jobs"
+Write-Host "Type:       $BuildType"
+Write-Host ""
+
+New-Item -ItemType Directory -Force -Path $SrcDir, $BuildDir, $InstallDir | Out-Null
+
+# --- FreeType ---
+if (-not $SkipFreeType) {
+    if (-not $SkipDownload -and -not (Test-Path $FtSrc)) {
+        Write-Host ">>> Download FreeType $FreeTypeVersion" -ForegroundColor Yellow
+        # Use .tar.gz: Windows built-in tar cannot extract .tar.xz without a separate xz tool.
+        $ftArchive = Join-Path $SrcDir "freetype-$FreeTypeVersion.tar.gz"
+        $ftUrl = "https://download.savannah.gnu.org/releases/freetype/freetype-$FreeTypeVersion.tar.gz"
+        Invoke-WebRequest -Uri $ftUrl -OutFile $ftArchive
+        & tar -xzf $ftArchive -C $SrcDir
+        if (-not (Test-Path $FtSrc)) { throw "FreeType extract failed: $FtSrc" }
+    }
+
+    if (-not $ReconfigureOnly -or -not (Test-Path (Join-Path $FtBuild "CMakeCache.txt"))) {
+        Write-Host ">>> Configure FreeType (wasm)" -ForegroundColor Yellow
+        New-Item -ItemType Directory -Force -Path $FtBuild | Out-Null
+        Invoke-EmCMake -CmakeArguments @(
+            "-S", $FtSrc,
+            "-B", $FtBuild,
+            "-DCMAKE_BUILD_TYPE=$BuildType",
+            "-DCMAKE_INSTALL_PREFIX=$FtInstall",
+            "-DCMAKE_CXX_FLAGS=$ExceptionFlags",
+            "-DCMAKE_C_FLAGS=$ExceptionFlags",
+            "-DCMAKE_EXE_LINKER_FLAGS=$ExceptionFlags",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DCMAKE_DISABLE_FIND_PACKAGE_ZLIB=ON",
+            "-DCMAKE_DISABLE_FIND_PACKAGE_BZip2=ON",
+            "-DCMAKE_DISABLE_FIND_PACKAGE_PNG=ON",
+            "-DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=ON",
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        )
+    }
+
+    Write-Host ">>> Build & install FreeType" -ForegroundColor Yellow
+    Invoke-EmInstall -BuildDir $FtBuild -Parallel $Jobs
+}
+
+$FreeTypeDir = Join-Path $FtInstall "lib\cmake\freetype"
+if (-not (Test-Path $FreeTypeDir)) {
+    throw "FreeType CMake package not found: $FreeTypeDir"
+}
+
+# --- OCCT source ---
+if (-not $SkipDownload) {
+    if (-not (Test-Path $OcctSrc)) {
+        Write-Host ">>> Clone OCCT ($OcctTag)" -ForegroundColor Yellow
+        & git clone --depth 1 --branch $OcctTag `
+            https://github.com/Open-Cascade-SAS/OCCT.git $OcctSrc
+        if ($LASTEXITCODE -ne 0) { throw "git clone failed" }
+    }
+    else {
+        Write-Host ">>> OCCT source exists; checkout $OcctTag" -ForegroundColor Yellow
+        Push-Location $OcctSrc
+        try {
+            & git fetch --depth 1 origin tag $OcctTag
+            if ($LASTEXITCODE -ne 0) { throw "git fetch failed" }
+            & git checkout $OcctTag
+            if ($LASTEXITCODE -ne 0) { throw "git checkout failed" }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+}
+elseif (-not (Test-Path $OcctSrc)) {
+    throw "OCCT source missing: $OcctSrc (omit -SkipDownload)"
+}
+
+# --- OCCT build ---
+if (-not $SkipOcct) {
+    if (-not $ReconfigureOnly -or -not (Test-Path (Join-Path $OcctBuild "CMakeCache.txt"))) {
+        Write-Host ">>> Configure OCCT (wasm static + GLES2)" -ForegroundColor Yellow
+        New-Item -ItemType Directory -Force -Path $OcctBuild | Out-Null
+
+        # EzyCad links TKOpenGles, not TKOpenGl.
+        $OcctCmakeArgs = @(
+            "-S", $OcctSrc,
+            "-B", $OcctBuild,
+            "-DCMAKE_BUILD_TYPE=$BuildType",
+            "-DCMAKE_INSTALL_PREFIX=$OcctInstall",
+            "-DBUILD_LIBRARY_TYPE=Static",
+            "-DBUILD_MODULE_Draw=OFF",
+            "-DBUILD_SAMPLES=OFF",
+            "-DBUILD_DOC_Overview=OFF",
+            "-DUSE_OPENGL=OFF",
+            "-DUSE_GLES2=ON",
+            "-DUSE_FREETYPE=ON",
+            "-DUSE_TBB=OFF",
+            "-DUSE_FFMPEG=OFF",
+            "-DUSE_FREEIMAGE=OFF",
+            "-DUSE_OPENVR=OFF",
+            "-DUSE_TK=OFF",
+            "-Dfreetype_DIR=$FreeTypeDir",
+            "-DCMAKE_CXX_FLAGS=$ExceptionFlags",
+            "-DCMAKE_C_FLAGS=$ExceptionFlags",
+            "-DCMAKE_EXE_LINKER_FLAGS=$ExceptionFlags",
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        )
+        # USE_VTK option exists from OCCT 7.x; default OFF in 8.0.
+        $OcctCmakeArgs += "-DUSE_VTK=OFF"
+        Invoke-EmCMake -CmakeArguments $OcctCmakeArgs
+    }
+
+    Write-Host ">>> Build & install OCCT (may take 1-3+ hours)" -ForegroundColor Yellow
+    Invoke-EmInstall -BuildDir $OcctBuild -Parallel $Jobs
+}
+
+$OcctConfig = Join-Path $OcctInstall "lib\cmake\opencascade\OpenCASCADEConfig.cmake"
+if (-not (Test-Path $OcctConfig)) {
+    throw "OCCT install incomplete; missing: $OcctConfig"
+}
+
+$OpenCascadeDir = Join-Path $OcctInstall "lib\cmake\opencascade"
+$tagSuffix = ($OcctTag -replace '^V', '' -replace '_', '-').ToLower()
+$EzyCadBuildDir = "build-em-$tagSuffix"
+Write-Host ""
+Write-Host "=== Done ===" -ForegroundColor Green
+Write-Host "OcctTag=$OcctTag"
+Write-Host "VersionDir=$VersionDir"
+Write-Host "OpenCASCADE_DIR=$OpenCascadeDir"
+Write-Host ""
+Write-Host "EzyCad wasm configure example:"
+Write-Host "  emcmake cmake $((Split-Path -Parent $PSScriptRoot)) -Wno-dev -G Ninja -B $EzyCadBuildDir -DOpenCASCADE_DIR=$OpenCascadeDir -DCMAKE_BUILD_TYPE=Release"
+Write-Host "  ninja -C $EzyCadBuildDir"

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -17,10 +17,9 @@
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
-#else
+#endif
 
 #include "third_party/tinyfiledialogs/tinyfiledialogs.h"
-#endif
 
 #include "utl_geom.h"
 #include "imgui.h"
@@ -32,6 +31,8 @@
 #include "sketch.h"
 #include "utl.h"
 #include "version.h"
+
+#include <Standard_Version.hxx>
 
 // Must be here to prevent compiler warning
 #include <GLFW/glfw3.h>
@@ -660,6 +661,22 @@ void GUI::ensure_about_assets_()
     m_about_markdown = "Could not load res/about.md.\n";
   else
     m_about_markdown = std::string("**EzyCad ") + EZYCAD_VERSION_STRING + "**\n\n" + m_about_markdown;
+
+  m_about_markdown += "\n\nOpen CASCADE ";
+  m_about_markdown += OCC_VERSION_STRING_EXT;
+  m_about_markdown += "\nDear ImGui ";
+  m_about_markdown += IMGUI_VERSION;
+  m_about_markdown += "\nnlohmann/json ";
+  m_about_markdown += std::to_string(NLOHMANN_JSON_VERSION_MAJOR);
+  m_about_markdown += '.';
+  m_about_markdown += std::to_string(NLOHMANN_JSON_VERSION_MINOR);
+  m_about_markdown += '.';
+  m_about_markdown += std::to_string(NLOHMANN_JSON_VERSION_PATCH);
+  m_about_markdown += "\ntinyfiledialogs ";
+  m_about_markdown += tinyfd_version;
+  m_about_markdown += "\nImGuiColorTextEdit ";
+  m_about_markdown += EZYCAD_IMGUI_COLOR_TEXT_EDIT_REF;
+  m_about_markdown += "\n";
 
   const char* png_paths[] = {
 #ifdef __EMSCRIPTEN__

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2137,6 +2137,7 @@ void GUI::shape_list_()
         return;
 
       shape->SetMaterial(Graphic3d_MaterialAspect(static_cast<Graphic3d_NameOfMaterial>(i)));
+      m_view->refresh_shape_shading_(shape);
       m_view->ctx().Redisplay(shape, true);
       m_view->ctx().UpdateCurrentViewer();
     };

--- a/src/occt_view.cpp
+++ b/src/occt_view.cpp
@@ -23,6 +23,9 @@
 #include <Precision.hxx>
 #include <Prs3d_DatumAspect.hxx>
 #include <Prs3d_Drawer.hxx>
+#include <Prs3d_ShadingAspect.hxx>
+#include <Graphic3d_AspectFillArea3d.hxx>
+#include <Standard_Version.hxx>
 #include <Prs3d_LineAspect.hxx>
 #include <PrsDim_LengthDimension.hxx>
 #include <STEPControl_Reader.hxx>
@@ -63,6 +66,7 @@
 #include <Font_NameOfFont.hxx>
 #include <TCollection_AsciiString.hxx>
 #include <Wasm_Window.hxx>
+#include "occt_view_wasm_bisect.h"
 #endif
 
 #include <GLFW/glfw3.h>
@@ -155,7 +159,11 @@ void Occt_view::init_viewer()
   Handle(Aspect_DisplayConnection) aDisp;
   Handle(OpenGl_GraphicDriver) aDriver        = new OpenGl_GraphicDriver(aDisp, false);
   aDriver->ChangeOptions().buffersNoSwap      = true; // swap has no effect in WebGL
+#if defined(WASM_BISECT_DISABLE_OPAQUE_ALPHA)
+  aDriver->ChangeOptions().buffersOpaqueAlpha = false;
+#else
   aDriver->ChangeOptions().buffersOpaqueAlpha = true; // avoid unexpected blending of canvas with page background
+#endif
   // Match native OpenGL path (sRGBDisable) so shading/material gamma is consistent vs desktop.
   aDriver->ChangeOptions().sRGBDisable = true;
   if (!aDriver->InitContext())
@@ -169,6 +177,7 @@ void Occt_view::init_viewer()
   aViewer->SetDefaultShadingModel(Graphic3d_TypeOfShadingModel_Phong);
   aViewer->SetDefaultLights();
   aViewer->SetLightOn();
+#ifndef WASM_BISECT_DISABLE_LIGHT_CAST_SHADOWS
   for (NCollection_List<Handle(Graphic3d_CLight)>::Iterator aLightIter(aViewer->ActiveLights()); aLightIter.More();
        aLightIter.Next())
   {
@@ -176,6 +185,7 @@ void Occt_view::init_viewer()
     if (aLight->Type() == Graphic3d_TypeOfLightSource_Directional)
       aLight->SetCastShadows(true);
   }
+#endif
 
   Handle(Wasm_Window) aWindow = new Wasm_Window("#canvas");
 
@@ -207,15 +217,38 @@ void Occt_view::init_viewer()
 #endif
 
   m_view->SetImmediateUpdate(false);
-  auto& params                 = m_view->ChangeRenderingParams();
+  auto& params = m_view->ChangeRenderingParams();
   params.ToShowStats           = true;
-  params.NbMsaaSamples         = 8;                             // Set MSAA samples
-  params.RenderResolutionScale = 2.0;                           // Increase resolution scale
-  params.IsShadowEnabled       = true;                          // Enable shadows
-  params.ShadowMapResolution   = 1024;                          // Shadow map resolution
-  params.TransparencyMethod    = Graphic3d_RTM_BLEND_UNORDERED; // Better transparency
-  params.OitDepthFactor        = 0.0;                           // Depth peeling for better transparency
+  params.ShadowMapResolution   = 1024;
+  params.OitDepthFactor        = 0.0;
   params.Resolution            = (unsigned int)(96.0 * myDevicePixelRatio + 0.5);
+#ifdef __EMSCRIPTEN__
+#if defined(WASM_BISECT_DISABLE_MSAA)
+  params.NbMsaaSamples = 0;
+#else
+  params.NbMsaaSamples = 8;
+#endif
+#if defined(WASM_BISECT_DISABLE_RESOLUTION_SCALE)
+  params.RenderResolutionScale = 1.0;
+#else
+  params.RenderResolutionScale = 2.0;
+#endif
+#if defined(WASM_BISECT_DISABLE_VIEW_SHADOWS)
+  params.IsShadowEnabled = false;
+#else
+  params.IsShadowEnabled = true;
+#endif
+#if defined(WASM_BISECT_DEPTH_PEELING_OIT)
+  params.TransparencyMethod = Graphic3d_RTM_DEPTH_PEELING_OIT;
+#else
+  params.TransparencyMethod = Graphic3d_RTM_BLEND_UNORDERED;
+#endif
+#else
+  params.NbMsaaSamples         = 8;
+  params.RenderResolutionScale = 2.0;
+  params.IsShadowEnabled       = true;
+  params.TransparencyMethod    = Graphic3d_RTM_BLEND_UNORDERED;
+#endif
 
   // m_view->SetScale(1000.0); // Treat coordinates as millimeters
   // m_view->SetScale(39.3701);
@@ -874,10 +907,41 @@ std::optional<gp_Pnt> Occt_view::get_hit_point_(const AIS_Shape_ptr& shp, const 
   return std::nullopt;
 }
 
+void Occt_view::refresh_shape_shading_(const Shp_ptr& shp)
+{
+  if (shp.IsNull())
+    return;
+
+#ifdef __EMSCRIPTEN__
+  // OCCT 8 GLES: Phong needs explicit color; UNLIT fallback was removed in 8.0.
+  shp->SetColor(Quantity_Color(0.78, 0.78, 0.80, Quantity_TOC_RGB));
+
+  const Handle(Prs3d_Drawer)& drawer = shp->Attributes();
+  if (!drawer.IsNull())
+  {
+    drawer->SetFaceBoundaryDraw(false);
+    const Handle(Prs3d_ShadingAspect)& shading = drawer->ShadingAspect();
+    if (!shading.IsNull())
+    {
+      const Handle(Graphic3d_AspectFillArea3d)& aspect = shading->Aspect();
+      if (!aspect.IsNull())
+      {
+#if OCC_VERSION_HEX >= 0x080000
+        aspect->SetUseVertexColorForBackFaces(false);
+#endif
+      }
+    }
+  }
+#endif
+}
+
 void Occt_view::add_shp_(Shp_ptr& shp)
 {
   shp->SetMaterial(m_default_material);
-  shp->set_selection_mode(m_shp_selection_mode); // Adds to m_ctx
+  refresh_shape_shading_(shp);
+  shp->set_selection_mode(m_shp_selection_mode);
+  m_ctx->Redisplay(shp, true);
+  m_ctx->UpdateCurrentViewer();
   m_shps.push_back(shp);
 }
 
@@ -2140,8 +2204,10 @@ void Occt_view::load(const std::string& json_str, bool restore_view)
     if (mat_idx < 0 || mat_idx >= nmat)
       mat_idx = static_cast<int>(m_default_material.Name());
     shp->SetMaterial(Graphic3d_MaterialAspect(static_cast<Graphic3d_NameOfMaterial>(mat_idx)));
+    refresh_shape_shading_(shp);
     m_shps.push_back(shp);
     m_ctx->Display(shp, shp->get_disp_mode(), 0, true);
+    m_ctx->Redisplay(shp, true);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -246,6 +246,8 @@ public:
   // Material related
   const Graphic3d_MaterialAspect& get_default_material() const;
   void                            set_default_material(const Graphic3d_MaterialAspect& mat);
+  /// Apply default material/color and wasm GLES presentation fixes; call before Redisplay.
+  void refresh_shape_shading_(const Shp_ptr& shp);
 
   // View presentation (background gradient) and grid colors (0-1 RGB)
   void get_bg_gradient_colors(float color1[3], float color2[3]) const;

--- a/src/occt_view_wasm_bisect.h
+++ b/src/occt_view_wasm_bisect.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// WASM / TKOpenGles bisection toggles (Emscripten only). All OFF by default.
+//
+// To isolate OCCT 8 wasm shading bugs: uncomment ONE line below, rebuild build-em, retest.
+//
+//   DISABLE_VIEW_SHADOWS       - RenderingParams.IsShadowEnabled=false
+//   DISABLE_LIGHT_CAST_SHADOWS - skip SetCastShadows on directional lights
+//   DISABLE_MSAA               - NbMsaaSamples=0
+//   DISABLE_RESOLUTION_SCALE   - RenderResolutionScale=1.0 (default wasm uses 2.0)
+//   DEPTH_PEELING_OIT          - TransparencyMethod depth peeling instead of BLEND_UNORDERED
+//   DISABLE_OPAQUE_ALPHA       - OpenGl_GraphicDriver buffersOpaqueAlpha=false
+
+#ifdef __EMSCRIPTEN__
+
+// #define WASM_BISECT_DISABLE_VIEW_SHADOWS
+// #define WASM_BISECT_DISABLE_LIGHT_CAST_SHADOWS
+// #define WASM_BISECT_DISABLE_MSAA
+// #define WASM_BISECT_DISABLE_RESOLUTION_SCALE
+// #define WASM_BISECT_DEPTH_PEELING_OIT
+// #define WASM_BISECT_DISABLE_OPAQUE_ALPHA
+
+#endif

--- a/src/shp_chamfer.cpp
+++ b/src/shp_chamfer.cpp
@@ -101,7 +101,7 @@ Status Shp_chamfer::add_chamfer(const ScreenCoords& screen_coords, const Chamfer
   }
   catch (const Standard_Failure& e)
   {
-    const char* msg     = e.what();
+    const char* msg     = e.GetMessageString();
     std::string err_str = msg ? msg : "Unknown OCCT error";
     DBG_MSG(err_str);
     return Status::user_error(err_str);

--- a/src/shp_extrude.cpp
+++ b/src/shp_extrude.cpp
@@ -5,6 +5,7 @@
 #include <Precision.hxx>
 #include <TopoDS.hxx>
 #include <V3d_View.hxx>
+#include <V3d_View.hxx>
 
 #include "utl_dbg.h"
 #include "utl_geom.h"
@@ -167,17 +168,18 @@ void Shp_extrude::update_extrude_preview_(const double extrude_dist, const Plane
   }
 
   TopoDS_Shape body = BRepPrimAPI_MakePrism(face, extrude_vec);
-  if (!m_extruded)
+  if (m_extruded.IsNull())
   {
     m_extruded = new Shp(ctx(), body);
-    m_extruded->SetMaterial(view().get_default_material());
-    ctx().Display(m_extruded, m_extruded->get_disp_mode(), -1, true);
+    ctx().Display(m_extruded, AIS_Shaded, AIS_Shape::SelectionMode(TopAbs_SHAPE), true);
   }
   else
-  {
     m_extruded->Set(body);
-    ctx().Redisplay(m_extruded, true);
-  }
+
+  m_extruded->SetMaterial(view().get_default_material());
+  view().refresh_shape_shading_(m_extruded);
+  ctx().Redisplay(m_extruded, true);
+  ctx().UpdateCurrentViewer();
 }
 
 void Shp_extrude::refresh_tmp_dimension_style(const Length_dimension_style& style)

--- a/src/shp_fillet.cpp
+++ b/src/shp_fillet.cpp
@@ -97,7 +97,7 @@ Status Shp_fillet::add_fillet(const ScreenCoords& screen_coords, const Fillet_mo
   }
   catch (const Standard_Failure& e)
   {
-    const char* msg     = e.what();
+    const char* msg     = e.GetMessageString();
     std::string err_str = msg ? msg : "Unknown OCCT error";
     DBG_MSG(err_str);
     return Status::user_error(err_str);

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -1327,7 +1327,7 @@ Shp_rslt Sketch::revolve_selected(const double angle)
   {
     // Catch OCCT exception and return error with message
     std::string error_msg = "Revolution failed: ";
-    const char* msg       = e.what();
+    const char* msg       = e.GetMessageString();
     error_msg += msg ? msg : "Unknown OCCT error";
     return Shp_rslt(Result_status::Topo_error, error_msg);
   }

--- a/src/version.h
+++ b/src/version.h
@@ -7,3 +7,6 @@
 #define EZYCAD_VERSION_PATCH 0
 
 #define EZYCAD_VERSION_STRING "0.2.0"
+
+// Pinned ImGuiColorTextEdit ref when fetched by CMake (see CMakeLists.txt GIT_TAG).
+#define EZYCAD_IMGUI_COLOR_TEXT_EDIT_REF "ca2f9f1"


### PR DESCRIPTION
## Summary

- Documents OCCT **8.x GLES shading regression** on wasm (wireframe / partial face shading); **7.9.3** restores correct presentation
- Adds versioned wasm OCCT build scripts with shared implementation:
  - `scripts/build-occt-wasm.ps1` (core)
  - `scripts/build-occt-793-wasm.ps1` / `.cmd` (recommended default: `%USERPROFILE%\occt-wasm-build\V7_9_3`)
  - `scripts/build-occt-v8-wasm.ps1` / `.cmd` refactored as thin wrapper for `V8_0_0_p1`
- Fixes PowerShell splatting bug when passing cmake arg arrays to `Invoke-EmCMake`
- EzyCad wasm compatibility: `Standard_Failure::GetMessageString()` (7.9.3), guard OCCT 8-only `SetUseVertexColorForBackFaces`
- Wasm presentation helpers: `refresh_shape_shading_`, extrude preview `Redisplay`, `occt_view_wasm_bisect.h` (bisect toggles, off by default)
- Updates `README.md`, `docs/building-occt.md`, `agents/dev.md`, `docs/bugs.md`

Closes #152

## Test plan

- [x] `.\scripts\build-occt-793-wasm.ps1` completes; prints `OpenCASCADE_DIR=...\V7_9_3\install\lib\cmake\opencascade`
- [x] EzyCad wasm configures and builds against OCCT 7.9.3 (`build-em-7-9-3`)
- [x] Browser test: new solids and extrude preview shade correctly on 7.9.3 (vs broken on 8.0.p1)
- [x] Native Windows build unaffected (desktop remains OCCT 8)
- [x] `.\scripts\build-occt-v8-wasm.ps1` still configures (regression compare path)