### PR TITLE
Sketch List row hover emphasizes sketch geometry and underlay

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1048,6 +1048,7 @@ void GUI::sketch_list_()
 {
   if (!show_sketch_list_effective())
   {
+    m_view->set_sketch_list_hover(nullptr);
     m_view->set_sketch_list_measurement_hover(nullptr, SIZE_MAX);
     return;
   }
@@ -1063,6 +1064,7 @@ void GUI::sketch_list_()
 
   if (!ImGui::Begin("Sketch List", &m_show_sketch_list, ImGuiWindowFlags_None))
   {
+    m_view->set_sketch_list_hover(nullptr);
     m_view->set_sketch_list_measurement_hover(nullptr, SIZE_MAX);
     ImGui::End();
     return;
@@ -1073,11 +1075,14 @@ void GUI::sketch_list_()
 
   int          index = 0;
   Sketch::sptr sketch_to_delete;
+  Sketch::sptr sketch_list_hover;
   Sketch::sptr sketch_list_measurement_hover_sketch;
   size_t       sketch_list_measurement_hover_index = SIZE_MAX;
   for (Sketch::sptr& sketch : m_view->get_sketches())
   {
     EZY_ASSERT(sketch);
+
+    ImGui::BeginGroup();
 
     // Buffer for editable name
     char name_buffer[1024];
@@ -1139,7 +1144,12 @@ void GUI::sketch_list_()
     ImGui::PushID(("visible" + id_suffix).c_str());
     bool visible = sketch->is_visible();
     if (ImGui::Checkbox("", &visible))
+    {
+      if (!visible && m_view->sketch_list_hover() == sketch)
+        m_view->set_sketch_list_hover(nullptr);
+
       sketch->set_visible(visible);
+    }
 
     if (ui_show_contextual_help() && ImGui::IsItemHovered())
       ImGui::SetTooltip("Visibility");
@@ -1161,6 +1171,11 @@ void GUI::sketch_list_()
         sketch->underlay_set_visible(ul_vis);
         if (m_underlay_panel_sketch == sketch.get())
           m_underlay_vis = ul_vis;
+        if (m_view->sketch_list_hover() == sketch)
+        {
+          m_view->set_sketch_list_hover(nullptr);
+          m_view->set_sketch_list_hover(sketch);
+        }
       }
 
       if (!has_ul)
@@ -1198,12 +1213,18 @@ void GUI::sketch_list_()
       ImGui::PopID();
     }
 
+    ImGui::EndGroup();
+
+    if (ImGui::IsItemHovered() && sketch->is_visible())
+      sketch_list_hover = sketch;
+
     if (expanded && ui_show_sketch_list_expand())
       sketch_list_inspector_(sketch, index, sketch_list_measurement_hover_sketch, sketch_list_measurement_hover_index);
 
     ++index;
   }
 
+  m_view->set_sketch_list_hover(sketch_list_hover);
   m_view->set_sketch_list_measurement_hover(sketch_list_measurement_hover_sketch, sketch_list_measurement_hover_index);
 
   ImGui::EndChild();

--- a/src/occt_view.cpp
+++ b/src/occt_view.cpp
@@ -1701,6 +1701,31 @@ void Occt_view::update_shape_list_hover_drawer_()
   m_shape_list_hover_drawer->SetWireAspect(wire_aspect);
 }
 
+void Occt_view::clear_sketch_list_hover_ais_()
+{
+  if (is_headless() || m_ctx.IsNull())
+    return;
+
+  for (const AIS_InteractiveObject_ptr& ais : m_sketch_list_hover_ais)
+    if (!ais.IsNull())
+      m_ctx->Unhilight(ais, false);
+
+  m_sketch_list_hover_ais.clear();
+}
+
+void Occt_view::apply_sketch_list_hover_highlight_()
+{
+  if (is_headless() || m_ctx.IsNull() || !m_sketch_list_hover || !m_sketch_list_hover->is_visible())
+    return;
+
+  update_shape_list_hover_drawer_();
+  m_sketch_list_hover->append_list_hover_ais(m_sketch_list_hover_ais);
+
+  for (const AIS_InteractiveObject_ptr& ais : m_sketch_list_hover_ais)
+    if (!ais.IsNull())
+      m_ctx->HilightWithColor(ais, m_shape_list_hover_drawer, false);
+}
+
 void Occt_view::restore_sketch_list_measurement_hover_style_()
 {
   if (m_sketch_list_measurement_hover.IsNull())
@@ -1747,6 +1772,12 @@ void Occt_view::refresh_shape_list_hover_highlight()
   if (!m_sketch_list_measurement_hover.IsNull())
     apply_sketch_list_measurement_hover_style_();
 
+  if (m_sketch_list_hover)
+  {
+    clear_sketch_list_hover_ais_();
+    apply_sketch_list_hover_highlight_();
+  }
+
   m_ctx->UpdateCurrentViewer();
 }
 
@@ -1773,6 +1804,25 @@ void Occt_view::set_sketch_list_measurement_hover(const Sketch_ptr& sketch, cons
 
   if (!m_sketch_list_measurement_hover.IsNull())
     apply_sketch_list_measurement_hover_style_();
+
+  m_ctx->UpdateCurrentViewer();
+}
+
+void Occt_view::set_sketch_list_hover(const Sketch_ptr& sketch)
+{
+  if (is_headless() || m_ctx.IsNull())
+    return;
+
+  if (m_sketch_list_hover == sketch)
+    return;
+
+  clear_sketch_list_hover_ais_();
+  m_sketch_list_hover = sketch;
+
+  if (m_sketch_list_hover && m_sketch_list_hover->is_visible())
+    apply_sketch_list_hover_highlight_();
+  else if (m_sketch_list_hover)
+    m_sketch_list_hover.reset();
 
   m_ctx->UpdateCurrentViewer();
 }
@@ -2008,6 +2058,9 @@ Occt_view::Sketch_list& Occt_view::get_sketches() { return m_sketches; }
 
 void Occt_view::remove_sketch(const Sketch_ptr& sketch)
 {
+  if (m_sketch_list_hover == sketch)
+    set_sketch_list_hover(nullptr);
+
   push_undo_snapshot();
   m_sketches.remove(sketch);
   if (m_cur_sketch == sketch)

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -241,6 +241,9 @@ public:
   /// Highlight \a shp in the 3D viewer while the Shape List row is hovered (null clears).
   void           set_shape_list_hover(const Shp_ptr& shp);
   const Shp_ptr& shape_list_hover() const { return m_shape_list_hover; }
+  /// Highlight \a sketch geometry (including underlay) while its Sketch List row is hovered (null clears).
+  void           set_sketch_list_hover(const Sketch_ptr& sketch);
+  const Sketch_ptr& sketch_list_hover() const { return m_sketch_list_hover; }
   /// Highlight a sketch length dimension while its Sketch List row is hovered (\a dim_index == SIZE_MAX clears).
   void set_sketch_list_measurement_hover(const Sketch_ptr& sketch, size_t dim_index);
   /// Re-apply list-hover highlight after Settings changes the hover color.
@@ -351,13 +354,17 @@ private:
   Sketch_list                       m_sketches;
   std::shared_ptr<Sketch>           m_cur_sketch;
   TopAbs_ShapeEnum                  m_shp_selection_mode{TopAbs_SHAPE};
-  Shp_ptr                           m_shape_list_hover;
-  PrsDim_LengthDimension_ptr        m_sketch_list_measurement_hover;
-  opencascade::handle<Prs3d_Drawer> m_shape_list_hover_drawer;
-  void                              update_shape_list_hover_drawer_();
-  void                              apply_sketch_list_measurement_hover_style_();
-  void                              restore_sketch_list_measurement_hover_style_();
-  void                              refresh_sketch_list_measurement_hover_highlight_();
+  Shp_ptr                                    m_shape_list_hover;
+  Sketch_ptr                                 m_sketch_list_hover;
+  std::vector<AIS_InteractiveObject_ptr>     m_sketch_list_hover_ais;
+  PrsDim_LengthDimension_ptr                 m_sketch_list_measurement_hover;
+  opencascade::handle<Prs3d_Drawer>          m_shape_list_hover_drawer;
+  void                                       update_shape_list_hover_drawer_();
+  void                                       clear_sketch_list_hover_ais_();
+  void                                       apply_sketch_list_hover_highlight_();
+  void                                       apply_sketch_list_measurement_hover_style_();
+  void                                       restore_sketch_list_measurement_hover_style_();
+  void                                       refresh_sketch_list_measurement_hover_highlight_();
   Graphic3d_MaterialAspect          m_default_material;
   bool                              m_headless_view{false};
   /// True when LMB press was handled by planar-face sketch creation without AIS_ViewController::PressMouseButton (pair with

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -2941,6 +2941,30 @@ PrsDim_LengthDimension_ptr Sketch::length_dimension_handle(const size_t dim_inde
   return m_length_dimensions[dim_index].dim;
 }
 
+void Sketch::append_list_hover_ais(std::vector<AIS_InteractiveObject_ptr>& out) const
+{
+  if (!m_visible)
+    return;
+
+  for (const Edge& e : m_edges)
+    if (!e.shp.IsNull())
+      out.push_back(e.shp);
+
+  if (m_show_faces)
+    for (const Sketch_face_shp_ptr& face : m_faces)
+      if (!face.IsNull())
+        out.push_back(face);
+
+  if (m_originating_face)
+    out.push_back(m_originating_face);
+
+  if (m_operation_axis.has_value() && !m_operation_axis->shp.IsNull())
+    out.push_back(m_operation_axis->shp);
+
+  if (m_underlay && underlay_visible())
+    m_underlay->append_list_hover_ais(out);
+}
+
 void Sketch::set_dimension_name(size_t dim_index, const std::string& name)
 {
   EZY_ASSERT(dim_index < m_length_dimensions.size());

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -87,6 +87,9 @@ public:
   /// OCCT length-dimension object for list hover / viewer highlight (may be null while rebuilding).
   PrsDim_LengthDimension_ptr length_dimension_handle(size_t dim_index) const;
 
+  /// AIS objects to emphasize while this sketch's Sketch List row is hovered.
+  void append_list_hover_ais(std::vector<AIS_InteractiveObject_ptr>& out) const;
+
   /// Rebuild length dimensions and/or permanent node '+' markers (e.g. after settings changes).
   void refresh_annotations(const Sketch_annotation_refresh& refresh);
 

--- a/src/sketch_underlay.cpp
+++ b/src/sketch_underlay.cpp
@@ -1,5 +1,7 @@
 #include "sketch_underlay.h"
 
+#include <AIS_InteractiveObject.hxx>
+
 #include <AIS_InteractiveContext.hxx>
 #include <AIS_InteractiveObject.hxx>
 #include <AIS_Shape.hxx>
@@ -608,6 +610,18 @@ void Sketch_underlay::redisplay(AIS_InteractiveContext& ctx)
 {
   if (!m_ais.IsNull())
     ctx.Redisplay(m_ais, true);
+}
+
+void Sketch_underlay::append_list_hover_ais(std::vector<opencascade::handle<AIS_InteractiveObject>>& out) const
+{
+  if (!has_image() || !m_visible)
+    return;
+
+  if (!m_ais.IsNull())
+    out.push_back(m_ais);
+
+  if (!m_border.IsNull())
+    out.push_back(m_border);
 }
 
 nlohmann::json Sketch_underlay::to_json(const Ezy_asset_store& store) const

--- a/src/sketch_underlay.h
+++ b/src/sketch_underlay.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+class AIS_InteractiveObject;
 class AIS_TexturedShape;
 class AIS_Shape;
 class AIS_InteractiveContext;
@@ -75,6 +76,9 @@ public:
   void sync_visibility(const gp_Pln& pln, AIS_InteractiveContext& ctx);
   /// Force viewer update after live property changes (e.g. threshold) without a full rebuild.
   void redisplay(AIS_InteractiveContext& ctx);
+
+  /// Add displayed AIS objects for Sketch List row hover emphasis (image quad and border wire).
+  void append_list_hover_ais(std::vector<opencascade::handle<AIS_InteractiveObject>>& out) const;
 
   nlohmann::json to_json(const Ezy_asset_store& store) const;
   /// Returns false if JSON is invalid or image decode fails.


### PR DESCRIPTION
## Summary

- **Sketch List row hover:** Hovering a sketch row in the Sketch List now emphasizes that sketch in the 3D viewer, matching the existing Shape List behavior.
- **Underlay included:** Highlight covers edge wireframes, face fills (when shown), originating face, operation axis, and underlay image quad + border wire (when underlay display is enabled).
- **Viewer plumbing:** `Occt_view::set_sketch_list_hover()` applies `HilightWithColor` via the same drawer as shape list hover; clears on list close, sketch hide, or sketch delete.
- **Dimension hover unchanged:** Expanded inspector dimension rows still highlight individual length dimensions as before.

Closes #159

## Files changed

- `src/gui.cpp` — track row hover in `sketch_list_()`, wrap rows in ImGui groups
- `src/occt_view.cpp`, `src/occt_view.h` — sketch list hover state and highlight apply/clear
- `src/sketch.cpp`, `src/sketch.h` — `append_list_hover_ais()` collects sketch display objects
- `src/sketch_underlay.cpp`, `src/sketch_underlay.h` — underlay image and border wire for hover

## Test plan

- [ ] Build `EzyCad` (Debug).
- [ ] Open Sketch List with multiple sketches; hover each row and confirm geometry highlights in the viewer using the Element hover color from Settings.
- [ ] Verify underlay image and border highlight when underlay display is enabled.
- [ ] Toggle sketch visibility while hovered — highlight clears.
- [ ] Toggle underlay visibility while hovered — highlight refreshes.
- [ ] Hover dimension rows in expanded inspector — individual dimension highlight still works.
- [ ] Close Sketch List — highlight clears.