### PR TITLE
Refactor monolithic Sketch into focused modules (edges, topo, dims, tools, node marks)

### DIFF
--- a/agents/drafts/issues/active/gh-163-sketch-module-refactor.md
+++ b/agents/drafts/issues/active/gh-163-sketch-module-refactor.md
@@ -16,27 +16,27 @@ paired_draft: ../prs/active/gh-164-sketch-module-refactor.md
 
 ## Title (GitHub)
 
-Refactor monolithic `Sketch` into focused modules (edges, topo, dims, tools, node marks)
+Refactor monolithic Sketch into focused modules (edges, topo, dims, tools, node marks)
 
 ## Body (GitHub)
 
 ### Summary
 
-Split the large `Sketch` class in `src/sketch.cpp` into smaller, single-responsibility modules so edge storage, planar topology, dimensions, interactive drawing tools, permanent node marks, and AIS helpers each live in their own files. `Sketch` becomes a thin coordinator that owns sub-objects and delegates.
+Split the large `Sketch` class in `src/sketch.cpp` into smaller, single-responsibility modules so edge storage, planar topology, dimensions, interactive drawing tools, permanent node marks, AIS helpers, viewer display, and mirror/revolve operations each live in focused files. `Sketch` becomes a thin coordinator that owns sub-objects and delegates.
 
 No user-visible behavior change is intended; this is structural cleanup following the `Sketch_underlay` extraction (#161 / PR #162).
 
 ### Problem
 
-- `sketch.cpp` had grown into a god object (~3000 lines) mixing persistent geometry, face extraction, dimension UI, interactive tool state, JSON/delta paths, and OCCT display helpers.
+- `sketch.cpp` had grown into a god object (~3000 lines) mixing persistent geometry, face extraction, dimension UI, interactive tool state, JSON/delta paths, OCCT display helpers, and mirror/revolve logic.
 - Hard to navigate, review, and test in isolation.
 - Transient draw state (`m_tmp_edges`, previews, finalize/cancel) was intertwined with committed edge list and topology.
 
 ### Implemented scope
 
-**New modules:**
+**New modules / translation units:**
 
-| Module | Responsibility |
+| Module / file | Responsibility |
 | --- | --- |
 | `sketch_edge` | `Sketch_edge` type and `sketch_edge_is_linear()` |
 | `Sketch_edges` | Persistent edge list; add/split/remove; JSON linear edges; read-only `for_each_linear` / `for_each_arc` visitors |
@@ -45,6 +45,8 @@ No user-visible behavior change is intended; this is structural cleanup followin
 | `Sketch_node_marks` | Permanent node '+' markers (`sync`, `remove_at`, etc.) |
 | `sketch_ais` | `Sketch_AIS_edge`, `Sketch_AIS_node_mark`, `Sketch_face_shp`, mark removal helper |
 | `Sketch_tools` | Interactive drawing session: tmp edges/nodes, mode-specific tools, finalize/cancel |
+| `sketch_display.cpp` | Viewer display: visibility, edge styling, sketch switching, list hover (state on `Sketch`) |
+| `sketch_operations.cpp` | Operation axis, mirror, revolve (state on `Sketch`) |
 
 **`Sketch` layout after refactor:**
 
@@ -59,6 +61,8 @@ Sketch
   └── Sketch_underlay
 ```
 
+`sketch.cpp` (~400 lines) retains coordinator logic, input routing, edge shape updates, snap helpers, and inspector labels. Display and operations are split into dedicated `.cpp` files without new wrapper classes.
+
 **Call-site updates:**
 
 - `sketch_json.cpp`, `sketch_delta.cpp` use edge visitors and module delegates.
@@ -72,22 +76,24 @@ Sketch
 
 ### Acceptance criteria
 
-- [ ] `Sketch` delegates drawing to `Sketch_tools`; topology to `Sketch_topo`; edges to `Sketch_edges`.
-- [ ] All `Sketch_test.*` cases pass (53 tests).
-- [ ] Native Release build succeeds (`EzyCad_lib`, `EzyCad_tests`).
-- [ ] No user-facing doc updates required (internal refactor only).
+- [x] `Sketch` delegates drawing to `Sketch_tools`; topology to `Sketch_topo`; edges to `Sketch_edges`.
+- [x] Display and operations logic split into `sketch_display.cpp` / `sketch_operations.cpp`.
+- [x] All `Sketch_test.*` cases pass (53 tests).
+- [x] Native Release build succeeds (`EzyCad_lib`, `EzyCad_tests`).
+- [x] No user-facing doc updates required (internal refactor only).
 
 ### Files touched
 
-- `src/sketch.cpp`, `src/sketch.h` (slimmed coordinator)
+- `src/sketch.cpp`, `src/sketch.h` (slim coordinator)
 - `src/sketch_edge.*`, `src/sketch_edges.*`
 - `src/sketch_topo.*`, `src/sketch_dims.*`
 - `src/sketch_tools.*`, `src/sketch_node_marks.*`, `src/sketch_ais.*`
+- `src/sketch_display.cpp`, `src/sketch_operations.cpp`
 - `src/sketch_json.cpp`, `src/sketch_delta.cpp`, `src/utl_types.h`
 - `tests/sketch_tests.cpp`
 
 ### Test plan
 
-- [ ] Build `EzyCad_tests` (Release).
-- [ ] Run `EzyCad_tests --gtest_filter=Sketch_test.*` (53 cases).
+- [x] Build `EzyCad_tests` (Release).
+- [x] Run `EzyCad_tests --gtest_filter=Sketch_test.*` (53 cases).
 - [ ] Manual smoke: add line, square, circle, arc; undo/redo; mirror/revolve with operation axis.

--- a/agents/drafts/issues/active/gh-163-sketch-module-refactor.md
+++ b/agents/drafts/issues/active/gh-163-sketch-module-refactor.md
@@ -1,7 +1,7 @@
 ---
 github_issue: 163
 status: active
-paired_draft: ../prs/active/draft-sketch-module-refactor.md
+paired_draft: ../prs/active/gh-164-sketch-module-refactor.md
 ---
 
 # Refactor monolithic Sketch into focused modules

--- a/agents/drafts/issues/active/gh-163-sketch-module-refactor.md
+++ b/agents/drafts/issues/active/gh-163-sketch-module-refactor.md
@@ -1,0 +1,93 @@
+---
+github_issue: 163
+status: active
+paired_draft: ../prs/active/draft-sketch-module-refactor.md
+---
+
+# Refactor monolithic Sketch into focused modules
+
+**Suggested labels:** `refactor`, `sketch`, `enhancement`
+
+**Branch:** `Trailcode/sketch_topo_refactor`
+
+**GitHub:** https://github.com/trailcode/EzyCad/issues/163
+
+---
+
+## Title (GitHub)
+
+Refactor monolithic `Sketch` into focused modules (edges, topo, dims, tools, node marks)
+
+## Body (GitHub)
+
+### Summary
+
+Split the large `Sketch` class in `src/sketch.cpp` into smaller, single-responsibility modules so edge storage, planar topology, dimensions, interactive drawing tools, permanent node marks, and AIS helpers each live in their own files. `Sketch` becomes a thin coordinator that owns sub-objects and delegates.
+
+No user-visible behavior change is intended; this is structural cleanup following the `Sketch_underlay` extraction (#161 / PR #162).
+
+### Problem
+
+- `sketch.cpp` had grown into a god object (~3000 lines) mixing persistent geometry, face extraction, dimension UI, interactive tool state, JSON/delta paths, and OCCT display helpers.
+- Hard to navigate, review, and test in isolation.
+- Transient draw state (`m_tmp_edges`, previews, finalize/cancel) was intertwined with committed edge list and topology.
+
+### Implemented scope
+
+**New modules:**
+
+| Module | Responsibility |
+| --- | --- |
+| `sketch_edge` | `Sketch_edge` type and `sketch_edge_is_linear()` |
+| `Sketch_edges` | Persistent edge list; add/split/remove; JSON linear edges; read-only `for_each_linear` / `for_each_arc` visitors |
+| `Sketch_topo` | Face extraction, `split_linear_edges_at_node_if_interior`, face caches |
+| `Sketch_dims` | Length dimensions, typed input, pick state, tmp dimension preview |
+| `Sketch_node_marks` | Permanent node '+' markers (`sync`, `remove_at`, etc.) |
+| `sketch_ais` | `Sketch_AIS_edge`, `Sketch_AIS_node_mark`, `Sketch_face_shp`, mark removal helper |
+| `Sketch_tools` | Interactive drawing session: tmp edges/nodes, mode-specific tools, finalize/cancel |
+
+**`Sketch` layout after refactor:**
+
+```
+Sketch
+  ├── Sketch_nodes
+  ├── Sketch_node_marks
+  ├── Sketch_edges
+  ├── Sketch_topo
+  ├── Sketch_dims
+  ├── Sketch_tools
+  └── Sketch_underlay
+```
+
+**Call-site updates:**
+
+- `sketch_json.cpp`, `sketch_delta.cpp` use edge visitors and module delegates.
+- `sketch_dims.cpp` reads tmp session state via `m_sketch.m_tools` accessors.
+- `utl_types.h` includes `sketch_ais.h` for shared AIS typedefs.
+
+**Follow-up (out of scope):**
+
+- [ ] Deduplicate batch edge commit in `Sketch_tools::finalize_edges_` with `Sketch_edges::add_edge_impl_` (shared `commit_linear_batch` helper).
+- [ ] Fix or retire `tools/gen_sketch_tools.py` generator script if kept.
+
+### Acceptance criteria
+
+- [ ] `Sketch` delegates drawing to `Sketch_tools`; topology to `Sketch_topo`; edges to `Sketch_edges`.
+- [ ] All `Sketch_test.*` cases pass (53 tests).
+- [ ] Native Release build succeeds (`EzyCad_lib`, `EzyCad_tests`).
+- [ ] No user-facing doc updates required (internal refactor only).
+
+### Files touched
+
+- `src/sketch.cpp`, `src/sketch.h` (slimmed coordinator)
+- `src/sketch_edge.*`, `src/sketch_edges.*`
+- `src/sketch_topo.*`, `src/sketch_dims.*`
+- `src/sketch_tools.*`, `src/sketch_node_marks.*`, `src/sketch_ais.*`
+- `src/sketch_json.cpp`, `src/sketch_delta.cpp`, `src/utl_types.h`
+- `tests/sketch_tests.cpp`
+
+### Test plan
+
+- [ ] Build `EzyCad_tests` (Release).
+- [ ] Run `EzyCad_tests --gtest_filter=Sketch_test.*` (53 cases).
+- [ ] Manual smoke: add line, square, circle, arc; undo/redo; mirror/revolve with operation axis.

--- a/agents/drafts/prs/active/draft-sketch-module-refactor.md
+++ b/agents/drafts/prs/active/draft-sketch-module-refactor.md
@@ -1,0 +1,52 @@
+---
+github_issue: 163
+status: active
+paired_draft: ../issues/active/gh-163-sketch-module-refactor.md
+---
+
+## Title
+
+Refactor monolithic Sketch into focused modules (edges, topo, dims, tools, node marks)
+
+## Summary
+
+- Split `sketch.cpp` (~3000 lines) into focused modules: `Sketch_edges`, `Sketch_topo`, `Sketch_dims`, `Sketch_tools`, `Sketch_node_marks`, and `sketch_ais`.
+- `Sketch` now owns sub-objects and delegates: interactive drawing to `Sketch_tools`, face/split logic to `Sketch_topo`, persistent edges to `Sketch_edges`, dimensions to `Sketch_dims`.
+- Added read-only edge visitors (`for_each_linear` / `for_each_arc`) for JSON and delta paths.
+- Moved AIS sketch types (`Sketch_AIS_edge`, `Sketch_AIS_node_mark`, `Sketch_face_shp`) into `sketch_ais.h`.
+- No intended user-visible behavior change; structural cleanup after `Sketch_underlay` (#161).
+
+Closes #163.
+
+## Files Changed
+
+- `src/sketch.cpp`, `src/sketch.h` — slim coordinator
+- `src/sketch_edge.*`, `src/sketch_edges.*` — edge type and persistent list
+- `src/sketch_topo.*` — face extraction and interior splits
+- `src/sketch_dims.*` — length dimensions and typed input
+- `src/sketch_tools.*` — interactive draw session (tmp edges, finalize/cancel)
+- `src/sketch_node_marks.*`, `src/sketch_ais.*` — node marks and AIS helpers
+- `src/sketch_json.cpp`, `src/sketch_delta.cpp`, `src/utl_types.h`
+- `tests/sketch_tests.cpp`
+
+## Related
+
+- Issue: https://github.com/trailcode/EzyCad/issues/163
+- Builds on: #161 / PR #162 (`Sketch_underlay`)
+
+## Test Plan
+
+- [x] Build `EzyCad_lib` and `EzyCad_tests` (Release).
+- [x] Run `EzyCad_tests --gtest_filter=Sketch_test.*` — 53/53 passed.
+- [ ] Manual smoke: add line, square, circle, arc; undo/redo; mirror/revolve with operation axis.
+- [ ] No user-doc updates required (internal refactor).
+
+## Notes
+
+- `Sketch_tools::finalize_edges_` intentionally stays in tools (session commit), not `Sketch_topo` (graph primitives).
+- Follow-up: deduplicate batch edge commit with `Sketch_edges::add_edge_impl_`.
+
+## Post-merge
+
+- [ ] Move drafts to `archive/`.
+- [ ] Consider `CHANGELOG.md` `[Unreleased]` entry for internal refactor.

--- a/agents/drafts/prs/active/gh-164-sketch-module-refactor.md
+++ b/agents/drafts/prs/active/gh-164-sketch-module-refactor.md
@@ -15,18 +15,21 @@ Refactor monolithic Sketch into focused modules (edges, topo, dims, tools, node 
 - `Sketch` now owns sub-objects and delegates: interactive drawing to `Sketch_tools`, face/split logic to `Sketch_topo`, persistent edges to `Sketch_edges`, dimensions to `Sketch_dims`.
 - Added read-only edge visitors (`for_each_linear` / `for_each_arc`) for JSON and delta paths.
 - Moved AIS sketch types (`Sketch_AIS_edge`, `Sketch_AIS_node_mark`, `Sketch_face_shp`) into `sketch_ais.h`.
+- Light polish: moved display and operations implementations to `sketch_display.cpp` and `sketch_operations.cpp` (no new wrapper classes; state stays on `Sketch`). `sketch.cpp` is ~400 lines.
 - No intended user-visible behavior change; structural cleanup after `Sketch_underlay` (#161).
 
 Closes #163.
 
 ## Files Changed
 
-- `src/sketch.cpp`, `src/sketch.h` — slim coordinator
+- `src/sketch.cpp`, `src/sketch.h` — slim coordinator (~400 lines)
 - `src/sketch_edge.*`, `src/sketch_edges.*` — edge type and persistent list
 - `src/sketch_topo.*` — face extraction and interior splits
 - `src/sketch_dims.*` — length dimensions and typed input
 - `src/sketch_tools.*` — interactive draw session (tmp edges, finalize/cancel)
 - `src/sketch_node_marks.*`, `src/sketch_ais.*` — node marks and AIS helpers
+- `src/sketch_display.cpp` — visibility, edge style, sketch switching, list hover
+- `src/sketch_operations.cpp` — operation axis, mirror, revolve
 - `src/sketch_json.cpp`, `src/sketch_delta.cpp`, `src/utl_types.h`
 - `tests/sketch_tests.cpp`
 
@@ -41,11 +44,12 @@ Closes #163.
 - [x] Build `EzyCad_lib` and `EzyCad_tests` (Release).
 - [x] Run `EzyCad_tests --gtest_filter=Sketch_test.*` — 53/53 passed.
 - [ ] Manual smoke: add line, square, circle, arc; undo/redo; mirror/revolve with operation axis.
-- [ ] No user-doc updates required (internal refactor).
+- [x] No user-doc updates required (internal refactor).
 
 ## Notes
 
 - `Sketch_tools::finalize_edges_` intentionally stays in tools (session commit), not `Sketch_topo` (graph primitives).
+- Display/operations split uses dedicated `.cpp` files only (lighter than `Sketch_display` / `Sketch_operations` classes).
 - Follow-up: deduplicate batch edge commit with `Sketch_edges::add_edge_impl_`.
 
 ## Post-merge

--- a/agents/drafts/prs/active/gh-164-sketch-module-refactor.md
+++ b/agents/drafts/prs/active/gh-164-sketch-module-refactor.md
@@ -1,5 +1,6 @@
 ---
 github_issue: 163
+github_pr: 164
 status: active
 paired_draft: ../issues/active/gh-163-sketch-module-refactor.md
 ---
@@ -32,6 +33,7 @@ Closes #163.
 ## Related
 
 - Issue: https://github.com/trailcode/EzyCad/issues/163
+- PR: https://github.com/trailcode/EzyCad/pull/164
 - Builds on: #161 / PR #162 (`Sketch_underlay`)
 
 ## Test Plan

--- a/src/occt_view.cpp
+++ b/src/occt_view.cpp
@@ -627,8 +627,9 @@ bool Occt_view::cancel_sketch_extrude_() { return m_shp_extrude.cancel(); }
 
 void Occt_view::create_default_sketch_()
 {
-  EZY_ASSERT(m_sketches.empty());
-  EZY_ASSERT(!m_cur_sketch);
+  if (!m_sketches.empty() || m_cur_sketch)
+    return;
+
   m_cur_sketch = std::make_shared<Sketch>("Sketch", *this, xy_plane());
   m_sketches.push_back(m_cur_sketch);
   m_cur_sketch->set_current();
@@ -637,7 +638,13 @@ void Occt_view::create_default_sketch_()
 void Occt_view::ensure_current_sketch_()
 {
   if (m_cur_sketch)
-    return;
+  {
+    for (const Sketch_ptr& s : m_sketches)
+      if (s == m_cur_sketch)
+        return;
+
+    m_cur_sketch.reset();
+  }
 
   if (!m_sketches.empty())
   {
@@ -2077,6 +2084,14 @@ Aspect_VKeyFlags Occt_view::key_flags_from_glfw_(int theFlags)
 
 Occt_view::Sketch_list& Occt_view::get_sketches() { return m_sketches; }
 
+size_t Occt_view::allocate_sketch_id() { return m_next_sketch_id++; }
+
+void Occt_view::adopt_sketch_id(const size_t id)
+{
+  if (id >= m_next_sketch_id)
+    m_next_sketch_id = id + 1;
+}
+
 void Occt_view::remove_sketch(const Sketch_ptr& sketch)
 {
   if (m_sketch_list_hover == sketch)
@@ -2101,6 +2116,8 @@ Sketch& Occt_view::curr_sketch()
   ensure_current_sketch_();
   return *m_cur_sketch;
 }
+
+Sketch* Occt_view::current_sketch_if_any() const { return m_cur_sketch.get(); }
 
 Occt_view::Sketch_ptr Occt_view::curr_sketch_shared() const
 {
@@ -2330,6 +2347,13 @@ void Occt_view::load(const std::string& json_str, bool restore_view)
     m_ctx->Remove(s, false);
 
   clear_all(m_sketches, m_cur_sketch, m_shps);
+
+  if (!m_restoring)
+  {
+    m_undo_stack.clear();
+    m_redo_stack.clear();
+  }
+
   const json j = json::parse(json_str);
   (void)j.value("ezyFormat", 1); // Reserved for future migrations; sketch JSON migrates per-edge dim flags in Sketch_json.
   EZY_ASSERT(j.contains("sketches") && j["sketches"].is_array());
@@ -2593,6 +2617,7 @@ void Occt_view::new_file()
   remove(m_shps);
   clear_all(m_shps, m_sketches, m_cur_sketch);
   m_assets.clear();
+  m_next_sketch_id = 1;
 
   create_default_sketch_();
   refresh_viewer_grid_();

--- a/src/occt_view.h
+++ b/src/occt_view.h
@@ -135,11 +135,15 @@ public:
 
   // Sketch related
   Sketch_list& get_sketches();
+  size_t       allocate_sketch_id();
+  void         adopt_sketch_id(size_t id);
   void         remove_sketch(const Sketch_ptr& sketch);
   /// Empty sketch on \a pln; \a base_name is uniquified (e.g. Sketch_xy, Sketch_xy.001).
   void       add_sketch(const gp_Pln& pln, const std::string& base_name);
   Sketch&    curr_sketch();
   Sketch_ptr curr_sketch_shared() const;
+  /// Non-owning; null when none selected. Does not create a default sketch.
+  Sketch*    current_sketch_if_any() const;
   void       set_curr_sketch(const Sketch_ptr& sketch);
   void       sketch_face_extrude(const ScreenCoords& screen_coords, bool is_mouse_move);
 
@@ -343,6 +347,7 @@ private:
   std::vector<Undo_entry> m_undo_stack;
   std::vector<Undo_entry> m_redo_stack;
   bool                    m_restoring{false};
+  size_t                  m_next_sketch_id{1};
   Ezy_asset_store         m_assets;
 
   // --------------------------------------------------------------------

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -1,26 +1,20 @@
 #include "sketch.h"
 
 #include <BRepBuilderAPI_MakeEdge.hxx>
-#include <BRepPrimAPI_MakeRevol.hxx>
-#include <GC_MakeArcOfCircle.hxx>
-#include <Graphic3d_AspectFillArea3d.hxx>
+#include <BRep_Tool.hxx>
 #include <Precision.hxx>
 #include <PrsDim_LengthDimension.hxx>
+#include <TopExp.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Edge.hxx>
 #include <TopoDS_Wire.hxx>
-#include <V3d_View.hxx>
-#include <cmath>
 #include <functional>
-#include <map>
 
 #include "utl_geom.h"
-#include "gui.h"
 #include "mode.h"
 #include "occt_view.h"
 #include "sketch_delta.h"
-#include "utl_occt.h"
 #include "utl.h"
 
 using namespace glm;
@@ -116,56 +110,6 @@ void Sketch::dbg_append_str(std::string& out) const
   out += "Tmp Edges: " + std::to_string(m_tools.tmp_edge_count()) + "\n";
 }
 
-void Sketch::update_edge_style_(AIS_Shape_ptr& shp)
-{
-  switch (m_edge_style)
-  {
-  case Edge_style::Full:
-    // shp->SetWidth(1.5);
-    shp->SetWidth(1.0);
-    shp->SetColor(Quantity_Color(0.0, 1.0, 0.0, Quantity_TOC_RGB));
-    shp->SetTransparency(0.0);
-
-    break;
-
-  case Edge_style::Background:
-    shp->SetWidth(1.0);
-    shp->SetColor(Quantity_Color(0.3, 0.3, 0.3, Quantity_TOC_RGB));
-    shp->SetTransparency(0.7);
-    break;
-
-  default:
-    EZY_ASSERT(false);
-  }
-}
-
-void Sketch::update_originating_face_style()
-{
-  if (!m_originating_face)
-    return;
-
-  switch (m_edge_style)
-  {
-  case Edge_style::Full:
-    m_originating_face->SetWidth(1.0);
-    m_originating_face->SetColor(Quantity_Color(0.3, 0.0, 0.0, Quantity_TOC_RGB));
-    m_originating_face->SetTransparency(0.0);
-
-    break;
-
-  case Edge_style::Background:
-    m_originating_face->SetWidth(1.0);
-    m_originating_face->SetColor(Quantity_Color(0.3, 0.3, 0.3, Quantity_TOC_RGB));
-    m_originating_face->SetTransparency(0.7);
-    break;
-
-  default:
-    EZY_ASSERT(false);
-  }
-
-  m_ctx.Redisplay(m_originating_face, true);
-}
-
 void Sketch::update_edge_shp_(Edge& edge, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
 {
   EZY_ASSERT(unique(pt_a, pt_b));
@@ -202,21 +146,6 @@ void Sketch::add_edge_raw_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b) { m_edges
 void Sketch::sketch_json_add_linear_edge_(size_t idx_a, size_t idx_b, std::optional<size_t> idx_mid)
 {
   m_edges.sketch_json_add_linear_edge(idx_a, idx_b, idx_mid);
-}
-
-void Sketch::sketch_json_set_operation_axis_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
-{
-  if (!unique(pt_a, pt_b))
-    return;
-
-  clear_operation_axis();
-
-  Edge axis{m_nodes.get_node_exact(pt_a)};
-  axis.node_idx_b = m_nodes.get_node_exact(pt_b);
-  update_edge_shp_(axis, pt_a, pt_b);
-  m_operation_axis = std::move(axis);
-
-  sync_operation_axis_display_();
 }
 
 std::vector<Sketch::Edge> Sketch::get_selected_edges_() const { return m_edges.get_selected(); }
@@ -357,165 +286,12 @@ void Sketch::add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const g
 
 void Sketch::add_arc_circle_(const std::vector<size_t>& node_idxs) { m_edges.add_arc_circle_edges(node_idxs); }
 
-void Sketch::clear_operation_axis()
-{
-  if (m_operation_axis.has_value())
-    m_ctx.Remove(m_operation_axis->shp, false);
-
-  m_operation_axis = std::nullopt;
-  m_node_marks.sync();
-  m_nodes.hide_snap_annos();
-}
-
-bool Sketch::has_operation_axis() const { return m_operation_axis.has_value(); }
-
-void Sketch::mirror_selected_edges()
-{
-  EZY_ASSERT(m_operation_axis.has_value());
-  Sketch_op_recorder rec(m_view, *this);
-
-  const std::vector<Edge> mirror_edges = get_selected_edges_();
-  if (mirror_edges.empty())
-  {
-    rec.cancel();
-    m_view.gui().show_message(ERROR_NO_EDGES_SELECTED);
-    return;
-  }
-
-  EZY_ASSERT(!m_operation_axis->shp.IsNull());
-  const auto [mirror_pt_a, mirror_pt_b] = get_edge_endpoints(m_pln, TopoDS::Edge(m_operation_axis->shp->Shape()));
-
-  std::vector<std::pair<gp_Pnt2d, gp_Pnt2d>>     mirrored_edges;
-  std::map<AIS_Shape_ptr, std::set<const Edge*>> arc_circles;
-
-  for (const Edge& e : m_edges.edges())
-    for (const Edge& selected : mirror_edges)
-      if (e.shp == selected.shp || e.circle_arc == selected.circle_arc)
-      {
-        if (e.circle_arc)
-        {
-          std::set<const Edge*>& arc_circle_edges = arc_circles[e.shp];
-          arc_circle_edges.insert(&e);
-          if (arc_circle_edges.size() == 2)
-            break;
-        }
-        else
-        {
-          const gp_Pnt2d a = mirror_point(mirror_pt_a, mirror_pt_b, m_nodes[e.node_idx_a]);
-          const gp_Pnt2d b = mirror_point(mirror_pt_a, mirror_pt_b, m_nodes[e.node_idx_b]);
-          mirrored_edges.push_back({a, b});
-          break;
-        }
-      }
-
-  for (const auto& [a, b] : mirrored_edges)
-    add_edge_(a, b, rec);
-
-  for (auto& [_, arc_circle_edges] : arc_circles)
-  {
-    EZY_ASSERT(arc_circle_edges.size() == 2);
-    const Edge* a = nullptr;
-    const Edge* b = nullptr;
-    for (const Edge* e : arc_circle_edges)
-      if (e->node_idx_arc.has_value())
-        a = e;
-      else
-        b = e;
-
-    EZY_ASSERT(a && b);
-    EZY_ASSERT(a->node_idx_arc.has_value());
-    EZY_ASSERT(b->node_idx_b);
-    const gp_Pnt2d pt_a = mirror_point(mirror_pt_a, mirror_pt_b, m_nodes[a->node_idx_a]);
-    const gp_Pnt2d pt_b = mirror_point(mirror_pt_a, mirror_pt_b, m_nodes[a->node_idx_arc]);
-    const gp_Pnt2d pt_c = mirror_point(mirror_pt_a, mirror_pt_b, m_nodes[b->node_idx_b]);
-    add_arc_circle_(pt_a, pt_b, pt_c, rec);
-  }
-
-  m_nodes.hide_snap_annos();
-  update_faces_();
-  rec.commit();
-}
-
-Shp_rslt Sketch::revolve_selected(const double angle)
-{
-  EZY_ASSERT_MSG(m_operation_axis.has_value(), "No defined operation axis.");
-
-  TopoDS_Compound compound;
-  BRep_Builder    builder;
-  builder.MakeCompound(compound);
-
-  const std::vector<Sketch_face_shp_ptr> faces          = get_selected_faces_();
-  const std::vector<Edge>                selected_edges = get_selected_edges_();
-  if (selected_edges.size())
-  {
-    std::set<AIS_Shape*> seen;
-    for (const Edge& e : selected_edges)
-      // Arc circles share the same shape
-      if (!seen.count(e.shp.get()))
-      {
-        seen.insert(e.shp.get());
-        builder.Add(compound, e.shp->Shape());
-      }
-  }
-  else if (faces.size())
-    for (const Sketch_face_shp_ptr& face : faces)
-      builder.Add(compound, face->Shape());
-
-  else
-    return Shp_rslt(Result_status::User_error, "No selected faces or edges.");
-
-  try
-  {
-    const auto [pt_a, pt_b] = get_edge_endpoints(TopoDS::Edge(m_operation_axis->shp->Shape()));
-
-    const gp_Dir direction((pt_b.XYZ() - pt_a.XYZ()).Normalized());
-    const gp_Ax1 axis(pt_a, direction);
-
-    BRepPrimAPI_MakeRevol revolMaker(compound, axis, angle);
-    return Shp_rslt(new Shp(m_ctx, try_make_solid(revolMaker.Shape())));
-  }
-  catch (const Standard_Failure& e)
-  {
-    // Catch OCCT exception and return error with message
-    std::string error_msg = "Revolution failed: ";
-    const char* msg       = e.GetMessageString();
-    error_msg += msg ? msg : "Unknown OCCT error";
-    return Shp_rslt(Result_status::Topo_error, error_msg);
-  }
-  catch (const std::exception& e)
-  {
-    // Catch other unexpected errors
-    return Shp_rslt(Result_status::User_error, "Unexpected error: " + std::string(e.what()));
-  }
-}
-
 void Sketch::on_mode()
 {
   // Reset state
   cancel_elm();
   sync_operation_axis_display_();
   m_node_marks.sync();
-}
-
-bool Sketch::show_operation_axis_() const
-{
-  return m_operation_axis.has_value() && m_visible && is_current() && get_mode() == Mode::Sketch_operation_axis;
-}
-
-bool Sketch::operation_axis_suppresses_sketch_snap_() const
-{
-  return get_mode() == Mode::Sketch_operation_axis && m_operation_axis.has_value();
-}
-
-void Sketch::sync_operation_axis_display_()
-{
-  if (!m_operation_axis.has_value())
-    return;
-
-  if (show_operation_axis_())
-    m_ctx.Display(m_operation_axis->shp, AIS_WireFrame, 0, false);
-  else
-    m_ctx.Erase(m_operation_axis->shp, false);
 }
 
 Mode Sketch::get_mode() const { return m_view.get_mode(); }
@@ -566,155 +342,6 @@ void Sketch::get_originating_face_snp_pts_3d_(std::vector<gp_Pnt>& out)
   }
 
   append(out, snp_pts);
-}
-void Sketch::set_visible(bool state)
-{
-  m_visible = state;
-
-  if (state)
-  {
-    if (m_show_faces)
-      for (AIS_Shape_ptr& face : m_topo.faces())
-        m_ctx.Display(face, AIS_Shaded, 0, false);
-
-    for (Edge& e : m_edges.edges())
-      m_ctx.Display(e.shp, AIS_WireFrame, 0, false);
-
-    m_dims.on_sketch_shown();
-
-    if (m_originating_face)
-      m_ctx.Display(m_originating_face, AIS_WireFrame, 0, false);
-
-    if (m_underlay.has_image())
-      m_underlay.rebuild_and_display(m_pln);
-
-    sync_operation_axis_display_();
-    m_node_marks.sync();
-  }
-  else
-  {
-    for (AIS_Shape_ptr& face : m_topo.faces())
-      m_ctx.Erase(face, false);
-
-    for (Edge& e : m_edges.edges())
-      m_ctx.Erase(e.shp, false);
-
-    m_dims.on_sketch_hidden();
-
-    if (m_originating_face)
-      m_ctx.Erase(m_originating_face, false);
-
-    m_underlay.ctx_erase();
-
-    if (m_operation_axis.has_value())
-      m_ctx.Erase(m_operation_axis->shp, false);
-
-    m_nodes.hide_snap_annos();
-    cancel_elm();
-
-    m_node_marks.erase_all();
-  }
-
-  m_ctx.UpdateCurrentViewer();
-
-  m_view.curr_sketch().set_current();
-}
-
-bool Sketch::is_visible() const { return m_visible; }
-
-void Sketch::set_show_faces(bool show)
-{
-  if (show && m_visible)
-    for (AIS_Shape_ptr& face : m_topo.faces())
-      m_ctx.Display(face, AIS_Shaded, 0, false);
-  else
-    for (AIS_Shape_ptr& face : m_topo.faces())
-      m_ctx.Erase(face, false);
-
-  m_show_faces = show;
-}
-
-void Sketch::set_show_edges(bool show)
-{
-  if (show && m_visible)
-    for (Edge& e : m_edges.edges())
-      m_ctx.Display(e.shp, AIS_WireFrame, 0, false);
-  else
-    for (Edge& e : m_edges.edges())
-      m_ctx.Erase(e.shp, false);
-}
-void Sketch::append_list_hover_ais(std::vector<AIS_InteractiveObject_ptr>& out) const
-{
-  if (!m_visible)
-    return;
-
-  for (const Edge& e : m_edges.edges())
-    if (!e.shp.IsNull())
-      out.push_back(e.shp);
-
-  if (m_show_faces)
-    for (const Sketch_face_shp_ptr& face : m_topo.faces())
-      if (!face.IsNull())
-        out.push_back(face);
-
-  if (m_originating_face)
-    out.push_back(m_originating_face);
-
-  if (m_operation_axis.has_value() && !m_operation_axis->shp.IsNull())
-    out.push_back(m_operation_axis->shp);
-
-  if (m_underlay.has_image() && m_underlay.visible())
-    m_underlay.append_list_hover_ais(out);
-}
-bool Sketch::is_current() const { return this == &m_view.curr_sketch(); }
-
-void Sketch::set_current()
-{
-  m_ctx.CurrentViewer()->SetPrivilegedPlane(m_pln.Position());
-  set_edge_style(Edge_style::Full);
-  m_nodes.clear_outside_snap_pnts();
-
-  m_tmp_pts_3d.clear();
-  get_originating_face_snp_pts_3d_(m_tmp_pts_3d);
-
-  for (const gp_Pnt& pt3d : m_tmp_pts_3d)
-    // Insert 2D points on this `m_pln`, points will be considered the same using `Precision::Confusion()`
-    m_nodes.add_outside_snap_pnt(pt3d);
-
-  for (Sketch_ptr& sketch : m_view.get_sketches())
-    if (sketch.get() != this)
-    {
-      sketch->set_edge_style(Edge_style::Background);
-
-      // Hide operation axis from other sketches
-      if (sketch->m_operation_axis.has_value())
-        m_ctx.Erase(sketch->m_operation_axis->shp, false);
-
-      if (sketch->is_visible())
-      {
-        // Add snap points from other sketches, but only if they are visible.
-        sketch->get_snap_pts_3d_(m_tmp_pts_3d);
-        for (const gp_Pnt& pt3d : m_tmp_pts_3d)
-          // Insert 2D points on this `m_pln`, points will be considered the same using `Precision::Confusion()`
-          m_nodes.add_outside_snap_pnt(pt3d);
-      }
-    }
-
-  sync_operation_axis_display_();
-
-  // DBG_MSG("m_outside_snap_pts " << m_nodes.m_outside_snap_pts.size());
-}
-
-void Sketch::set_edge_style(Edge_style style)
-{
-  m_edge_style = style;
-
-  for (Edge& e : m_edges.edges())
-    update_edge_style_(e.shp);
-
-  // Permanent node marker style/visibility is managed elsewhere; avoid
-  // rebuilding marker geometry during sketch switching.
-  update_originating_face_style();
 }
 
 gp_Pnt Sketch::to_3d_(size_t node_idx) const { return to_3d(m_pln, m_nodes[node_idx]); }

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -25,8 +25,6 @@
 
 using namespace glm;
 
-struct Sketch_AIS_node_mark;
-
 namespace
 {
 struct Symmetric_edge_span
@@ -66,6 +64,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln)
     , m_edges(*this)
     , m_topo(*this)
     , m_dims(*this)
+    , m_node_marks(*this)
     , m_underlay(view.ctx())
 {
 }
@@ -79,6 +78,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, cons
     , m_edges(*this)
     , m_topo(*this)
     , m_dims(*this)
+    , m_node_marks(*this)
     , m_underlay(view.ctx())
 {
   m_originating_face = new AIS_Shape(outer_wire);
@@ -99,7 +99,7 @@ Sketch::~Sketch()
   if (m_operation_axis.has_value())
     m_ctx.Remove(m_operation_axis->shp, false);
 
-  remove_all_permanent_node_marks_();
+  m_node_marks.remove_all();
 
   m_ctx.Remove(m_originating_face, true);
 }
@@ -208,14 +208,6 @@ void Sketch::update_edge_style_(AIS_Shape_ptr& shp)
   default:
     EZY_ASSERT(false);
   }
-}
-
-void Sketch::update_node_mark_style_(AIS_Shape_ptr& shp)
-{
-  // Keep permanent node markers visually stable across sketch switching.
-  shp->SetWidth(1.25);
-  shp->SetColor(Quantity_NOC_RED);
-  shp->SetTransparency(0.0);
 }
 
 void Sketch::update_originating_face_style()
@@ -970,7 +962,7 @@ void Sketch::finalize_operation_axis_(Sketch_op_recorder& rec)
 
   cancel_elm(); // Reset state, we have the operation axis
   sync_operation_axis_display_();
-  sync_permanent_node_annos_();
+  m_node_marks.sync();
   m_nodes.hide_snap_annos();
 }
 
@@ -980,7 +972,7 @@ void Sketch::clear_operation_axis()
     m_ctx.Remove(m_operation_axis->shp, false);
 
   m_operation_axis = std::nullopt;
-  sync_permanent_node_annos_();
+  m_node_marks.sync();
   m_nodes.hide_snap_annos();
 }
 
@@ -1252,7 +1244,7 @@ void Sketch::refresh_annotations(const Sketch_annotation_refresh& refresh)
     m_dims.refresh_all_length_dimensions();
 
   if (refresh.permanent_node_marks)
-    sync_permanent_node_annos_();
+    m_node_marks.sync();
 }
 
 size_t Sketch::length_dimension_count() const { return m_dims.length_dimension_count(); }
@@ -1318,7 +1310,7 @@ bool Sketch::cancel_elm()
   m_nodes.hide_snap_annos();
   m_nodes.cancel();
 
-  trim_trailing_permanent_node_marks_();
+  m_node_marks.trim_trailing();
 
   return operation_canceled;
 }
@@ -1408,7 +1400,7 @@ void Sketch::on_mode()
   // Reset state
   cancel_elm();
   sync_operation_axis_display_();
-  sync_permanent_node_annos_();
+  m_node_marks.sync();
 }
 
 bool Sketch::show_operation_axis_() const
@@ -1503,7 +1495,7 @@ void Sketch::set_visible(bool state)
       m_underlay.rebuild_and_display(m_pln);
 
     sync_operation_axis_display_();
-    sync_permanent_node_annos_();
+    m_node_marks.sync();
   }
   else
   {
@@ -1526,7 +1518,7 @@ void Sketch::set_visible(bool state)
     m_nodes.hide_snap_annos();
     cancel_elm();
 
-    erase_permanent_node_marks_();
+    m_node_marks.erase_all();
   }
 
   m_ctx.UpdateCurrentViewer();
@@ -1678,78 +1670,6 @@ std::vector<std::string> Sketch::inspector_face_labels() const
   return labels;
 }
 
-/// Selectable "+" marker for user-placed permanent sketch nodes (add-node tool).
-struct Sketch_AIS_node_mark : public AIS_Shape
-{
-  Sketch_AIS_node_mark(Sketch& owner, size_t node_idx, const TopoDS_Shape& shp);
-  Sketch& owner_sketch;
-  size_t  node_idx{};
-};
-
-bool try_remove_sketch_permanent_node_mark(AIS_Shape* shp)
-{
-  if (!shp)
-    return false;
-
-  if (auto* mark = dynamic_cast<Sketch_AIS_node_mark*>(shp))
-  {
-    mark->owner_sketch.remove_permanent_node_mark(*mark);
-    return true;
-  }
-
-  return false;
-}
-
-void Sketch::sync_permanent_node_annos_()
-{
-  if (m_permanent_node_marks.size() < m_nodes.size())
-    m_permanent_node_marks.resize(m_nodes.size());
-
-  const double size_scale = std::max(static_cast<double>(m_view.gui().permanent_node_anno_scale()), 0.0);
-  const double half_arm   = std::max(m_topo.plane_pick_snap_radius_world() * 0.45 * size_scale, Precision::Confusion() * 50.0);
-
-  const Mode mode = get_mode();
-  // Show "+" markers for permanent user nodes in sketch modes and polar duplicate (which snaps to sketch nodes).
-  // Hide during face extrude so face selection is unobstructed.
-  const bool show_permanent_marks =
-      mode != Mode::Sketch_face_extrude && (is_sketch_mode(mode) || mode == Mode::Shape_polar_duplicate);
-  const bool hide_for_operation_axis = operation_axis_suppresses_sketch_snap_();
-
-  for (size_t i = 0, n = m_nodes.size(); i < n; ++i)
-  {
-    const Sketch_nodes::Node& node = m_nodes[i];
-    const bool show = m_visible && node.permanent && !node.deleted && show_permanent_marks && !hide_for_operation_axis;
-
-    if (!show)
-    {
-      if (m_permanent_node_marks[i])
-      {
-        m_ctx.Remove(m_permanent_node_marks[i], false);
-        m_permanent_node_marks[i].Nullify();
-      }
-      continue;
-    }
-
-    const gp_Pnt2d     p2(node.X(), node.Y());
-    const gp_Pnt       c3    = to_3d(m_pln, p2);
-    const TopoDS_Shape cross = create_plus_cross_shape(m_pln, c3, half_arm);
-
-    if (m_permanent_node_marks[i])
-    {
-      m_permanent_node_marks[i]->Set(cross);
-      update_node_mark_style_(m_permanent_node_marks[i]);
-      m_ctx.Redisplay(m_permanent_node_marks[i], true);
-    }
-    else
-    {
-      Sketch_AIS_node_mark_ptr mk = new Sketch_AIS_node_mark(*this, i, cross);
-      update_node_mark_style_(mk);
-      m_permanent_node_marks[i] = mk;
-      m_ctx.Display(mk, AIS_WireFrame, 0, false);
-    }
-  }
-}
-
 void Sketch::remove_permanent_node_mark(Sketch_AIS_node_mark& mark)
 {
   EZY_ASSERT(&mark.owner_sketch == this);
@@ -1757,67 +1677,7 @@ void Sketch::remove_permanent_node_mark(Sketch_AIS_node_mark& mark)
   EZY_ASSERT(i < m_nodes.size());
   m_nodes[i].deleted = true;
   remove_length_dimensions_referencing_node_(i);
-  if (i < m_permanent_node_marks.size() && m_permanent_node_marks[i].get() == &mark)
-  {
-    m_ctx.Remove(m_permanent_node_marks[i], false);
-    m_permanent_node_marks[i].Nullify();
-  }
+  m_node_marks.remove_at(i);
 
   m_ctx.UpdateCurrentViewer();
-}
-
-void Sketch::remove_permanent_node_mark_ais_at_(size_t node_idx)
-{
-  if (node_idx >= m_permanent_node_marks.size() || m_permanent_node_marks[node_idx].IsNull())
-    return;
-
-  m_ctx.Remove(m_permanent_node_marks[node_idx], false);
-  m_permanent_node_marks[node_idx].Nullify();
-}
-
-void Sketch::remove_all_permanent_node_marks_()
-{
-  for (Sketch_AIS_node_mark_ptr& mk : m_permanent_node_marks)
-    if (mk)
-      m_ctx.Remove(mk, false);
-
-  m_permanent_node_marks.clear();
-}
-
-void Sketch::erase_permanent_node_marks_()
-{
-  for (Sketch_AIS_node_mark_ptr& mk : m_permanent_node_marks)
-    if (mk)
-      m_ctx.Erase(mk, false);
-}
-
-void Sketch::trim_trailing_permanent_node_marks_()
-{
-  while (m_permanent_node_marks.size() > m_nodes.size())
-  {
-    const size_t last = m_permanent_node_marks.size() - 1;
-    if (m_permanent_node_marks[last])
-      m_ctx.Remove(m_permanent_node_marks[last], false);
-
-    m_permanent_node_marks.pop_back();
-  }
-}
-
-Sketch_AIS_edge::Sketch_AIS_edge(Sketch& owner, const TopoDS_Shape& shp)
-    : AIS_Shape(shp)
-    , owner_sketch(owner)
-{
-}
-
-Sketch_AIS_node_mark::Sketch_AIS_node_mark(Sketch& owner, size_t node_idx, const TopoDS_Shape& shp)
-    : AIS_Shape(shp)
-    , owner_sketch(owner)
-    , node_idx(node_idx)
-{
-}
-
-Sketch_face_shp::Sketch_face_shp(Sketch& owner, const TopoDS_Shape& face)
-    : owner_sketch(owner)
-    , AIS_Shape(face)
-{
 }

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -1,11 +1,7 @@
 #include "sketch.h"
-#include "utl_occt.h"
 
 #include <BRepBuilderAPI_MakeEdge.hxx>
-#include <BRepBuilderAPI_MakeFace.hxx>
-#include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepPrimAPI_MakeRevol.hxx>
-#include <BRepTools.hxx>
 #include <GC_MakeArcOfCircle.hxx>
 #include <Graphic3d_AspectFillArea3d.hxx>
 #include <Precision.hxx>
@@ -17,19 +13,14 @@
 #include <V3d_View.hxx>
 #include <cmath>
 #include <functional>
-#include <glm/glm.hpp>
-#include <limits>
 #include <map>
-#include <numbers>
-#include <tuple>
-#include <unordered_set>
 
 #include "utl_geom.h"
 #include "gui.h"
-#include "imgui.h"
 #include "mode.h"
 #include "occt_view.h"
 #include "sketch_delta.h"
+#include "utl_occt.h"
 #include "utl.h"
 
 using namespace glm;

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -73,6 +73,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln)
     , m_name(name)
     , m_nodes(view, pln)
     , m_topo(*this)
+    , m_dims(*this)
     , m_underlay(view.ctx())
 {
 }
@@ -84,6 +85,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, cons
     , m_name(name)
     , m_nodes(view, pln)
     , m_topo(*this)
+    , m_dims(*this)
     , m_underlay(view.ctx())
 {
   m_originating_face = new AIS_Shape(outer_wire);
@@ -103,11 +105,7 @@ Sketch::~Sketch()
   for (Edge& e : m_edges)
     remove_edge(e);
 
-  for (Length_dimension& ld : m_length_dimensions)
-    if (!ld.dim.IsNull())
-      m_ctx.Remove(ld.dim, false);
-
-  m_length_dimensions.clear();
+  m_dims.remove_displayed();
 
   m_topo.remove_displayed_faces();
 
@@ -115,9 +113,6 @@ Sketch::~Sketch()
     remove_edge(*m_operation_axis);
 
   remove_all_permanent_node_marks_();
-
-  if (m_len_dim_rubber_shp)
-    m_ctx.Remove(m_len_dim_rubber_shp, false);
 
   m_ctx.Remove(m_originating_face, true);
 }
@@ -164,7 +159,7 @@ void Sketch::sketch_pt_move(const ScreenCoords& screen_coords)
 
     case Mode::Sketch_dim_anno:
       (void)m_nodes.try_pick_existing_node(screen_coords);
-      update_len_dim_rubber_line_(screen_coords);
+      m_dims.update_len_dim_rubber_line_(screen_coords);
       break;
     
     case Mode::Sketch_add_rectangle:
@@ -180,13 +175,13 @@ void Sketch::sketch_pt_move(const ScreenCoords& screen_coords)
 
 void Sketch::dimension_input(const ScreenCoords& screen_coords)
 {
-  m_show_dim_input = true;
+  m_dims.set_show_dim_input(true);
   sketch_pt_move(screen_coords);
 }
 
 void Sketch::angle_input(const ScreenCoords& screen_coords)
 {
-  m_show_angle_input = true;
+  m_dims.set_show_angle_input(true);
   sketch_pt_move(screen_coords);
 }
 
@@ -299,11 +294,17 @@ void Sketch::on_enter()
     case Mode::Sketch_add_rectangle_center_pt:
     case Mode::Sketch_add_circle:
     case Mode::Sketch_add_node:
-      check_dimension_rubber_();
+      m_dims.check_dimension_rubber_();
       break;
-    case Mode::Sketch_add_edge:         check_dimension_seg_(Linestring_type::Single);    break;
-    case Mode::Sketch_add_slot:         check_dimension_seg_(Linestring_type::Two);       break;
-    case Mode::Sketch_add_multi_edges:  check_dimension_seg_(Linestring_type::Multiple);  break;
+    case Mode::Sketch_add_edge:
+      m_dims.check_dimension_seg_(static_cast<int>(Linestring_type::Single));
+      break;
+    case Mode::Sketch_add_slot:
+      m_dims.check_dimension_seg_(static_cast<int>(Linestring_type::Two));
+      break;
+    case Mode::Sketch_add_multi_edges:
+      m_dims.check_dimension_seg_(static_cast<int>(Linestring_type::Multiple));
+      break;
     // clang-format on
   default:
     break;
@@ -326,16 +327,16 @@ bool Sketch::complete_edge_from_center_(const ScreenCoords& screen_coords)
   const gp_Pnt2d& center = m_nodes[edge.node_idx_a];
 
   std::optional<Symmetric_edge_span> span;
-  if (m_entered_edge_len.has_value())
-    span = symmetric_edge_from_center(center, m_entered_edge_len->dir, m_entered_edge_len->len);
+  if (m_dims.entered_edge_len().has_value())
+    span = symmetric_edge_from_center(center, m_dims.entered_edge_len()->dir, m_dims.entered_edge_len()->len);
 
-  else if (m_entered_edge_angle.has_value())
+  else if (m_dims.entered_edge_angle().has_value())
   {
     std::optional<gp_Pnt2d> pt_opt = m_view.pt_on_plane(screen_coords, m_pln);
     if (!pt_opt)
       return true;
 
-    const double angle_rad = to_radians(*m_entered_edge_angle);
+    const double angle_rad = to_radians(*m_dims.entered_edge_angle());
     gp_Dir2d     dir(std::cos(angle_rad), std::sin(angle_rad));
     gp_Vec2d     to_click(center, *pt_opt);
     const double half = std::abs(to_click.Dot(gp_Vec2d(dir)));
@@ -355,10 +356,10 @@ bool Sketch::complete_edge_from_center_(const ScreenCoords& screen_coords)
 
   edge.node_idx_a = m_nodes.get_node_exact(span->pt_a);
   update_edge_end_pt_(edge, m_nodes.get_node_exact(span->pt_b));
-  m_entered_edge_angle = std::nullopt;
-  m_entered_edge_len   = std::nullopt;
-  m_show_angle_input   = false;
-  m_show_dim_input     = false;
+  m_dims.entered_edge_angle() = std::nullopt;
+  m_dims.entered_edge_len()   = std::nullopt;
+  m_dims.set_show_angle_input(false);
+  m_dims.set_show_dim_input(false);
   m_view.gui().hide_angle_edit();
   finalize_elm();
   return true;
@@ -397,15 +398,15 @@ void Sketch::add_line_string_pt_(const ScreenCoords& screen_coords, Linestring_t
     }
 
     // Start a new edge - clear constraints for fresh start (click path for multi-line)
-    m_entered_edge_angle = std::nullopt;
-    m_entered_edge_len   = std::nullopt;
-    m_show_angle_input   = false;
+    m_dims.entered_edge_angle() = std::nullopt;
+    m_dims.entered_edge_len()   = std::nullopt;
+    m_dims.set_show_angle_input(false);
     m_view.gui().hide_angle_edit();
     m_tmp_edges.push_back({node_idx});
   };
 
   // When angle constraint is active, finalize on the constrained line (project click onto it)
-  if (m_entered_edge_angle.has_value() && m_tmp_edges.size())
+  if (m_dims.entered_edge_angle().has_value() && m_tmp_edges.size())
   {
     if (edge_from_center_active_())
     {
@@ -418,7 +419,7 @@ void Sketch::add_line_string_pt_(const ScreenCoords& screen_coords, Linestring_t
       return;
 
     const gp_Pnt2d& pt_a      = m_nodes[m_tmp_edges.back().node_idx_a];
-    double          angle_rad = to_radians(*m_entered_edge_angle);
+    double          angle_rad = to_radians(*m_dims.entered_edge_angle());
     gp_Dir2d        constrained_dir(std::cos(angle_rad), std::sin(angle_rad));
     gp_Vec2d        to_click(pt_opt->X() - pt_a.X(), pt_opt->Y() - pt_a.Y());
     double          dist_along = to_click.Dot(gp_Vec2d(constrained_dir));
@@ -446,12 +447,12 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
       const gp_Pnt2d& center = m_nodes[edge.node_idx_a];
 
       std::optional<Symmetric_edge_span> span;
-      if (m_entered_edge_angle.has_value())
+      if (m_dims.entered_edge_angle().has_value())
       {
-        const double angle_rad = to_radians(*m_entered_edge_angle);
+        const double angle_rad = to_radians(*m_dims.entered_edge_angle());
         gp_Dir2d     dir(std::cos(angle_rad), std::sin(angle_rad));
-        if (m_entered_edge_len.has_value())
-          span = symmetric_edge_from_center(center, dir, m_entered_edge_len->len);
+        if (m_dims.entered_edge_len().has_value())
+          span = symmetric_edge_from_center(center, dir, m_dims.entered_edge_len()->len);
         else
         {
           gp_Vec2d     to_mouse(center, pt_b);
@@ -459,8 +460,8 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
           span              = symmetric_edge_from_center(center, dir, half * 2.0);
         }
       }
-      else if (m_entered_edge_len.has_value())
-        span = symmetric_edge_from_center(center, m_entered_edge_len->dir, m_entered_edge_len->len);
+      else if (m_dims.entered_edge_len().has_value())
+        span = symmetric_edge_from_center(center, m_dims.entered_edge_len()->dir, m_dims.entered_edge_len()->len);
       else
         span = symmetric_edge_from_center_and_hint(center, pt_b);
 
@@ -471,8 +472,7 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
           m_ctx.Remove(edge.shp, true);
           edge.shp.Nullify();
         }
-        m_ctx.Remove(m_tmp_dim_anno, true);
-        m_tmp_dim_anno.Nullify();
+        m_dims.clear_tmp_dim_anno();
         return;
       }
 
@@ -481,43 +481,10 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
       update_edge_shp_(edge, span_a, span_b);
 
       const double dist = span->full_len / m_view.get_dimension_scale();
-      m_ctx.Remove(m_tmp_dim_anno, true);
-      m_tmp_dim_anno = create_distance_annotation(
-          span_a, span_b, m_pln, m_view.gui().length_dimension_style(), approx_sketch_interior_ref_3d_(),
-          m_topo.dim_classifier_faces().empty() ? nullptr : &m_topo.dim_classifier_faces());
-      m_tmp_dim_anno->SetCustomValue(dist);
-      m_ctx.Display(m_tmp_dim_anno, true);
-
-      if (m_show_dim_input)
-      {
-        gp_Dir2d     edge_dir = get_unit_dir(span_a, span_b);
-        ScreenCoords spos     = m_view.get_screen_coords(to_3d(m_pln, center_point(span_a, span_b)));
-        auto         cb       = [&, edge_dir](float new_dist, bool is_finial)
-        {
-          m_entered_edge_len = {edge_dir, new_dist * m_view.get_dimension_scale()};
-          m_show_dim_input   = !is_finial;
-          if (is_finial)
-            on_enter();
-        };
-        m_view.gui().set_dist_edit(float(dist), std::move(std::function<void(float, bool)>(cb)), spos);
-      }
-
-      if (m_show_angle_input)
-      {
-        ScreenCoords spos = m_view.get_screen_coords(to_3d(m_pln, center_point(span_a, span_b)));
-        gp_Vec2d     vec(center, pt_b);
-        double       current_angle_deg = to_degrees(std::atan2(vec.Y(), vec.X()));
-        auto         cb                = [&](float new_angle, bool is_finial)
-        {
-          m_entered_edge_angle = new_angle;
-          m_show_angle_input   = !is_finial;
-          ScreenCoords current_pos(dvec2(ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y));
-          sketch_pt_move(current_pos);
-        };
-
-        float angle_to_show = m_entered_edge_angle.has_value() ? float(*m_entered_edge_angle) : float(current_angle_deg);
-        m_view.gui().set_angle_edit(angle_to_show, std::move(std::function<void(float, bool)>(cb)), spos);
-      }
+      m_dims.show_tmp_dim_preview(span_a, span_b);
+      m_dims.offer_dist_edit_for_segment(span_a, span_b, dist);
+      m_dims.offer_angle_edit_for_segment(center, pt_b,
+                                          to_degrees(std::atan2(gp_Vec2d(center, pt_b).Y(), gp_Vec2d(center, pt_b).X())));
     };
 
     move_sketch_pt_(screen_coords, l);
@@ -539,16 +506,16 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
     gp_Pnt2d final_pt_b = pt_b;
 
     // Apply angle constraint if set - this takes priority
-    if (m_entered_edge_angle.has_value())
+    if (m_dims.entered_edge_angle().has_value())
     {
       // Calculate direction based on angle (0 degrees = positive X axis, counterclockwise)
-      double   angle_rad = to_radians(*m_entered_edge_angle);
+      double   angle_rad = to_radians(*m_dims.entered_edge_angle());
       gp_Dir2d constrained_dir(std::cos(angle_rad), std::sin(angle_rad));
 
       // If distance is also constrained, use that
-      if (m_entered_edge_len.has_value())
+      if (m_dims.entered_edge_len().has_value())
         // Use the constrained distance - angle constraint is always enforced
-        final_pt_b = gp_Pnt2d(pt_a).Translated(gp_Vec2d(constrained_dir) * m_entered_edge_len->len);
+        final_pt_b = gp_Pnt2d(pt_a).Translated(gp_Vec2d(constrained_dir) * m_dims.entered_edge_len()->len);
       else
       {
         // Project the mouse point onto the angle-constrained line
@@ -565,9 +532,9 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
       edge.node_idx_b = std::nullopt;
     }
     // Apply distance constraint if set (and angle is not set)
-    else if (m_entered_edge_len.has_value())
+    else if (m_dims.entered_edge_len().has_value())
     {
-      final_pt_b      = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_entered_edge_len->dir) * m_entered_edge_len->len);
+      final_pt_b      = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_dims.entered_edge_len()->dir) * m_dims.entered_edge_len()->len);
       edge.node_idx_b = m_nodes.try_get_node_idx_snap(final_pt_b);
     }
     else
@@ -579,62 +546,11 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
     }
 
     double dist = pt_a.Distance(final_pt_b) / m_view.get_dimension_scale();
-    m_ctx.Remove(m_tmp_dim_anno, true);
-    // When angle constraint is active, final_pt_b is the projection of the mouse onto the constrained
-    // line; if the mouse is (nearly) perpendicular to that line, the projection coincides with pt_a.
-    if (unique(pt_a, final_pt_b))
-    {
-      m_tmp_dim_anno = create_distance_annotation(
-          pt_a, final_pt_b, m_pln, m_view.gui().length_dimension_style(), approx_sketch_interior_ref_3d_(),
-          m_topo.dim_classifier_faces().empty() ? nullptr : &m_topo.dim_classifier_faces());
+    m_dims.show_tmp_dim_preview(pt_a, final_pt_b);
+    m_dims.offer_dist_edit_for_segment(pt_a, final_pt_b, dist);
 
-      m_tmp_dim_anno->SetCustomValue(dist);
-      m_ctx.Display(m_tmp_dim_anno, true);
-    }
-    else
-      m_tmp_dim_anno.Nullify();
-
-    if (m_show_dim_input && unique(pt_a, final_pt_b))
-    {
-      gp_Dir2d     edge_dir = get_unit_dir(pt_a, final_pt_b);
-      ScreenCoords spos     = m_view.get_screen_coords(to_3d(m_pln, center_point(pt_a, final_pt_b)));
-
-      auto l = [&, edge_dir](float new_dist, bool is_finial)
-      {
-        m_entered_edge_len = {edge_dir, new_dist * m_view.get_dimension_scale()};
-
-        m_show_dim_input = !is_finial;
-        if (is_finial)
-          on_enter();
-      };
-
-      m_view.gui().set_dist_edit(float(dist), std::move(std::function<void(float, bool)>(l)), spos);
-    }
-
-    if (m_show_angle_input)
-    {
-      ScreenCoords spos = m_view.get_screen_coords(to_3d(m_pln, center_point(pt_a, final_pt_b)));
-
-      // Calculate current angle from pt_a to actual mouse position (pt_b), not constrained position
-      // This ensures we show the actual angle the user is moving to
-      gp_Vec2d vec(pt_a, pt_b);
-      double   current_angle_rad = std::atan2(vec.Y(), vec.X());
-      double   current_angle_deg = to_degrees(current_angle_rad);
-
-      auto l = [&](float new_angle, bool is_finial)
-      {
-        m_entered_edge_angle = new_angle;
-        m_show_angle_input   = !is_finial;
-        // Recalculate the point with the new angle using current mouse position
-        // Get current mouse position from ImGui
-        ScreenCoords current_pos(dvec2(ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y));
-        sketch_pt_move(current_pos);
-      };
-
-      // Use the current mouse angle if angle hasn't been set yet, otherwise use the set angle
-      float angle_to_show = m_entered_edge_angle.has_value() ? float(*m_entered_edge_angle) : float(current_angle_deg);
-      m_view.gui().set_angle_edit(angle_to_show, std::move(std::function<void(float, bool)>(l)), spos);
-    }
+    gp_Vec2d vec(pt_a, pt_b);
+    m_dims.offer_angle_edit_for_segment(pt_a, pt_b, to_degrees(std::atan2(vec.Y(), vec.X())));
 
     if (unique(pt_a, final_pt_b))
       update_edge_shp_(edge, pt_a, final_pt_b);
@@ -802,22 +718,21 @@ void Sketch::add_node_pt_(const ScreenCoords& screen_coords)
       // a sketch edge between the anchor and the new node - only nodes and interior splits matter.
       m_tmp_node_idxs.clear();
       clear_tmps_();
-      m_ctx.Remove(m_tmp_dim_anno, true);
-      m_tmp_dim_anno.Nullify();
+      m_dims.clear_tmp_dim_anno();
       m_nodes.hide_snap_annos();
       update_faces_();
       rec.commit();
     }
   };
 
-  if (m_entered_edge_angle.has_value() && m_tmp_edges.size())
+  if (m_dims.entered_edge_angle().has_value() && m_tmp_edges.size())
   {
     std::optional<gp_Pnt2d> pt_opt = m_view.pt_on_plane(screen_coords, m_pln);
     if (!pt_opt)
       return;
 
     const gp_Pnt2d& pt_a      = m_nodes[m_tmp_edges.back().node_idx_a];
-    double          angle_rad = to_radians(*m_entered_edge_angle);
+    double          angle_rad = to_radians(*m_dims.entered_edge_angle());
     gp_Dir2d        constrained_dir(std::cos(angle_rad), std::sin(angle_rad));
     gp_Vec2d        to_click(pt_opt->X() - pt_a.X(), pt_opt->Y() - pt_a.Y());
     double          dist_along = to_click.Dot(gp_Vec2d(constrained_dir));
@@ -852,10 +767,10 @@ void Sketch::add_node_pt_(const ScreenCoords& screen_coords)
     {
       auto start_rubber_from_anchor = [this](size_t idx_a)
       {
-        m_entered_edge_angle = std::nullopt;
-        m_entered_edge_len   = std::nullopt;
-        m_show_angle_input   = false;
-        m_show_dim_input     = false;
+        m_dims.entered_edge_angle() = std::nullopt;
+        m_dims.entered_edge_len()   = std::nullopt;
+        m_dims.set_show_angle_input(false);
+        m_dims.set_show_dim_input(false);
         m_view.gui().hide_angle_edit();
         m_tmp_edges.push_back({idx_a});
       };
@@ -869,8 +784,7 @@ void Sketch::add_node_pt_(const ScreenCoords& screen_coords)
       const size_t ni = m_nodes.add_new_node(pt, false, true);
       rec.note_curr_node(ni);
       m_topo.split_linear_edges_at_node_if_interior(ni, rec);
-      m_ctx.Remove(m_tmp_dim_anno, true);
-      m_tmp_dim_anno.Nullify();
+      m_dims.clear_tmp_dim_anno();
       m_nodes.hide_snap_annos();
       update_faces_();
       rec.commit();
@@ -1253,122 +1167,6 @@ template <typename Callback> void Sketch::if_edge_pt_valid_(Callback&& callback)
       callback(e, pt_a, *m_last_pt);
 }
 
-void Sketch::check_dimension_seg_(Linestring_type linestring_type)
-{
-  if (!m_entered_edge_len.has_value())
-    return;
-
-  if (m_entered_edge_len->len <= Precision::Confusion())
-    return;
-
-  EZY_ASSERT(m_tmp_edges.size());
-
-  Edge& edge = m_tmp_edges.back();
-  if (edge_from_center_active_() && linestring_type == Linestring_type::Single)
-  {
-    const gp_Pnt2d&                    center = m_nodes[edge.node_idx_a];
-    std::optional<Symmetric_edge_span> span =
-        symmetric_edge_from_center(center, m_entered_edge_len->dir, m_entered_edge_len->len);
-
-    if (span)
-    {
-      edge.node_idx_a = m_nodes.get_node_exact(span->pt_a);
-      update_edge_end_pt_(edge, m_nodes.get_node_exact(span->pt_b));
-      clear_all(m_entered_edge_len);
-      finalize_elm();
-    }
-    return;
-  }
-
-  const gp_Pnt2d& pt_a = m_nodes[edge.node_idx_a];
-  m_last_pt            = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_entered_edge_len->dir) * m_entered_edge_len->len);
-
-  update_edge_end_pt_(edge, m_nodes.get_node_exact(*m_last_pt));
-
-  EZY_ASSERT(edge.node_idx_b.has_value());
-
-  clear_all(m_entered_edge_len);
-
-  if (linestring_type == Linestring_type::Single)
-    finalize_elm();
-
-  else if (linestring_type == Linestring_type::Two)
-  {
-    switch (m_tmp_edges.size())
-    {
-    case 1:
-      m_entered_edge_angle = std::nullopt;
-      m_show_angle_input   = false;
-      m_view.gui().hide_angle_edit();
-      m_tmp_edges.push_back({*edge.node_idx_b});
-      break;
-
-    case 2:
-      finalize_elm();
-      break;
-
-    default:
-      EZY_ASSERT(false);
-    }
-  }
-  else
-  {
-    // Next segment must not inherit the previous angle constraint
-    m_entered_edge_angle = std::nullopt;
-    m_show_angle_input   = false;
-    m_view.gui().hide_angle_edit();
-    m_tmp_edges.push_back({*edge.node_idx_b});
-  }
-}
-
-void Sketch::check_dimension_rubber_()
-{
-  if (!m_entered_edge_len.has_value())
-    return;
-
-  if (m_entered_edge_len->len <= Precision::Confusion())
-    return;
-
-  if (m_tmp_edges.empty())
-    return;
-
-  Edge&           edge = m_tmp_edges.back();
-  const gp_Pnt2d& pt_a = m_nodes[edge.node_idx_a];
-  m_last_pt            = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_entered_edge_len->dir) * m_entered_edge_len->len);
-
-  if (!unique(pt_a, *m_last_pt))
-    return;
-
-  const Mode mode = get_mode();
-  if (mode == Mode::Sketch_add_square || mode == Mode::Sketch_add_circle || mode == Mode::Sketch_add_rectangle ||
-      mode == Mode::Sketch_add_rectangle_center_pt)
-  {
-    update_edge_end_pt_(edge, m_nodes.get_node_exact(*m_last_pt));
-    EZY_ASSERT(edge.node_idx_b.has_value());
-    clear_all(m_entered_edge_len);
-    finalize_elm();
-    return;
-  }
-
-  EZY_ASSERT(mode == Mode::Sketch_add_node);
-  const size_t b = m_nodes.get_node_exact(*m_last_pt, true);
-  clear_all(m_entered_edge_len);
-
-  Sketch_op_recorder rec(m_view, *this);
-  {
-    rec.note_curr_node(b);
-    m_topo.split_linear_edges_at_node_if_interior(b, rec);
-
-    m_tmp_node_idxs.clear();
-    clear_tmps_();
-    m_ctx.Remove(m_tmp_dim_anno, true);
-    m_tmp_dim_anno.Nullify();
-    m_nodes.hide_snap_annos();
-    update_faces_();
-    rec.commit();
-  }
-}
-
 void Sketch::finalize_add_node_elm_cleanup_()
 {
   if (!m_tmp_edges.empty() && !m_tmp_edges.back().node_idx_b.has_value())
@@ -1561,247 +1359,80 @@ std::list<Sketch::Edge>::iterator Sketch::get_edge_at_(const ScreenCoords& scree
 
   return m_edges.end();
 }
+bool Sketch::try_remove_length_dimension(PrsDim_LengthDimension* dim) { return m_dims.try_remove_length_dimension(dim); }
 
-void Sketch::clear_len_dim_rubber_line_()
-{
-  if (m_len_dim_rubber_shp)
-  {
-    m_ctx.Remove(m_len_dim_rubber_shp, false);
-    m_len_dim_rubber_shp.Nullify();
-  }
-}
-
-void Sketch::clear_len_dim_pick_state_()
-{
-  m_len_dim_pick_anchor_node.reset();
-  clear_len_dim_rubber_line_();
-}
-
-void Sketch::update_len_dim_rubber_line_(const ScreenCoords& screen_coords)
-{
-  if (!m_len_dim_pick_anchor_node.has_value())
-  {
-    clear_len_dim_rubber_line_();
-    return;
-  }
-
-  const gp_Pnt2d&         pt_a   = m_nodes[*m_len_dim_pick_anchor_node];
-  std::optional<gp_Pnt2d> pt_opt = m_view.pt_on_plane(screen_coords, m_pln);
-  if (!pt_opt)
-    return;
-
-  gp_Pnt2d pt_b = *pt_opt;
-  (void)m_nodes.try_get_node_idx_snap(pt_b);
-
-  if (!unique(pt_a, pt_b))
-  {
-    clear_len_dim_rubber_line_();
-    return;
-  }
-
-  const TopoDS_Shape edge_shape = BRepBuilderAPI_MakeEdge(to_3d(m_pln, pt_a), to_3d(m_pln, pt_b)).Edge();
-
-  if (m_len_dim_rubber_shp)
-  {
-    m_len_dim_rubber_shp->Set(edge_shape);
-    update_edge_style_(m_len_dim_rubber_shp);
-    m_ctx.Redisplay(m_len_dim_rubber_shp, true);
-  }
-  else
-  {
-    m_len_dim_rubber_shp = new AIS_Shape(edge_shape);
-    update_edge_style_(m_len_dim_rubber_shp);
-    m_ctx.Display(m_len_dim_rubber_shp, AIS_WireFrame, 0, true);
-  }
-}
-
-std::optional<gp_Pnt> Sketch::approx_sketch_interior_ref_3d_() const
-{
-  gp_XYZ acc(0., 0., 0.);
-  size_t n = 0;
-  for (size_t i = 0; i < m_nodes.size(); ++i)
-  {
-    if (m_nodes[i].deleted)
-      continue;
-
-    acc += to_3d_(i).XYZ();
-    ++n;
-  }
-  if (n == 0)
-    return std::nullopt;
-
-  return gp_Pnt(acc / static_cast<double>(n));
-}
-
-void Sketch::rebuild_length_dimension_display_(Length_dimension& d)
-{
-  if (!d.dim.IsNull())
-    m_ctx.Remove(d.dim, false);
-
-  d.dim = create_distance_annotation(m_nodes[d.node_idx_lo], m_nodes[d.node_idx_hi], m_pln,
-                                     m_view.gui().length_dimension_style(), approx_sketch_interior_ref_3d_(),
-                                     m_topo.dim_classifier_faces().empty() ? nullptr : &m_topo.dim_classifier_faces());
-
-  const double dist = m_nodes[d.node_idx_lo].Distance(m_nodes[d.node_idx_hi]);
-  d.dim->SetCustomValue(dist / m_view.get_dimension_scale());
-  if (d.flyout_offset.has_value() && *d.flyout_offset > 0.0)
-  {
-    const double f    = d.dim->GetFlyout();
-    const double sign = f < 0.0 ? -1.0 : 1.0;
-    d.dim->SetFlyout(static_cast<double>(sign * *d.flyout_offset));
-  }
-
-  if (m_visible && m_show_dims && d.visible)
-    m_ctx.Display(d.dim, false);
-}
-
-void Sketch::purge_stale_length_dimensions_()
-{
-  for (auto it = m_length_dimensions.begin(); it != m_length_dimensions.end();)
-  {
-    const bool bad = it->node_idx_lo >= m_nodes.size() || it->node_idx_hi >= m_nodes.size() ||
-                     m_nodes[it->node_idx_lo].deleted || m_nodes[it->node_idx_hi].deleted;
-    if (bad)
-    {
-      if (!it->dim.IsNull())
-        m_ctx.Remove(it->dim, true);
-
-      it = m_length_dimensions.erase(it);
-    }
-    else
-      ++it;
-  }
-}
-
-void Sketch::refresh_all_length_dimensions_()
-{
-  for (Length_dimension& d : m_length_dimensions)
-    rebuild_length_dimension_display_(d);
-}
-
-void Sketch::remove_length_dimensions_referencing_node_(size_t node_idx)
-{
-  for (auto it = m_length_dimensions.begin(); it != m_length_dimensions.end();)
-    if (it->node_idx_lo == node_idx || it->node_idx_hi == node_idx)
-    {
-      if (!it->dim.IsNull())
-        m_ctx.Remove(it->dim, true);
-
-      it = m_length_dimensions.erase(it);
-    }
-    else
-      ++it;
-}
-
-void Sketch::add_or_toggle_length_dim_between_node_indices_(size_t node_a, size_t node_b)
-{
-  const size_t lo = std::min(node_a, node_b);
-  const size_t hi = std::max(node_a, node_b);
-  if (lo == hi)
-    return;
-
-  for (auto it = m_length_dimensions.begin(); it != m_length_dimensions.end(); ++it)
-    if (it->node_idx_lo == lo && it->node_idx_hi == hi)
-    {
-      Sketch_op_recorder rec(m_view, *this);
-      rec.note_prev_length_dim(lo, hi, it->visible, it->flyout_offset, it->name);
-      if (!it->dim.IsNull())
-        m_ctx.Remove(it->dim, true);
-
-      m_length_dimensions.erase(it);
-      rec.commit();
-      return;
-    }
-
-  Sketch_op_recorder rec(m_view, *this);
-  {
-    Length_dimension d;
-    d.node_idx_lo = lo;
-    d.node_idx_hi = hi;
-    m_length_dimensions.push_back(std::move(d));
-    rebuild_length_dimension_display_(m_length_dimensions.back());
-    rec.note_curr_length_dim(lo, hi, m_length_dimensions.back().visible, m_length_dimensions.back().flyout_offset,
-                             m_length_dimensions.back().name);
-    rec.commit();
-  }
-}
+void Sketch::toggle_edge_dim_anno(const ScreenCoords& screen_coords) { m_dims.toggle_edge_dim_anno(screen_coords); }
 
 void Sketch::json_add_length_dimension_(size_t node_a, size_t node_b, const bool visible,
                                         const std::optional<double> flyout_offset, const std::string& name)
 {
-  const size_t lo = std::min(node_a, node_b);
-  const size_t hi = std::max(node_a, node_b);
-  if (lo == hi)
-    return;
-
-  for (const Length_dimension& x : m_length_dimensions)
-    if (x.node_idx_lo == lo && x.node_idx_hi == hi)
-      return;
-
-  Length_dimension d;
-  d.node_idx_lo   = lo;
-  d.node_idx_hi   = hi;
-  d.visible       = visible;
-  d.flyout_offset = flyout_offset;
-  d.name          = name;
-  m_length_dimensions.push_back(std::move(d));
-  rebuild_length_dimension_display_(m_length_dimensions.back());
+  m_dims.json_add_length_dimension_(node_a, node_b, visible, flyout_offset, name);
 }
 
-bool Sketch::try_remove_length_dimension(PrsDim_LengthDimension* dim)
+void Sketch::remove_length_dimensions_referencing_node_(size_t node_idx)
 {
-  if (!dim)
-    return false;
-
-  for (auto it = m_length_dimensions.begin(); it != m_length_dimensions.end(); ++it)
-    if (it->dim.get() == dim)
-    {
-      m_ctx.Remove(it->dim, true);
-      m_length_dimensions.erase(it);
-      return true;
-    }
-
-  return false;
+  m_dims.remove_length_dimensions_referencing_node_(node_idx);
 }
 
-void Sketch::toggle_edge_dim_anno(const ScreenCoords& screen_coords)
+void Sketch::set_show_dims(bool show) { m_dims.set_show_dims(show); }
+
+bool Sketch::shows_dimensions() const { return m_dims.shows_dimensions(); }
+
+bool Sketch::dimension_visible(size_t dim_index) const { return m_dims.dimension_visible(dim_index); }
+
+void Sketch::set_dimension_visible(size_t dim_index, bool visible) { m_dims.set_dimension_visible(dim_index, visible); }
+
+size_t Sketch::dimension_node_lo(size_t dim_index) const { return m_dims.dimension_node_lo(dim_index); }
+
+size_t Sketch::dimension_node_hi(size_t dim_index) const { return m_dims.dimension_node_hi(dim_index); }
+
+double Sketch::dimension_offset(size_t dim_index) const { return m_dims.dimension_offset(dim_index); }
+
+void Sketch::set_dimension_offset(size_t dim_index, const double offset) { m_dims.set_dimension_offset(dim_index, offset); }
+
+std::string Sketch::dimension_name(size_t dim_index) const { return m_dims.dimension_name(dim_index); }
+
+void Sketch::set_dimension_name(size_t dim_index, const std::string& name) { m_dims.set_dimension_name(dim_index, name); }
+
+PrsDim_LengthDimension_ptr Sketch::length_dimension_handle(const size_t dim_index) const
 {
-  if (std::optional<size_t> n = m_nodes.try_pick_existing_node(screen_coords))
+  return m_dims.length_dimension_handle(dim_index);
+}
+
+void Sketch::refresh_annotations(const Sketch_annotation_refresh& refresh)
+{
+  if (refresh.length_dimensions)
+    m_dims.refresh_all_length_dimensions();
+
+  if (refresh.permanent_node_marks)
+    sync_permanent_node_annos_();
+}
+
+size_t Sketch::length_dimension_count() const { return m_dims.length_dimension_count(); }
+
+std::vector<std::string> Sketch::inspector_dimension_labels() const { return m_dims.inspector_dimension_labels(); }
+
+std::vector<std::string> Sketch::inspector_node_labels() const
+{
+  std::vector<std::string> labels;
+  for (size_t i = 0; i < m_nodes.size(); ++i)
   {
-    if (!m_len_dim_pick_anchor_node.has_value())
+    const Sketch_nodes::Node& n = m_nodes[i];
+    if (n.permanent && !n.deleted)
     {
-      m_len_dim_pick_anchor_node = *n;
-      update_len_dim_rubber_line_(screen_coords);
-      return;
+      std::string lbl = n.name.empty() ? ("N" + std::to_string(i)) : n.name;
+      labels.push_back(std::move(lbl));
     }
-
-    if (*m_len_dim_pick_anchor_node != *n)
-      add_or_toggle_length_dim_between_node_indices_(*m_len_dim_pick_anchor_node, *n);
-
-    clear_len_dim_pick_state_();
-    return;
   }
 
-  if (std::list<Edge>::iterator itr = get_edge_at_(screen_coords); itr != m_edges.end())
-    if (!itr->circle_arc && itr->node_idx_b.has_value() && !itr->node_idx_arc.has_value())
-    {
-      add_or_toggle_length_dim_between_node_indices_(itr->node_idx_a, *itr->node_idx_b);
-      clear_len_dim_pick_state_();
-      return;
-    }
-
-  clear_len_dim_pick_state_();
+  return labels;
 }
 
 void Sketch::finalize_elm()
 {
   Sketch_op_recorder rec(m_view, *this);
   {
-    m_show_dim_input     = false;
-    m_show_angle_input   = false;
-    m_entered_edge_angle = std::nullopt;
-    m_view.gui().hide_angle_edit();
-    m_ctx.Remove(m_tmp_dim_anno, true);
+    m_dims.on_finalize_elm_start();
 
     switch (get_mode())
     {
@@ -1835,8 +1466,8 @@ void Sketch::finalize_elm()
 bool Sketch::cancel_elm()
 {
   bool operation_canceled = clear_tmps_();
-  clear_len_dim_pick_state_();
-  m_ctx.Remove(m_tmp_dim_anno, true);
+  m_dims.clear_pick_state();
+  m_dims.clear_tmp_dim_anno();
   m_nodes.hide_snap_annos();
   m_nodes.cancel();
 
@@ -1844,7 +1475,6 @@ bool Sketch::cancel_elm()
 
   return operation_canceled;
 }
-
 bool Sketch::s_add_mid_pt_edges = false;
 bool Sketch::s_edge_from_center = false;
 
@@ -1943,8 +1573,8 @@ bool Sketch::clear_tmps_()
   }
 
   bool operation_canceled = m_tmp_edges.size();
-  clear_all(m_tmp_node_idxs, m_tmp_shp, m_tmp_edges, m_entered_edge_len, m_show_dim_input, m_entered_edge_angle,
-            m_show_angle_input);
+  clear_all(m_tmp_node_idxs, m_tmp_shp, m_tmp_edges);
+  m_dims.on_clear_tmps();
 
   return operation_canceled;
 }
@@ -2027,7 +1657,6 @@ void Sketch::get_originating_face_snp_pts_3d_(std::vector<gp_Pnt>& out)
 
   append(out, snp_pts);
 }
-
 void Sketch::set_visible(bool state)
 {
   m_visible = state;
@@ -2041,13 +1670,7 @@ void Sketch::set_visible(bool state)
     for (Edge& e : m_edges)
       m_ctx.Display(e.shp, AIS_WireFrame, 0, false);
 
-    if (m_len_dim_rubber_shp && m_len_dim_pick_anchor_node.has_value())
-      m_ctx.Display(m_len_dim_rubber_shp, AIS_WireFrame, 0, false);
-
-    if (m_show_dims)
-      for (Length_dimension& ld : m_length_dimensions)
-        if (!ld.dim.IsNull() && ld.visible)
-          m_ctx.Display(ld.dim, false);
+    m_dims.on_sketch_shown();
 
     if (m_originating_face)
       m_ctx.Display(m_originating_face, AIS_WireFrame, 0, false);
@@ -2066,16 +1689,13 @@ void Sketch::set_visible(bool state)
     for (Edge& e : m_edges)
       m_ctx.Erase(e.shp, false);
 
-    for (Length_dimension& ld : m_length_dimensions)
-      if (!ld.dim.IsNull())
-        m_ctx.Erase(ld.dim, false);
+    m_dims.on_sketch_hidden();
 
     if (m_originating_face)
       m_ctx.Erase(m_originating_face, false);
 
     m_underlay.ctx_erase();
 
-    // Hide operation axis when sketch becomes invisible
     if (m_operation_axis.has_value())
       m_ctx.Erase(m_operation_axis->shp, false);
 
@@ -2087,7 +1707,6 @@ void Sketch::set_visible(bool state)
 
   m_ctx.UpdateCurrentViewer();
 
-  // Call to update outside sketch snap points.
   m_view.curr_sketch().set_current();
 }
 
@@ -2114,100 +1733,6 @@ void Sketch::set_show_edges(bool show)
     for (Edge& e : m_edges)
       m_ctx.Erase(e.shp, false);
 }
-
-void Sketch::set_show_dims(bool show)
-{
-  m_show_dims = show;
-  if (show && m_visible)
-  {
-    for (Length_dimension& ld : m_length_dimensions)
-      if (!ld.dim.IsNull() && ld.visible)
-        m_ctx.Display(ld.dim, false);
-  }
-  else
-  {
-    for (Length_dimension& ld : m_length_dimensions)
-      if (!ld.dim.IsNull())
-        m_ctx.Erase(ld.dim, false);
-  }
-}
-
-bool Sketch::shows_dimensions() const { return m_show_dims; }
-
-bool Sketch::dimension_visible(size_t dim_index) const
-{
-  EZY_ASSERT(dim_index < m_length_dimensions.size());
-  return m_length_dimensions[dim_index].visible;
-}
-
-void Sketch::set_dimension_visible(size_t dim_index, bool visible)
-{
-  EZY_ASSERT(dim_index < m_length_dimensions.size());
-  Length_dimension& d = m_length_dimensions[dim_index];
-  if (d.visible == visible)
-    return;
-
-  d.visible = visible;
-  if (!d.dim.IsNull())
-  {
-    if (visible && m_visible && m_show_dims)
-      m_ctx.Display(d.dim, false);
-    else
-      m_ctx.Erase(d.dim, false);
-  }
-}
-
-size_t Sketch::dimension_node_lo(size_t dim_index) const
-{
-  EZY_ASSERT(dim_index < m_length_dimensions.size());
-  return m_length_dimensions[dim_index].node_idx_lo;
-}
-
-size_t Sketch::dimension_node_hi(size_t dim_index) const
-{
-  EZY_ASSERT(dim_index < m_length_dimensions.size());
-  return m_length_dimensions[dim_index].node_idx_hi;
-}
-
-double Sketch::dimension_offset(size_t dim_index) const
-{
-  EZY_ASSERT(dim_index < m_length_dimensions.size());
-  const Length_dimension& d = m_length_dimensions[dim_index];
-  if (d.flyout_offset.has_value())
-    return *d.flyout_offset;
-
-  if (!d.dim.IsNull())
-    return std::abs(static_cast<double>(d.dim->GetFlyout()));
-
-  return 0.0;
-}
-
-void Sketch::set_dimension_offset(size_t dim_index, const double offset)
-{
-  EZY_ASSERT(dim_index < m_length_dimensions.size());
-  Length_dimension& d = m_length_dimensions[dim_index];
-
-  const double off = std::max(0.0, offset);
-  if (off <= 0.0)
-    d.flyout_offset.reset();
-  else
-    d.flyout_offset = off;
-
-  rebuild_length_dimension_display_(d);
-}
-
-std::string Sketch::dimension_name(size_t dim_index) const
-{
-  EZY_ASSERT(dim_index < m_length_dimensions.size());
-  return m_length_dimensions[dim_index].name;
-}
-
-PrsDim_LengthDimension_ptr Sketch::length_dimension_handle(const size_t dim_index) const
-{
-  EZY_ASSERT(dim_index < m_length_dimensions.size());
-  return m_length_dimensions[dim_index].dim;
-}
-
 void Sketch::append_list_hover_ais(std::vector<AIS_InteractiveObject_ptr>& out) const
 {
   if (!m_visible)
@@ -2231,27 +1756,6 @@ void Sketch::append_list_hover_ais(std::vector<AIS_InteractiveObject_ptr>& out) 
   if (m_underlay.has_image() && m_underlay.visible())
     m_underlay.append_list_hover_ais(out);
 }
-
-void Sketch::set_dimension_name(size_t dim_index, const std::string& name)
-{
-  EZY_ASSERT(dim_index < m_length_dimensions.size());
-  Length_dimension& d = m_length_dimensions[dim_index];
-  if (d.name == name)
-    return;
-
-  d.name = name;
-  // name is only used in Sketch List inspector; no 3D annotation update needed
-}
-
-void Sketch::refresh_annotations(const Sketch_annotation_refresh& refresh)
-{
-  if (refresh.length_dimensions)
-    refresh_all_length_dimensions_();
-
-  if (refresh.permanent_node_marks)
-    sync_permanent_node_annos_();
-}
-
 bool Sketch::is_current() const { return this == &m_view.curr_sketch(); }
 
 void Sketch::set_current()
@@ -2321,8 +1825,6 @@ size_t Sketch::edge_count() const { return m_edges.size(); }
 
 size_t Sketch::face_count() const { return m_topo.faces().size(); }
 
-size_t Sketch::length_dimension_count() const { return m_length_dimensions.size(); }
-
 std::vector<std::string> Sketch::inspector_edge_labels() const
 {
   std::vector<std::string> labels;
@@ -2347,36 +1849,6 @@ std::vector<std::string> Sketch::inspector_face_labels() const
     const Sketch_face_shp_ptr& f   = m_topo.faces()[i];
     std::string                lbl = (f && !f->name.empty()) ? f->name : ("F" + std::to_string(i));
     labels.push_back(std::move(lbl));
-  }
-
-  return labels;
-}
-
-std::vector<std::string> Sketch::inspector_dimension_labels() const
-{
-  std::vector<std::string> labels;
-  labels.reserve(m_length_dimensions.size());
-  for (size_t i = 0; i < m_length_dimensions.size(); ++i)
-  {
-    const Length_dimension& d   = m_length_dimensions[i];
-    std::string             lbl = d.name.empty() ? ("D" + std::to_string(i)) : d.name;
-    labels.push_back(std::move(lbl));
-  }
-
-  return labels;
-}
-
-std::vector<std::string> Sketch::inspector_node_labels() const
-{
-  std::vector<std::string> labels;
-  for (size_t i = 0; i < m_nodes.size(); ++i)
-  {
-    const Sketch_nodes::Node& n = m_nodes[i];
-    if (n.permanent && !n.deleted)
-    {
-      std::string lbl = n.name.empty() ? ("N" + std::to_string(i)) : n.name;
-      labels.push_back(std::move(lbl));
-    }
   }
 
   return labels;

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -63,6 +63,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln)
     , m_pln(pln)
     , m_name(name)
     , m_nodes(view, pln)
+    , m_edges(*this)
     , m_topo(*this)
     , m_dims(*this)
     , m_underlay(view.ctx())
@@ -75,6 +76,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, cons
     , m_pln(pln)
     , m_name(name)
     , m_nodes(view, pln)
+    , m_edges(*this)
     , m_topo(*this)
     , m_dims(*this)
     , m_underlay(view.ctx())
@@ -88,20 +90,14 @@ Sketch::~Sketch()
 {
   m_underlay.ctx_erase();
 
-  auto remove_edge = [&](Edge& e)
-  {
-    m_ctx.Remove(e.shp, false);
-  };
-
-  for (Edge& e : m_edges)
-    remove_edge(e);
+  m_edges.remove_displayed();
 
   m_dims.remove_displayed();
 
   m_topo.remove_displayed_faces();
 
   if (m_operation_axis.has_value())
-    remove_edge(*m_operation_axis);
+    m_ctx.Remove(m_operation_axis->shp, false);
 
   remove_all_permanent_node_marks_();
 
@@ -178,13 +174,7 @@ void Sketch::angle_input(const ScreenCoords& screen_coords)
 
 void Sketch::remove_edge(const Sketch_AIS_edge& to_remove)
 {
-  // Some shapes are composed with multiple edges, so we cannot break when a edge is found.
-  for (std::list<Edge>::iterator itr = m_edges.begin(); itr != m_edges.end();)
-    if (itr->shp.get() == &to_remove)
-      itr = m_edges.erase(itr);
-    else
-      ++itr;
-
+  m_edges.remove_by_ais(to_remove);
   update_faces_();
 }
 
@@ -606,7 +596,7 @@ void Sketch::finalize_edges_(Sketch_op_recorder& rec)
 
       gp_Pnt2d pa = m_nodes[te.node_idx_a];
       gp_Pnt2d pb = m_nodes[te.node_idx_b];
-      for (const Edge& oe : m_edges) // pre-batch olds only
+      for (const Edge& oe : m_edges.edges()) // pre-batch olds only
       {
         if (!is_linear_edge_(oe))
           continue;
@@ -628,7 +618,7 @@ void Sketch::finalize_edges_(Sketch_op_recorder& rec)
     for (const auto& ip : batch_inters)
     {
       bool is_old_interior = false;
-      for (const Edge& e : m_edges)
+      for (const Edge& e : m_edges.edges())
       {
         if (!is_linear_edge_(e))
           continue;
@@ -650,13 +640,13 @@ void Sketch::finalize_edges_(Sketch_op_recorder& rec)
       m_topo.split_linear_edges_at_node_if_interior(m_nodes.get_node_exact(ip), rec);
   }
 
-  append(m_edges, m_tmp_edges);
+  append(m_edges.edges(), m_tmp_edges);
   m_tmp_edges.clear();
 
   // Ensure topology is correct if snapping on a midpoint happened.
   // These edges need to be split. (Kept for compatibility with current midpoint marking during draw.)
   for (size_t mid_pt_idx : split_mid_points)
-    for (auto itr = m_edges.begin(), end = m_edges.end(); itr != end; ++itr)
+    for (auto itr = m_edges.edges().begin(), end = m_edges.edges().end(); itr != end; ++itr)
       if (itr->node_idx_mid.has_value() && *itr->node_idx_mid == mid_pt_idx)
         // Cannot split arc circles.
         if (!itr->node_idx_arc.has_value())
@@ -673,10 +663,10 @@ void Sketch::finalize_edges_(Sketch_op_recorder& rec)
           rec.note_curr_node(edge_a.node_idx_mid.value());
           rec.note_curr_node(edge_b.node_idx_mid.value());
           m_ctx.Remove(itr->shp, false);
-          m_edges.erase(itr);
+          m_edges.edges().erase(itr);
           m_nodes[mid_pt_idx].midpoint = false;
-          m_edges.emplace_back(edge_a);
-          m_edges.emplace_back(edge_b);
+          m_edges.edges().emplace_back(edge_a);
+          m_edges.edges().emplace_back(edge_b);
           break;
         }
 
@@ -1015,7 +1005,7 @@ void Sketch::mirror_selected_edges()
   std::vector<std::pair<gp_Pnt2d, gp_Pnt2d>>     mirrored_edges;
   std::map<AIS_Shape_ptr, std::set<const Edge*>> arc_circles;
 
-  for (const Edge& e : m_edges)
+  for (const Edge& e : m_edges.edges())
     for (const Edge& selected : mirror_edges)
       if (e.shp == selected.shp || e.circle_arc == selected.circle_arc)
       {
@@ -1170,136 +1160,18 @@ void Sketch::finalize_add_node_elm_cleanup_()
   update_faces_();
 }
 
-void Sketch::add_edge_raw_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
-{
-  Edge edge{m_nodes.get_node_exact(pt_a)};
-  update_edge_end_pt_(edge, m_nodes.get_node_exact(pt_b));
-  m_edges.emplace_back(edge);
-  m_nodes.finalize();
-}
-
-void Sketch::add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b) { add_edge_impl_(pt_a, pt_b, nullptr); }
+void Sketch::add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b) { m_edges.add_edge(pt_a, pt_b); }
 
 void Sketch::add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder& rec)
 {
-  rec.note_curr_linear_edge(pt_a, pt_b);
-  add_edge_impl_(pt_a, pt_b, &rec);
+  m_edges.add_edge(pt_a, pt_b, rec);
 }
 
-void Sketch::add_edge_impl_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder* rec)
-{
-  if (!unique(pt_a, pt_b))
-    return;
-
-  // Find intersections (crossings or T-touches) between this new segment and all *currently existing* linear edges.
-  // We will split the existing ones at interior intersections, and subdivide this new one as needed.
-  std::vector<gp_Pnt2d> inters;
-  for (const Edge& e : m_edges)
-  {
-    if (!is_linear_edge_(e))
-      continue;
-
-    gp_Pnt2d qa = m_nodes[e.node_idx_a];
-    gp_Pnt2d qb = m_nodes[e.node_idx_b];
-
-    if (auto inter = segment_intersection_2d(pt_a, pt_b, qa, qb, Segment_inclusion::Closed))
-      // The intersection point is guaranteed to lie on both finite closed segments
-      // (the new logic is now handled inside segment_intersection_2d).
-      // We still collect it for later splitting of existing edges and subdividing the new one.
-      add_unique_point(inters, *inter);
-  }
-
-  // Collect only the *interior* hits on existing edges for splitting.
-  // We must not call split (which does snap) on endpoint-touch "inters" (shared corners),
-  // otherwise in headless tests (giant snap radius) corners get projected onto unrelated edges,
-  // and in general we don't want to move known join points.
-  std::vector<gp_Pnt2d> inters_to_split;
-  for (const auto& ip : inters)
-  {
-    // Need to re-find which old edge (or any) this ip lies on interior; check against all current
-    // for safety (a point could in theory be interior hit for the collect).
-    bool is_old_interior = false;
-    for (const Edge& e : m_edges)
-    {
-      if (!is_linear_edge_(e))
-        continue;
-
-      gp_Pnt2d qa = m_nodes[e.node_idx_a];
-      gp_Pnt2d qb = m_nodes[e.node_idx_b];
-      if (point_on_open_segment_2d(ip, qa, qb))
-      {
-        is_old_interior = true;
-        break;
-      }
-    }
-    if (is_old_interior)
-      add_unique_point(inters_to_split, ip);
-  }
-
-  // All division points on this new edge: its own ends + any intersections
-  std::vector<gp_Pnt2d> div_pts{pt_a, pt_b};
-  div_pts.insert(div_pts.end(), inters.begin(), inters.end());
-
-  // Sort along the edge direction
-  gp_Vec2d dir(pt_a, pt_b);
-  double   len2 = dir.SquareMagnitude();
-  if (len2 < Precision::Confusion() * Precision::Confusion())
-    return;
-
-  std::sort(div_pts.begin(), div_pts.end(),
-            [&](const gp_Pnt2d& u, const gp_Pnt2d& v) { return gp_Vec2d(pt_a, u).Dot(dir) < gp_Vec2d(pt_a, v).Dot(dir); });
-
-  // Dedup after sort
-  std::vector<gp_Pnt2d> pts;
-  for (const auto& p : div_pts)
-  {
-    if (pts.empty() || pts.back().Distance(p) > Precision::Confusion())
-      pts.push_back(p);
-  }
-
-  if (pts.size() < 2)
-    return;
-
-  // Create nodes for all division points (for subdividing the new edge)
-  std::vector<size_t> div_node_idxs;
-  for (const auto& p : pts)
-    div_node_idxs.push_back(m_nodes.get_node_exact(p));
-
-  // Only split *existing* linear edges at the true *interior* intersection points we found on olds.
-  // Endpoint touches (shared corners) are excluded here so we do not invoke snap on known vertices.
-  for (const auto& inter_p : inters_to_split)
-  {
-    const size_t nidx = m_nodes.get_node_exact(inter_p);
-    if (rec)
-      rec->note_curr_node(nidx);
-
-    m_topo.split_linear_edges_at_node_if_interior(nidx, rec);
-  }
-
-  // Now insert the (subdivided) pieces of this new edge using the raw adder.
-  // Use the (possibly adjusted by split snap) node positions.
-  for (size_t i = 0; i + 1 < div_node_idxs.size(); ++i)
-  {
-    const gp_Pnt2d& pa = m_nodes[div_node_idxs[i]];
-    const gp_Pnt2d& pb = m_nodes[div_node_idxs[i + 1]];
-    add_edge_raw_(pa, pb);
-  }
-}
+void Sketch::add_edge_raw_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b) { m_edges.add_edge_raw_(pt_a, pt_b); }
 
 void Sketch::sketch_json_add_linear_edge_(size_t idx_a, size_t idx_b, std::optional<size_t> idx_mid)
 {
-  EZY_ASSERT(idx_a < m_nodes.size() && idx_b < m_nodes.size());
-  if (idx_mid.has_value())
-    EZY_ASSERT(*idx_mid < m_nodes.size());
-
-  Edge edge{idx_a};
-  edge.node_idx_b      = idx_b;
-  edge.node_idx_mid    = idx_mid;
-  const gp_Pnt2d& pt_a = m_nodes[idx_a];
-  const gp_Pnt2d& pt_b = m_nodes[idx_b];
-  update_edge_shp_(edge, pt_a, pt_b);
-  m_edges.emplace_back(edge);
-  m_nodes.finalize();
+  m_edges.sketch_json_add_linear_edge(idx_a, idx_b, idx_mid);
 }
 
 void Sketch::sketch_json_set_operation_axis_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
@@ -1317,16 +1189,7 @@ void Sketch::sketch_json_set_operation_axis_(const gp_Pnt2d& pt_a, const gp_Pnt2
   sync_operation_axis_display_();
 }
 
-std::vector<Sketch::Edge> Sketch::get_selected_edges_() const
-{
-  std::vector<Edge> ret;
-  for (const AIS_Shape_ptr& selected : m_view.get_selected())
-    for (const Edge& e : m_edges)
-      if (e.shp == selected)
-        ret.push_back(e);
-
-  return ret;
-}
+std::vector<Sketch::Edge> Sketch::get_selected_edges_() const { return m_edges.get_selected(); }
 
 std::vector<Sketch_face_shp_ptr> Sketch::get_selected_faces_() const
 {
@@ -1341,14 +1204,7 @@ std::vector<Sketch_face_shp_ptr> Sketch::get_selected_faces_() const
 
 std::list<Sketch::Edge>::iterator Sketch::get_edge_at_(const ScreenCoords& screen_coords)
 {
-  AIS_Shape_ptr shp = m_view.get_shape(screen_coords);
-  if (auto edge = dynamic_cast<Sketch_AIS_edge*>(shp.get()); edge)
-    if (&edge->owner_sketch == this)
-      for (std::list<Edge>::iterator itr = m_edges.begin(); itr != m_edges.end(); ++itr)
-        if (itr->shp.get() == edge)
-          return itr;
-
-  return m_edges.end();
+  return m_edges.get_at(screen_coords);
 }
 bool Sketch::try_remove_length_dimension(PrsDim_LengthDimension* dim) { return m_dims.try_remove_length_dimension(dim); }
 
@@ -1477,18 +1333,7 @@ void Sketch::set_edge_from_center(bool on) { s_edge_from_center = on; }
 
 bool Sketch::get_edge_from_center() { return s_edge_from_center; }
 
-void Sketch::update_edge_end_pt_(Edge& edge, size_t end_pt_idx)
-{
-  EZY_ASSERT(end_pt_idx < m_nodes.size());
-  edge.node_idx_b      = end_pt_idx;
-  const gp_Pnt2d& pt_a = m_nodes[edge.node_idx_a];
-  const gp_Pnt2d& pt_b = m_nodes[end_pt_idx];
-  update_edge_shp_(edge, pt_a, pt_b);
-  if (s_add_mid_pt_edges)
-    edge.node_idx_mid = m_nodes.add_new_node(get_midpoint(pt_a, pt_b), true);
-  else
-    edge.node_idx_mid = std::nullopt;
-}
+void Sketch::update_edge_end_pt_(Edge& edge, size_t end_pt_idx) { m_edges.update_end_pt(edge, end_pt_idx); }
 
 void Sketch::add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
 {
@@ -1512,19 +1357,7 @@ void Sketch::add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const g
   add_arc_circle_(std::vector<size_t>{node_idx_a, node_idx_c, node_idx_b});
 }
 
-void Sketch::add_arc_circle_(const std::vector<size_t>& node_idxs)
-{
-  EZY_ASSERT(node_idxs.size() == 3);
-  Geom_TrimmedCurve_ptr arc_of_circle = GC_MakeArcOfCircle(to_3d_(node_idxs[0]), to_3d_(node_idxs[2]), to_3d_(node_idxs[1]));
-
-  Sketch_AIS_edge_ptr shp = new Sketch_AIS_edge(*this, BRepBuilderAPI_MakeEdge(arc_of_circle));
-  update_edge_style_(shp);
-  m_ctx.Display(shp, false);
-
-  // Split into two edges for valid planer graph topology.
-  m_edges.push_back({node_idxs[0], node_idxs[2], node_idxs[2], std::nullopt, arc_of_circle, shp});
-  m_edges.push_back({node_idxs[2], node_idxs[1], std::nullopt, std::nullopt, arc_of_circle, shp});
-}
+void Sketch::add_arc_circle_(const std::vector<size_t>& node_idxs) { m_edges.add_arc_circle_edges(node_idxs); }
 
 // Circle related
 void Sketch::move_circle_pt_(const ScreenCoords& screen_coords)
@@ -1658,7 +1491,7 @@ void Sketch::set_visible(bool state)
       for (AIS_Shape_ptr& face : m_topo.faces())
         m_ctx.Display(face, AIS_Shaded, 0, false);
 
-    for (Edge& e : m_edges)
+    for (Edge& e : m_edges.edges())
       m_ctx.Display(e.shp, AIS_WireFrame, 0, false);
 
     m_dims.on_sketch_shown();
@@ -1677,7 +1510,7 @@ void Sketch::set_visible(bool state)
     for (AIS_Shape_ptr& face : m_topo.faces())
       m_ctx.Erase(face, false);
 
-    for (Edge& e : m_edges)
+    for (Edge& e : m_edges.edges())
       m_ctx.Erase(e.shp, false);
 
     m_dims.on_sketch_hidden();
@@ -1718,10 +1551,10 @@ void Sketch::set_show_faces(bool show)
 void Sketch::set_show_edges(bool show)
 {
   if (show && m_visible)
-    for (Edge& e : m_edges)
+    for (Edge& e : m_edges.edges())
       m_ctx.Display(e.shp, AIS_WireFrame, 0, false);
   else
-    for (Edge& e : m_edges)
+    for (Edge& e : m_edges.edges())
       m_ctx.Erase(e.shp, false);
 }
 void Sketch::append_list_hover_ais(std::vector<AIS_InteractiveObject_ptr>& out) const
@@ -1729,7 +1562,7 @@ void Sketch::append_list_hover_ais(std::vector<AIS_InteractiveObject_ptr>& out) 
   if (!m_visible)
     return;
 
-  for (const Edge& e : m_edges)
+  for (const Edge& e : m_edges.edges())
     if (!e.shp.IsNull())
       out.push_back(e.shp);
 
@@ -1790,7 +1623,7 @@ void Sketch::set_edge_style(Edge_style style)
 {
   m_edge_style = style;
 
-  for (Edge& e : m_edges)
+  for (Edge& e : m_edges.edges())
     update_edge_style_(e.shp);
 
   // Permanent node marker style/visibility is managed elsewhere; avoid
@@ -1821,7 +1654,7 @@ std::vector<std::string> Sketch::inspector_edge_labels() const
   std::vector<std::string> labels;
   labels.reserve(m_edges.size());
   size_t idx = 0;
-  for (const Edge& e : m_edges)
+  for (const Edge& e : m_edges.edges())
   {
     std::string lbl = e.name.empty() ? ("E" + std::to_string(idx)) : e.name;
     labels.push_back(std::move(lbl));
@@ -1844,20 +1677,6 @@ std::vector<std::string> Sketch::inspector_face_labels() const
 
   return labels;
 }
-
-bool Sketch::Edge::reversed(size_t idx_a, size_t idx_b) const
-{
-  if (node_idx_a == idx_a && node_idx_b == idx_b)
-    return false;
-
-  if (node_idx_a == idx_b && node_idx_b == idx_a)
-    return true;
-
-  EZY_ASSERT(false);
-  return false;
-}
-
-bool Sketch::is_linear_edge_(const Edge& e) { return !e.circle_arc && e.node_idx_b.has_value(); }
 
 /// Selectable "+" marker for user-placed permanent sketch nodes (add-node tool).
 struct Sketch_AIS_node_mark : public AIS_Shape

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -24,6 +24,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln)
     , m_ctx(view.ctx())
     , m_pln(pln)
     , m_name(name)
+    , m_id(view.allocate_sketch_id())
     , m_nodes(view, pln)
     , m_edges(*this)
     , m_topo(*this)
@@ -39,6 +40,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, cons
     , m_ctx(view.ctx())
     , m_pln(pln)
     , m_name(name)
+    , m_id(view.allocate_sketch_id())
     , m_nodes(view, pln)
     , m_edges(*this)
     , m_topo(*this)
@@ -355,6 +357,8 @@ gp_Pnt Sketch::to_3d_(const std::optional<size_t>& node_idx) const
 const std::string& Sketch::get_name() const { return m_name; }
 
 void Sketch::set_name(const std::string& name) { m_name = name; }
+
+size_t Sketch::get_id() const { return m_id; }
 
 bool Sketch::has_edges() const { return !m_edges.empty(); }
 

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -72,6 +72,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln)
     , m_pln(pln)
     , m_name(name)
     , m_nodes(view, pln)
+    , m_topo(*this)
     , m_underlay(view.ctx())
 {
 }
@@ -82,6 +83,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, cons
     , m_pln(pln)
     , m_name(name)
     , m_nodes(view, pln)
+    , m_topo(*this)
     , m_underlay(view.ctx())
 {
   m_originating_face = new AIS_Shape(outer_wire);
@@ -107,8 +109,7 @@ Sketch::~Sketch()
 
   m_length_dimensions.clear();
 
-  for (AIS_Shape_ptr& f : m_faces)
-    m_ctx.Remove(f, false);
+  m_topo.remove_displayed_faces();
 
   if (m_operation_axis.has_value())
     remove_edge(*m_operation_axis);
@@ -205,7 +206,7 @@ void Sketch::dbg_append_str(std::string& out) const
 {
   out += "    Nodes: " + std::to_string(m_nodes.size()) + "\n";
   out += "    Edges: " + std::to_string(m_edges.size()) + "\n";
-  out += "    Faces: " + std::to_string(m_faces.size()) + "\n";
+  out += "    Faces: " + std::to_string(m_topo.faces().size()) + "\n";
   out += "Tmp Nodes: " + std::to_string(m_tmp_node_idxs.size()) + "\n";
   out += "Tmp Edges: " + std::to_string(m_tmp_edges.size()) + "\n";
 }
@@ -481,9 +482,9 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
 
       const double dist = span->full_len / m_view.get_dimension_scale();
       m_ctx.Remove(m_tmp_dim_anno, true);
-      m_tmp_dim_anno = create_distance_annotation(span_a, span_b, m_pln, m_view.gui().length_dimension_style(),
-                                                  approx_sketch_interior_ref_3d_(),
-                                                  m_dim_classifier_faces.empty() ? nullptr : &m_dim_classifier_faces);
+      m_tmp_dim_anno = create_distance_annotation(
+          span_a, span_b, m_pln, m_view.gui().length_dimension_style(), approx_sketch_interior_ref_3d_(),
+          m_topo.dim_classifier_faces().empty() ? nullptr : &m_topo.dim_classifier_faces());
       m_tmp_dim_anno->SetCustomValue(dist);
       m_ctx.Display(m_tmp_dim_anno, true);
 
@@ -583,9 +584,9 @@ void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
     // line; if the mouse is (nearly) perpendicular to that line, the projection coincides with pt_a.
     if (unique(pt_a, final_pt_b))
     {
-      m_tmp_dim_anno = create_distance_annotation(pt_a, final_pt_b, m_pln, m_view.gui().length_dimension_style(),
-                                                  approx_sketch_interior_ref_3d_(),
-                                                  m_dim_classifier_faces.empty() ? nullptr : &m_dim_classifier_faces);
+      m_tmp_dim_anno = create_distance_annotation(
+          pt_a, final_pt_b, m_pln, m_view.gui().length_dimension_style(), approx_sketch_interior_ref_3d_(),
+          m_topo.dim_classifier_faces().empty() ? nullptr : &m_topo.dim_classifier_faces());
 
       m_tmp_dim_anno->SetCustomValue(dist);
       m_ctx.Display(m_tmp_dim_anno, true);
@@ -739,7 +740,7 @@ void Sketch::finalize_edges_(Sketch_op_recorder& rec)
     }
 
     for (const auto& ip : batch_to_split)
-      split_linear_edges_at_node_if_interior_(m_nodes.get_node_exact(ip), rec);
+      m_topo.split_linear_edges_at_node_if_interior(m_nodes.get_node_exact(ip), rec);
   }
 
   append(m_edges, m_tmp_edges);
@@ -781,7 +782,7 @@ void Sketch::finalize_edges_(Sketch_op_recorder& rec)
   {
     const size_t nidx = m_nodes.get_node_exact(ip);
     rec.note_curr_node(nidx);
-    split_linear_edges_at_node_if_interior_(nidx, rec);
+    m_topo.split_linear_edges_at_node_if_interior(nidx, rec);
   }
 
   m_nodes.hide_snap_annos();
@@ -795,7 +796,7 @@ void Sketch::add_node_pt_(const ScreenCoords& screen_coords)
     Sketch_op_recorder rec(m_view, *this);
     {
       rec.note_curr_node(node_b);
-      split_linear_edges_at_node_if_interior_(node_b, rec);
+      m_topo.split_linear_edges_at_node_if_interior(node_b, rec);
 
       // Add-node mode: the rubber band is only for placement (snap / dimension / angle). Do not create
       // a sketch edge between the anchor and the new node - only nodes and interior splits matter.
@@ -867,7 +868,7 @@ void Sketch::add_node_pt_(const ScreenCoords& screen_coords)
     {
       const size_t ni = m_nodes.add_new_node(pt, false, true);
       rec.note_curr_node(ni);
-      split_linear_edges_at_node_if_interior_(ni, rec);
+      m_topo.split_linear_edges_at_node_if_interior(ni, rec);
       m_ctx.Remove(m_tmp_dim_anno, true);
       m_tmp_dim_anno.Nullify();
       m_nodes.hide_snap_annos();
@@ -887,132 +888,7 @@ void Sketch::move_add_node_pt_(const ScreenCoords& screen_coords)
     move_sketch_pt_(screen_coords, [](const std::optional<size_t>&, const gp_Pnt2d&) {});
 }
 
-double Sketch::plane_pick_snap_radius_world_() const
-{
-  const double px = Sketch_nodes::get_snap_dist();
-  if (m_view.is_headless())
-    return std::max(px, Precision::Confusion() * 1e9);
-
-  const gp_Pnt2d          ref2(0.0, 0.0);
-  const ScreenCoords      s0   = m_view.get_screen_coords(to_3d(m_pln, ref2));
-  const dvec2             base = s0.unsafe_get();
-  std::optional<gp_Pnt2d> p1   = m_view.pt_on_plane(ScreenCoords(dvec2(base.x + px, base.y)), m_pln);
-  if (!p1)
-    return std::max(px, Precision::Confusion() * 1e9);
-
-  return ref2.Distance(*p1);
-}
-
-void Sketch::snap_placed_node_to_closest_linear_edge_interior_(size_t node_idx)
-{
-  EZY_ASSERT(node_idx < m_nodes.size());
-
-  const gp_Pnt2d p(m_nodes[node_idx].X(), m_nodes[node_idx].Y());
-  const double   max_d = plane_pick_snap_radius_world_();
-
-  double                  best_err = std::numeric_limits<double>::infinity();
-  std::optional<gp_Pnt2d> best_proj;
-
-  for (const auto& e : m_edges)
-  {
-    if (e.circle_arc)
-      continue;
-
-    if (e.node_idx_arc.has_value())
-      continue;
-
-    if (!e.node_idx_b.has_value())
-      continue;
-
-    const size_t    a  = e.node_idx_a;
-    const size_t    b  = *e.node_idx_b;
-    const gp_Pnt2d& pa = m_nodes[a];
-    const gp_Pnt2d& pb = m_nodes[b];
-    if (node_idx == a || node_idx == b)
-      continue;
-
-    std::optional<gp_Pnt2d> proj = snap_foot_to_open_segment_interior_if_close(p, pa, pb, max_d);
-    if (!proj)
-      continue;
-
-    const double err = p.Distance(*proj);
-    if (err < best_err)
-    {
-      best_err  = err;
-      best_proj = proj;
-    }
-  }
-
-  if (best_proj)
-  {
-    Sketch_nodes::Node& n = m_nodes[node_idx];
-    n.SetX(best_proj->X());
-    n.SetY(best_proj->Y());
-    n.midpoint = false;
-  }
-}
-
-void Sketch::split_linear_edges_at_node_if_interior_(size_t node_idx)
-{
-  split_linear_edges_at_node_if_interior_(node_idx, static_cast<Sketch_op_recorder*>(nullptr));
-}
-
-void Sketch::split_linear_edges_at_node_if_interior_(size_t node_idx, Sketch_op_recorder& rec)
-{
-  split_linear_edges_at_node_if_interior_(node_idx, &rec);
-}
-
-void Sketch::split_linear_edges_at_node_if_interior_(size_t node_idx, Sketch_op_recorder* rec)
-{
-  EZY_ASSERT(node_idx < m_nodes.size());
-  snap_placed_node_to_closest_linear_edge_interior_(node_idx);
-  const gp_Pnt2d& p = m_nodes[node_idx];
-
-  bool progress = true;
-  while (progress)
-  {
-    progress = false;
-    for (auto itr = m_edges.begin(); itr != m_edges.end(); ++itr)
-    {
-      if (itr->circle_arc)
-        continue;
-
-      if (itr->node_idx_arc.has_value())
-        continue;
-
-      if (!itr->node_idx_b.has_value())
-        continue;
-
-      const size_t    a  = itr->node_idx_a;
-      const size_t    b  = *itr->node_idx_b;
-      const gp_Pnt2d& pa = m_nodes[a];
-      const gp_Pnt2d& pb = m_nodes[b];
-
-      if (node_idx == a || node_idx == b)
-        continue;
-
-      if (!point_on_open_segment_2d(p, pa, pb))
-        continue;
-
-      Edge edge_a{a};
-      update_edge_end_pt_(edge_a, node_idx);
-      Edge edge_b{node_idx};
-      update_edge_end_pt_(edge_b, b);
-
-      if (rec)
-        rec->note_prev_linear_edge(itr->node_idx_a, *itr->node_idx_b, itr->node_idx_mid, itr->name);
-
-      m_ctx.Remove(itr->shp, false);
-      m_edges.erase(itr);
-      m_nodes[node_idx].midpoint = false;
-      m_edges.push_back(std::move(edge_a));
-      m_edges.push_back(std::move(edge_b));
-
-      progress = true;
-      break;
-    }
-  }
-}
+void Sketch::update_faces_() { m_topo.update_faces(); }
 
 // Arc circle related
 void Sketch::add_arc_circle_pt_(const ScreenCoords& screen_coords)
@@ -1481,7 +1357,7 @@ void Sketch::check_dimension_rubber_()
   Sketch_op_recorder rec(m_view, *this);
   {
     rec.note_curr_node(b);
-    split_linear_edges_at_node_if_interior_(b, rec);
+    m_topo.split_linear_edges_at_node_if_interior(b, rec);
 
     m_tmp_node_idxs.clear();
     clear_tmps_();
@@ -1608,7 +1484,7 @@ void Sketch::add_edge_impl_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_o
     if (rec)
       rec->note_curr_node(nidx);
 
-    split_linear_edges_at_node_if_interior_(nidx, rec);
+    m_topo.split_linear_edges_at_node_if_interior(nidx, rec);
   }
 
   // Now insert the (subdivided) pieces of this new edge using the raw adder.
@@ -1667,7 +1543,7 @@ std::vector<Sketch_face_shp_ptr> Sketch::get_selected_faces_() const
 {
   std::vector<Sketch_face_shp_ptr> ret;
   for (const AIS_Shape_ptr& selected : m_view.get_selected())
-    for (const Sketch_face_shp_ptr& face : m_faces)
+    for (const Sketch_face_shp_ptr& face : m_topo.faces())
       if (face == selected)
         ret.push_back(face);
 
@@ -1764,7 +1640,7 @@ void Sketch::rebuild_length_dimension_display_(Length_dimension& d)
 
   d.dim = create_distance_annotation(m_nodes[d.node_idx_lo], m_nodes[d.node_idx_hi], m_pln,
                                      m_view.gui().length_dimension_style(), approx_sketch_interior_ref_3d_(),
-                                     m_dim_classifier_faces.empty() ? nullptr : &m_dim_classifier_faces);
+                                     m_topo.dim_classifier_faces().empty() ? nullptr : &m_topo.dim_classifier_faces());
 
   const double dist = m_nodes[d.node_idx_lo].Distance(m_nodes[d.node_idx_hi]);
   d.dim->SetCustomValue(dist / m_view.get_dimension_scale());
@@ -1969,588 +1845,6 @@ bool Sketch::cancel_elm()
   return operation_canceled;
 }
 
-// Function to extract faces from the planar graph
-void Sketch::update_faces_()
-{
-  m_nodes.finalize();
-
-  m_view.remove(m_faces);
-  m_faces.clear();
-  m_dim_classifier_faces.clear();
-
-  // Used to cleanup dangling nodes;
-  std::vector<bool> used_nodes(m_nodes.size());
-
-  // Build adjacency list
-  std::unordered_map<size_t, std::vector<std::pair<size_t, const Edge*>>> adj_list;
-
-  for (const auto& edge : m_edges)
-  {
-    EZY_ASSERT(edge.node_idx_b.has_value());
-
-    size_t a = edge.node_idx_a;
-    size_t b = edge.node_idx_b.value();
-    adj_list[a].push_back({b, &edge});
-    adj_list[b].push_back({a, &edge});
-
-    // Keep track of used nodes.
-    used_nodes[a] = true;
-    used_nodes[b] = true;
-    if (edge.node_idx_mid.has_value())
-      used_nodes[*edge.node_idx_mid] = true;
-
-    if (edge.node_idx_arc.has_value())
-      used_nodes[*edge.node_idx_arc] = true;
-  }
-
-  if (m_operation_axis.has_value())
-  {
-    used_nodes[m_operation_axis->node_idx_a] = true;
-    if (m_operation_axis->node_idx_b.has_value())
-      used_nodes[*m_operation_axis->node_idx_b] = true;
-  }
-
-  // Remove dangling edges (edges with degree-1 endpoints) iteratively.
-  // These edges cannot form closed faces, so we exclude them from face detection.
-  std::unordered_set<const Edge*> excluded_edges;
-
-  // Treat edges attached to the virtual mid-node of an arc as dangling for face detection.
-  // Circle arcs are represented using a virtual node in the middle of the arc (`node_idx_arc`).
-  // Any non-arc edge that uses this virtual node as an endpoint should not participate in faces.
-  {
-    std::unordered_set<size_t> arc_mid_nodes;
-    for (const auto& edge : m_edges)
-      if (edge.node_idx_arc.has_value())
-        arc_mid_nodes.insert(*edge.node_idx_arc);
-
-    for (const auto& edge : m_edges)
-    {
-      // Only consider non-arc edges (straight segments etc.).
-      if (edge.circle_arc)
-        continue;
-
-      if (!edge.node_idx_b.has_value())
-        continue;
-
-      const size_t a = edge.node_idx_a;
-      const size_t b = *edge.node_idx_b;
-
-      if (arc_mid_nodes.count(a) || arc_mid_nodes.count(b))
-        excluded_edges.insert(&edge);
-    }
-  }
-
-  bool changed = true;
-  while (changed)
-  {
-    changed = false;
-    std::unordered_set<const Edge*> to_exclude;
-
-    // Find edges where at least one endpoint has degree 1 (considering only non-excluded edges)
-    for (const auto& edge : m_edges)
-    {
-      if (excluded_edges.count(&edge))
-        continue;
-
-      EZY_ASSERT(edge.node_idx_b.has_value());
-      size_t a = edge.node_idx_a;
-      size_t b = edge.node_idx_b.value();
-
-      // Count degree for each endpoint (excluding already excluded edges)
-      int degree_a = 0;
-      int degree_b = 0;
-      for (const auto& [neighbor, e] : adj_list[a])
-        if (!excluded_edges.count(e))
-          ++degree_a;
-
-      for (const auto& [neighbor, e] : adj_list[b])
-        if (!excluded_edges.count(e))
-          ++degree_b;
-
-      // If either endpoint has degree 1, this edge is dangling
-      if (degree_a == 1 || degree_b == 1)
-      {
-        to_exclude.insert(&edge);
-        changed = true;
-      }
-    }
-
-    excluded_edges.insert(to_exclude.begin(), to_exclude.end());
-  }
-  // Bridge edge removal logic (active). Excludes edges that purely connect separate cycles
-  // (both ends degree >=3 and no alternate path) from the adjacency used by the face walker.
-  // This is required for sketches like bridge.ezy that contain a "bridge" touching an inner
-  // triangular loop so that we obtain exactly two faces, one of which has the triangle as a
-  // hole. Dangling removal alone is not sufficient. The logic was previously disabled because
-  // an earlier version produced bad results on some nested rect holes; current state + other
-  // fixes (cw break, split rules, etc.) are being validated with the new regression test.
-  // Remove bridge edges that connect two separate cycles.
-  // A bridge edge connects two cycles and has both endpoints with degree >= 3.
-  // We detect this by checking if the edge is the only connection between two cycles.
-  std::unordered_set<const Edge*> bridge_edges;
-  for (const auto& edge : m_edges)
-  {
-    if (excluded_edges.count(&edge))
-      continue;
-
-    EZY_ASSERT(edge.node_idx_b.has_value());
-    size_t a = edge.node_idx_a;
-    size_t b = edge.node_idx_b.value();
-
-    // Count degree for each endpoint (excluding already excluded edges)
-    int degree_a = 0;
-    int degree_b = 0;
-    for (const auto& [neighbor, e] : adj_list[a])
-      if (!excluded_edges.count(e))
-        ++degree_a;
-
-    for (const auto& [neighbor, e] : adj_list[b])
-      if (!excluded_edges.count(e))
-        ++degree_b;
-
-    // Bridge edges have both endpoints with degree >= 3
-    // They connect two separate cycles. We detect this by checking if removing the edge
-    // creates two disconnected components, each containing a cycle.
-    if (degree_a >= 3 && degree_b >= 3)
-    {
-      // Check if removing this edge disconnects the graph
-      // by seeing if we can reach 'b' from 'a' without using this edge
-      std::unordered_set<size_t> visited;
-      std::vector<size_t>        queue;
-      queue.push_back(a);
-      visited.insert(a);
-      bool can_reach_b = false;
-
-      for (size_t i = 0; i < queue.size() && !can_reach_b; ++i)
-      {
-        size_t curr = queue[i];
-        for (const auto& [neighbor, e] : adj_list[curr])
-        {
-          if (excluded_edges.count(e) || e == &edge)
-            continue;
-
-          if (neighbor == b)
-          {
-            can_reach_b = true;
-            break;
-          }
-          if (!visited.count(neighbor))
-          {
-            visited.insert(neighbor);
-            queue.push_back(neighbor);
-          }
-        }
-      }
-
-      // If we can't reach b from a without this edge, it's a bridge
-      // But we also need to verify both sides have cycles
-      if (!can_reach_b)
-      {
-        // Check if component containing 'a' has a cycle
-        auto has_cycle_in_component = [&](size_t start, const Edge* exclude_edge) -> bool
-        {
-          std::unordered_set<size_t>          comp_visited;
-          std::function<bool(size_t, size_t)> dfs = [&](size_t curr, size_t parent) -> bool
-          {
-            comp_visited.insert(curr);
-            for (const auto& [neighbor, e] : adj_list[curr])
-            {
-              if (excluded_edges.count(e) || e == exclude_edge)
-                continue;
-
-              if (neighbor == parent)
-                continue;
-
-              if (comp_visited.count(neighbor))
-              {
-                // Found a back edge = cycle
-                return true;
-              }
-              if (dfs(neighbor, curr))
-                return true;
-            }
-            return false;
-          };
-
-          // Try starting from each neighbor
-          for (const auto& [neighbor, e] : adj_list[start])
-          {
-            if (excluded_edges.count(e) || e == exclude_edge)
-              continue;
-
-            comp_visited.clear();
-            comp_visited.insert(start);
-            if (dfs(neighbor, start))
-              return true;
-          }
-          return false;
-        };
-
-        bool a_has_cycle = has_cycle_in_component(a, &edge);
-        bool b_has_cycle = has_cycle_in_component(b, &edge);
-
-        // If both components have cycles, this edge is a bridge
-        if (a_has_cycle && b_has_cycle)
-          bridge_edges.insert(&edge);
-      }
-    }
-  }
-
-  // Add bridge edges to excluded set
-  excluded_edges.insert(bridge_edges.begin(), bridge_edges.end());
-
-  // Rebuild adjacency list excluding dangling and bridge edges
-  adj_list.clear();
-  for (const auto& edge : m_edges)
-  {
-    if (excluded_edges.count(&edge))
-      continue;
-
-    EZY_ASSERT(edge.node_idx_b.has_value());
-    size_t a = edge.node_idx_a;
-    size_t b = edge.node_idx_b.value();
-    adj_list[a].push_back({b, &edge});
-    adj_list[b].push_back({a, &edge});
-  }
-
-  std::vector<Face>                                        faces;
-  std::unordered_set<std::pair<size_t, size_t>, Pair_hash> seen_edges;
-
-  const auto edge_outgoing_dir = [this](size_t idx_a, size_t idx_b) -> gp_Vec2d
-  {
-    gp_Vec2d ret(m_nodes[idx_a], m_nodes[idx_b]);
-    ret.Normalize();
-    return ret;
-  };
-
-  for (auto& [a_idx, edges] : adj_list)
-    for (auto& [b_idx, start_edge] : edges)
-    {
-      if (seen_edges.count(std::make_pair(a_idx, b_idx)))
-        continue;
-
-      size_t      start_idx = a_idx;
-      size_t      prev_idx  = a_idx;
-      size_t      curr_idx  = b_idx;
-      const Edge* curr_edge = start_edge;
-      Face_edges  face;
-
-      for (;;)
-      {
-        face.push_back({*curr_edge, curr_edge->reversed(prev_idx, curr_idx)});
-
-        // Base case
-        if (curr_idx == start_idx)
-        {
-          EZY_ASSERT(face.size() > 2);
-
-          // Deliberately accept the cycle only if the left-most walker produced a traversal
-          // whose shoelace is positive under our is_face_clockwise_ convention. If not, break
-          // (skip pushing a face for this seed). This is not an error -- other seeds may still
-          // discover the same geometric cycle (or its sibling faces) in the matching orientation.
-          // The early break makes the set of accepted faces and their order in m_faces depend on
-          // m_edges list order (affected by appends and push_backs during splits) and on individual
-          // Edge node_idx_a/b values (set from pa/pb at creation time, i.e. draw direction for
-          // edges added via the GUI line tool). This dependency has been observed to be required
-          // for correct results in the GUI for cases such as "square then mid vertical splitter
-          // added lower-to-top vs. top-to-bottom" (the break version yields the expected rects
-          // on the sides the user sees; a force-to-cw normalization for every collected cycle
-          // re-introduces the direction asymmetry or malformed faces in that flow).
-          // The hole test (and bridge/dangling face tests) still pass because their edge addition
-          // order + walker seeds happen to produce matching orientations for both outer and inner
-          // boundaries.
-          if (!is_face_clockwise_(face))
-            break;
-
-          for (const Face_edge& e : face)
-          {
-            // Mark edge in both directions to avoid processing the same face twice
-            // when starting from different nodes
-            size_t start_idx = e.start_nd_idx();
-            size_t end_idx   = e.end_nd_idx();
-            seen_edges.insert(std::make_pair(start_idx, end_idx));
-            seen_edges.insert(std::make_pair(end_idx, start_idx));
-          }
-
-          auto f = create_face_shape_(face);
-          f->SetColor(Quantity_NOC_GRAY7);       // Base color
-          f->SetTransparency(0.5);               // 0.5 = 50% transparent (0.0 = opaque, 1.0 = invisible)
-          f->SetMaterial(Graphic3d_NOM_PLASTIC); // Optional: material for shading
-
-          m_ctx.Display(f, AIS_Shaded, AIS_Shape::SelectionMode(TopAbs_FACE), true);
-          m_ctx.Activate(f, AIS_Shape::SelectionMode(TopAbs_FACE));
-          // m_ctx.UpdateCurrentViewer();
-          m_faces.push_back(f);
-          break;
-        }
-
-        size_t      left_most_idx;
-        double      min_angle      = std::numeric_limits<double>::max();
-        const Edge* left_most_edge = nullptr;
-        gp_Vec2d    edge_a         = edge_outgoing_dir(prev_idx, curr_idx);
-
-        for (auto& [next_idx, next_edge] : adj_list[curr_idx])
-        {
-          if (next_idx == prev_idx)
-            continue;
-
-          gp_Vec2d edge_b = edge_outgoing_dir(curr_idx, next_idx);
-          double   angle  = std::atan2(edge_b.Crossed(edge_a), edge_b.Dot(edge_a));
-          if (angle < min_angle)
-          {
-            min_angle      = angle;
-            left_most_idx  = next_idx;
-            left_most_edge = next_edge;
-          }
-        }
-        if (!left_most_edge)
-          // Invalid topology, probably a dangling edge
-          break;
-
-        prev_idx  = curr_idx;
-        curr_idx  = left_most_idx;
-        curr_edge = left_most_edge;
-      }
-    }
-
-  // Mark unused nodes as deleted so they're excluded from snapping operations.
-  // Nodes become unused when all edges that reference them are removed.
-  // Permanent add-node points are never auto-tombstoned when unused; user delete sets `deleted` and it stays.
-  for (size_t idx = 0, num = m_nodes.size(); idx < num; ++idx)
-    if (!m_nodes[idx].permanent)
-      m_nodes[idx].deleted = !used_nodes[idx];
-
-  // Book keeping
-  struct Face_meta
-  {
-    Sketch_face_shp_ptr           shp;
-    double                        area;
-    int                           parent_idx;
-    std::vector<const Face_meta*> holes;
-  };
-
-  std::vector<Face_meta> face_metas;
-  face_metas.reserve(m_faces.size());
-  for (Sketch_face_shp_ptr& face : m_faces)
-    face_metas.push_back({face, compute_face_area(face), -1});
-
-  // Sort faces by area (descending) to check larger faces first
-  std::sort(face_metas.begin(), face_metas.end(),
-            [](const Face_meta& a, const Face_meta& b)
-            {
-              return a.area > b.area; // Descending by area
-            });
-
-  // Classify faces
-  for (size_t face_i = 0, num = face_metas.size(); face_i < num; ++face_i)
-  {
-    Face_meta& face_a = face_metas[face_i];
-    for (size_t face_j = face_i + 1; face_j < num; ++face_j)
-    {
-      Face_meta& face_b = face_metas[face_j];
-      if (is_face_contained(face_b.shp->Shape(), face_a.shp->Shape()))
-        // Check if face_a is better (smaller) parent than the current one
-        if (face_b.parent_idx == -1 || face_a.area < face_metas[face_a.parent_idx].area)
-          face_b.parent_idx = static_cast<int>(face_i);
-    }
-  }
-
-  // Assign holes
-  for (const Face_meta& face : face_metas)
-    if (face.parent_idx != -1)
-      face_metas[face.parent_idx].holes.push_back(&face);
-
-  // Rebuild face shapes with their holes
-  for (Face_meta& face : face_metas)
-    if (face.holes.size())
-    {
-      EZY_ASSERT(face.shp->Shape().ShapeType() == TopAbs_FACE);
-      BRepBuilderAPI_MakeFace face_maker(TopoDS::Face(face.shp->Shape()));
-      for (const Face_meta* hole : face.holes)
-      {
-        EZY_ASSERT(hole->shp->Shape().ShapeType() == TopAbs_FACE);
-        TopoDS_Wire hole_wire = BRepTools::OuterWire(TopoDS::Face(hole->shp->Shape()));
-        // Winding order is important
-        hole_wire.Reverse();
-        face_maker.Add(hole_wire);
-      }
-      EZY_ASSERT(face_maker.IsDone());
-      // auto dbg_face = to_boost(face_maker.Face(), m_pln);
-      face.shp->SetShape(face_maker.Face());
-    }
-
-  // Use the nesting depth of the faces to define the face selection sensitivity
-  for (const Face_meta& face : face_metas)
-  {
-    int              nesting_depth = 0;
-    const Face_meta* curr_face     = &face;
-    for (; curr_face->parent_idx != -1; ++nesting_depth)
-      curr_face = &face_metas[curr_face->parent_idx];
-
-    m_ctx.SetSelectionSensitivity(face.shp, 0, nesting_depth + 1);
-  }
-
-  rebuild_dim_classifier_face_cache_();
-  purge_stale_length_dimensions_();
-  sync_permanent_node_annos_();
-  refresh_all_length_dimensions_();
-
-  if (is_current())
-    m_view.refresh_active_sketch_grid();
-}
-
-void Sketch::rebuild_dim_classifier_face_cache_()
-{
-  m_dim_classifier_faces.clear();
-  m_dim_classifier_faces.reserve(m_faces.size());
-  for (const Sketch_face_shp_ptr& fp : m_faces)
-    m_dim_classifier_faces.push_back(TopoDS::Face(fp->Shape()));
-}
-
-size_t Sketch::Face_edge::start_nd_idx() const
-{
-  if (!reversed)
-    return edge.node_idx_a;
-
-  EZY_ASSERT(edge.node_idx_b);
-  return *edge.node_idx_b;
-}
-
-size_t Sketch::Face_edge::end_nd_idx() const
-{
-  if (reversed)
-    return edge.node_idx_a;
-
-  EZY_ASSERT(edge.node_idx_b);
-  return *edge.node_idx_b;
-}
-
-bool Sketch::is_face_clockwise_(const Face_edges& face) const
-{
-  // Compute signed area using the shoelace formula
-  double signed_area = 0.0;
-  for (const Face_edge& e : face)
-  {
-    // `start_nd_idx` and `end_nd_idx` consider reversed edges
-    const gp_Pnt2d& p1 = m_nodes[e.start_nd_idx()];
-    const gp_Pnt2d& p2 = m_nodes[e.end_nd_idx()];
-    signed_area += (p1.X() * p2.Y()) - (p2.X() * p1.Y());
-  }
-  // signed_area *= 0.5;  // Divide by 2 for actual area
-
-  return signed_area > 0;
-}
-
-Sketch_face_shp_ptr Sketch::create_face_shape_(const Face_edges& face)
-{
-  EZY_ASSERT(face.size() > 2);
-
-  // Create edges for the wire
-  BRepBuilderAPI_MakeWire wire_maker;
-
-  struct Circle_arc
-  {
-    std::optional<size_t> nd_idx_a;
-    std::optional<size_t> nd_idx_b;
-    std::optional<size_t> nd_idx_c;
-    std::optional<bool>   dbg_reversed;
-  };
-
-  std::map<Geom_TrimmedCurve*, Circle_arc> circle_arcs;
-  std::vector<gp_Pnt>                      node_verts;
-  std::optional<size_t>                    dbg_last_node_idx;
-
-  for (const Face_edge& e : face)
-  {
-    EZY_ASSERT(e.edge.node_idx_b);
-
-    auto add_node_vert_unique = [&](const gp_Pnt& pt)
-    {
-      if (node_verts.empty())
-        node_verts.push_back(pt);
-      else if (!node_verts.back().IsEqual(pt, Precision::Confusion()))
-        node_verts.push_back(pt);
-    };
-
-    if (e.edge.circle_arc.get())
-    {
-      Circle_arc& arc = circle_arcs[e.edge.circle_arc.get()];
-
-      auto try_arc_circle = [&](bool reversed)
-      {
-        if (!arc.dbg_reversed.has_value())
-          arc.dbg_reversed = reversed;
-        else
-          EZY_ASSERT(*arc.dbg_reversed == reversed);
-
-        if (arc.nd_idx_a && arc.nd_idx_b && arc.nd_idx_c)
-        {
-          gp_Pnt a = to_3d_(arc.nd_idx_a);
-          gp_Pnt b = to_3d_(arc.nd_idx_b);
-          gp_Pnt c = to_3d_(arc.nd_idx_c);
-
-          add_node_vert_unique(a);
-          add_node_vert_unique(b);
-          add_node_vert_unique(c);
-
-          Geom_TrimmedCurve_ptr arc_circle;
-          if (reversed)
-            arc_circle = GC_MakeArcOfCircle(c, b, a);
-          else
-            arc_circle = GC_MakeArcOfCircle(a, b, c);
-
-          BRepBuilderAPI_MakeEdge edge(arc_circle);
-          EZY_ASSERT(edge.IsDone());
-          wire_maker.Add(edge.Edge());
-        }
-      };
-
-      // Depending on the order of the node indexes in face,
-      // the first or second circle arc edge might come first.
-      if (e.edge.node_idx_arc)
-      {
-        // This is the first part of the circle arc.
-        EZY_ASSERT(e.edge.node_idx_arc);
-        EZY_ASSERT(*e.edge.node_idx_b == *e.edge.node_idx_arc);
-        arc.nd_idx_a = e.edge.node_idx_a;
-        arc.nd_idx_b = e.edge.node_idx_arc;
-        try_arc_circle(e.reversed);
-      }
-      else
-      {
-        // This is the second part of the circle arc.
-        arc.nd_idx_c = *e.edge.node_idx_b;
-        try_arc_circle(e.reversed);
-      }
-    }
-    else
-    {
-      gp_Pnt a = to_3d_(e.start_nd_idx());
-      gp_Pnt b = to_3d_(e.end_nd_idx());
-
-      add_node_vert_unique(a);
-      add_node_vert_unique(b);
-
-      BRepBuilderAPI_MakeEdge edge(a, b);
-      EZY_ASSERT(edge.IsDone());
-      wire_maker.Add(edge.Edge());
-    }
-  }
-
-  EZY_ASSERT(wire_maker.IsDone());
-  TopoDS_Wire wire = wire_maker.Wire();
-
-  // Create a face from the wire
-  BRepBuilderAPI_MakeFace face_maker(wire);
-  EZY_ASSERT(face_maker.IsDone());
-
-  // auto dbg_face = to_boost(face_maker.Face(), m_pln);
-
-  Sketch_face_shp* ret = new Sketch_face_shp(*this, face_maker.Face());
-  std::swap(node_verts, ret->verts_3d);
-  return ret;
-}
-
 bool Sketch::s_add_mid_pt_edges = false;
 bool Sketch::s_edge_from_center = false;
 
@@ -2741,7 +2035,7 @@ void Sketch::set_visible(bool state)
   if (state)
   {
     if (m_show_faces)
-      for (AIS_Shape_ptr& face : m_faces)
+      for (AIS_Shape_ptr& face : m_topo.faces())
         m_ctx.Display(face, AIS_Shaded, 0, false);
 
     for (Edge& e : m_edges)
@@ -2766,7 +2060,7 @@ void Sketch::set_visible(bool state)
   }
   else
   {
-    for (AIS_Shape_ptr& face : m_faces)
+    for (AIS_Shape_ptr& face : m_topo.faces())
       m_ctx.Erase(face, false);
 
     for (Edge& e : m_edges)
@@ -2802,10 +2096,10 @@ bool Sketch::is_visible() const { return m_visible; }
 void Sketch::set_show_faces(bool show)
 {
   if (show && m_visible)
-    for (AIS_Shape_ptr& face : m_faces)
+    for (AIS_Shape_ptr& face : m_topo.faces())
       m_ctx.Display(face, AIS_Shaded, 0, false);
   else
-    for (AIS_Shape_ptr& face : m_faces)
+    for (AIS_Shape_ptr& face : m_topo.faces())
       m_ctx.Erase(face, false);
 
   m_show_faces = show;
@@ -2924,7 +2218,7 @@ void Sketch::append_list_hover_ais(std::vector<AIS_InteractiveObject_ptr>& out) 
       out.push_back(e.shp);
 
   if (m_show_faces)
-    for (const Sketch_face_shp_ptr& face : m_faces)
+    for (const Sketch_face_shp_ptr& face : m_topo.faces())
       if (!face.IsNull())
         out.push_back(face);
 
@@ -3025,7 +2319,7 @@ bool Sketch::has_edges() const { return !m_edges.empty(); }
 
 size_t Sketch::edge_count() const { return m_edges.size(); }
 
-size_t Sketch::face_count() const { return m_faces.size(); }
+size_t Sketch::face_count() const { return m_topo.faces().size(); }
 
 size_t Sketch::length_dimension_count() const { return m_length_dimensions.size(); }
 
@@ -3047,10 +2341,10 @@ std::vector<std::string> Sketch::inspector_edge_labels() const
 std::vector<std::string> Sketch::inspector_face_labels() const
 {
   std::vector<std::string> labels;
-  labels.reserve(m_faces.size());
-  for (size_t i = 0; i < m_faces.size(); ++i)
+  labels.reserve(m_topo.faces().size());
+  for (size_t i = 0; i < m_topo.faces().size(); ++i)
   {
-    const Sketch_face_shp_ptr& f   = m_faces[i];
+    const Sketch_face_shp_ptr& f   = m_topo.faces()[i];
     std::string                lbl = (f && !f->name.empty()) ? f->name : ("F" + std::to_string(i));
     labels.push_back(std::move(lbl));
   }
@@ -3130,7 +2424,7 @@ void Sketch::sync_permanent_node_annos_()
     m_permanent_node_marks.resize(m_nodes.size());
 
   const double size_scale = std::max(static_cast<double>(m_view.gui().permanent_node_anno_scale()), 0.0);
-  const double half_arm   = std::max(plane_pick_snap_radius_world_() * 0.45 * size_scale, Precision::Confusion() * 50.0);
+  const double half_arm   = std::max(m_topo.plane_pick_snap_radius_world() * 0.45 * size_scale, Precision::Confusion() * 50.0);
 
   const Mode mode = get_mode();
   // Show "+" markers for permanent user nodes in sketch modes and polar duplicate (which snaps to sketch nodes).

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -25,36 +25,6 @@
 
 using namespace glm;
 
-namespace
-{
-struct Symmetric_edge_span
-{
-  gp_Pnt2d pt_a;
-  gp_Pnt2d pt_b;
-  double   full_len;
-};
-
-std::optional<Symmetric_edge_span> symmetric_edge_from_center(const gp_Pnt2d& center, const gp_Dir2d& dir, double full_len)
-{
-  if (full_len <= Precision::Confusion())
-    return std::nullopt;
-
-  const double   half = full_len * 0.5;
-  const gp_Vec2d v(dir);
-  return Symmetric_edge_span{center.Translated(-v * half), center.Translated(v * half), full_len};
-}
-
-std::optional<Symmetric_edge_span> symmetric_edge_from_center_and_hint(const gp_Pnt2d& center, const gp_Pnt2d& dir_hint_pt)
-{
-  gp_Vec2d     v(center, dir_hint_pt);
-  const double half = v.Magnitude();
-  if (half <= Precision::Confusion())
-    return std::nullopt;
-
-  return symmetric_edge_from_center(center, gp_Dir2d(v), half * 2.0);
-}
-} // namespace
-
 Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln)
     : m_view(view)
     , m_ctx(view.ctx())
@@ -65,6 +35,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln)
     , m_topo(*this)
     , m_dims(*this)
     , m_node_marks(*this)
+    , m_tools(*this)
     , m_underlay(view.ctx())
 {
 }
@@ -79,6 +50,7 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, cons
     , m_topo(*this)
     , m_dims(*this)
     , m_node_marks(*this)
+    , m_tools(*this)
     , m_underlay(view.ctx())
 {
   m_originating_face = new AIS_Shape(outer_wire);
@@ -89,75 +61,32 @@ Sketch::Sketch(const std::string& name, Occt_view& view, const gp_Pln& pln, cons
 Sketch::~Sketch()
 {
   m_underlay.ctx_erase();
-
   m_edges.remove_displayed();
-
   m_dims.remove_displayed();
-
   m_topo.remove_displayed_faces();
 
   if (m_operation_axis.has_value())
     m_ctx.Remove(m_operation_axis->shp, false);
 
   m_node_marks.remove_all();
-
   m_ctx.Remove(m_originating_face, true);
 }
 
-void Sketch::add_sketch_pt(const ScreenCoords& screen_coords)
-{
-  switch (get_mode())
-  {
-    // clang-format off
-    case Mode::Sketch_add_square:
-    case Mode::Sketch_add_circle:
-    case Mode::Sketch_add_rectangle:
-    case Mode::Sketch_add_rectangle_center_pt:
-      add_line_string_pt_(screen_coords, Linestring_type::Single);
-      break;
-    case Mode::Sketch_add_node:           add_node_pt_          (screen_coords);                            break;
-    case Mode::Sketch_add_edge:           add_line_string_pt_   (screen_coords, Linestring_type::Single);   break;
-    case Mode::Sketch_add_slot:           add_line_string_pt_   (screen_coords, Linestring_type::Two);      break;
-    case Mode::Sketch_add_multi_edges:    add_line_string_pt_   (screen_coords, Linestring_type::Multiple); break;
-    case Mode::Sketch_add_seg_circle_arc: add_arc_circle_pt_    (screen_coords);                            break;
-    case Mode::Sketch_operation_axis:     add_operation_axis_pt_(screen_coords);                            break;
-    default:
-      EZY_ASSERT(false);
-    // clang-format on
-  }
-}
+void Sketch::add_sketch_pt(const ScreenCoords& screen_coords) { m_tools.on_click(screen_coords); }
 
 void Sketch::sketch_pt_move(const ScreenCoords& screen_coords)
 {
   switch (get_mode())
   {
-    // clang-format off
-    case Mode::Sketch_add_node:            move_add_node_pt_    (screen_coords); break;
-    case Mode::Sketch_add_seg_circle_arc:  move_arc_circle_pt_  (screen_coords); break;
-    case Mode::Sketch_add_square:          move_square_pt_      (screen_coords); break;
-    case Mode::Sketch_add_circle:          move_circle_pt_      (screen_coords); break;
-    case Mode::Sketch_add_slot:            move_slot_pt_        (screen_coords); break;
-
-    case Mode::Sketch_add_edge:
-    case Mode::Sketch_operation_axis:
-    case Mode::Sketch_add_multi_edges:
-      move_line_string_pt_ (screen_coords);
-      break;
-
-    case Mode::Sketch_dim_anno:
-      (void)m_nodes.try_pick_existing_node(screen_coords);
-      m_dims.update_len_dim_rubber_line_(screen_coords);
-      break;
-    
-    case Mode::Sketch_add_rectangle:
-    case Mode::Sketch_add_rectangle_center_pt:
-      move_rectangle_pt_(screen_coords);
-      break;
-
-    // clang-format on
+  case Mode::Sketch_dim_anno:
+    (void)m_nodes.try_pick_existing_node(screen_coords);
+    m_dims.update_len_dim_rubber_line_(screen_coords);
+    return;
   default:
     break;
   }
+
+  m_tools.on_move(screen_coords);
 }
 
 void Sketch::dimension_input(const ScreenCoords& screen_coords)
@@ -183,8 +112,8 @@ void Sketch::dbg_append_str(std::string& out) const
   out += "    Nodes: " + std::to_string(m_nodes.size()) + "\n";
   out += "    Edges: " + std::to_string(m_edges.size()) + "\n";
   out += "    Faces: " + std::to_string(m_topo.faces().size()) + "\n";
-  out += "Tmp Nodes: " + std::to_string(m_tmp_node_idxs.size()) + "\n";
-  out += "Tmp Edges: " + std::to_string(m_tmp_edges.size()) + "\n";
+  out += "Tmp Nodes: " + std::to_string(m_tools.tmp_node_count()) + "\n";
+  out += "Tmp Edges: " + std::to_string(m_tools.tmp_edge_count()) + "\n";
 }
 
 void Sketch::update_edge_style_(AIS_Shape_ptr& shp)
@@ -257,714 +186,176 @@ void Sketch::update_edge_shp_(Edge& edge, const gp_Pnt2d& pt_a, const gp_Pnt2d& 
   }
 }
 
-void Sketch::on_enter()
-{
-  switch (get_mode())
-  {
-    // clang-format off
-    case Mode::Sketch_add_square:
-    case Mode::Sketch_add_rectangle:
-    case Mode::Sketch_add_rectangle_center_pt:
-    case Mode::Sketch_add_circle:
-    case Mode::Sketch_add_node:
-      m_dims.check_dimension_rubber_();
-      break;
-    case Mode::Sketch_add_edge:
-      m_dims.check_dimension_seg_(static_cast<int>(Linestring_type::Single));
-      break;
-    case Mode::Sketch_add_slot:
-      m_dims.check_dimension_seg_(static_cast<int>(Linestring_type::Two));
-      break;
-    case Mode::Sketch_add_multi_edges:
-      m_dims.check_dimension_seg_(static_cast<int>(Linestring_type::Multiple));
-      break;
-    // clang-format on
-  default:
-    break;
-  }
-}
-
-// Line string related
-bool Sketch::edge_from_center_active_() const
-{
-  return s_edge_from_center && get_mode() == Mode::Sketch_add_edge && !m_tmp_edges.empty() &&
-         !m_tmp_edges.back().node_idx_b.has_value();
-}
-
-bool Sketch::complete_edge_from_center_(const ScreenCoords& screen_coords)
-{
-  if (!edge_from_center_active_())
-    return false;
-
-  Edge&           edge   = m_tmp_edges.back();
-  const gp_Pnt2d& center = m_nodes[edge.node_idx_a];
-
-  std::optional<Symmetric_edge_span> span;
-  if (m_dims.entered_edge_len().has_value())
-    span = symmetric_edge_from_center(center, m_dims.entered_edge_len()->dir, m_dims.entered_edge_len()->len);
-
-  else if (m_dims.entered_edge_angle().has_value())
-  {
-    std::optional<gp_Pnt2d> pt_opt = m_view.pt_on_plane(screen_coords, m_pln);
-    if (!pt_opt)
-      return true;
-
-    const double angle_rad = to_radians(*m_dims.entered_edge_angle());
-    gp_Dir2d     dir(std::cos(angle_rad), std::sin(angle_rad));
-    gp_Vec2d     to_click(center, *pt_opt);
-    const double half = std::abs(to_click.Dot(gp_Vec2d(dir)));
-    span              = symmetric_edge_from_center(center, dir, half * 2.0);
-  }
-  else
-  {
-    std::optional<gp_Pnt2d> pt_opt = m_view.pt_on_plane(screen_coords, m_pln);
-    if (!pt_opt)
-      return true;
-
-    span = symmetric_edge_from_center_and_hint(center, *pt_opt);
-  }
-
-  if (!span)
-    return true;
-
-  edge.node_idx_a = m_nodes.get_node_exact(span->pt_a);
-  update_edge_end_pt_(edge, m_nodes.get_node_exact(span->pt_b));
-  m_dims.entered_edge_angle() = std::nullopt;
-  m_dims.entered_edge_len()   = std::nullopt;
-  m_dims.set_show_angle_input(false);
-  m_dims.set_show_dim_input(false);
-  m_view.gui().hide_angle_edit();
-  finalize_elm();
-  return true;
-}
-
-void Sketch::add_line_string_pt_(const ScreenCoords& screen_coords, Linestring_type linestring_type)
-{
-  if (edge_from_center_active_() && linestring_type == Linestring_type::Single)
-  {
-    complete_edge_from_center_(screen_coords);
-    return;
-  }
-
-  auto on_line_string = [&](size_t node_idx)
-  {
-    if (m_tmp_edges.size())
-    {
-      Edge& last_edge = m_tmp_edges.back();
-      if (node_idx == last_edge.node_idx_a)
-        // We cannot have edges with zero length.
-        return;
-
-      update_edge_end_pt_(last_edge, node_idx);
-
-      if (linestring_type == Linestring_type::Single)
-      {
-        finalize_elm();
-        return;
-      }
-      else if (linestring_type == Linestring_type::Two)
-        if (m_tmp_edges.size() == 2)
-        {
-          finalize_elm();
-          return;
-        }
-    }
-
-    // Start a new edge - clear constraints for fresh start (click path for multi-line)
-    m_dims.entered_edge_angle() = std::nullopt;
-    m_dims.entered_edge_len()   = std::nullopt;
-    m_dims.set_show_angle_input(false);
-    m_view.gui().hide_angle_edit();
-    m_tmp_edges.push_back({node_idx});
-  };
-
-  // When angle constraint is active, finalize on the constrained line (project click onto it)
-  if (m_dims.entered_edge_angle().has_value() && m_tmp_edges.size())
-  {
-    if (edge_from_center_active_())
-    {
-      complete_edge_from_center_(screen_coords);
-      return;
-    }
-
-    std::optional<gp_Pnt2d> pt_opt = m_view.pt_on_plane(screen_coords, m_pln);
-    if (!pt_opt)
-      return;
-
-    const gp_Pnt2d& pt_a      = m_nodes[m_tmp_edges.back().node_idx_a];
-    double          angle_rad = to_radians(*m_dims.entered_edge_angle());
-    gp_Dir2d        constrained_dir(std::cos(angle_rad), std::sin(angle_rad));
-    gp_Vec2d        to_click(pt_opt->X() - pt_a.X(), pt_opt->Y() - pt_a.Y());
-    double          dist_along = to_click.Dot(gp_Vec2d(constrained_dir));
-    gp_Pnt2d        final_pt   = gp_Pnt2d(pt_a).Translated(gp_Vec2d(constrained_dir) * dist_along);
-    if (!unique(pt_a, final_pt))
-      return;
-
-    // Do not run try_get_node_idx_snap here: it can move the point off the angle ray (axis snap).
-    const size_t node_idx = m_nodes.get_node_exact(final_pt);
-    m_tmp_node_idxs.push_back(node_idx);
-    on_line_string(node_idx);
-    return;
-  }
-
-  add_sketch_pt_(screen_coords, 1, on_line_string);
-}
-
-void Sketch::move_line_string_pt_(const ScreenCoords& screen_coords)
-{
-  if (edge_from_center_active_())
-  {
-    auto l = [&](const std::optional<size_t>&, const gp_Pnt2d& pt_b)
-    {
-      Edge&           edge   = m_tmp_edges.back();
-      const gp_Pnt2d& center = m_nodes[edge.node_idx_a];
-
-      std::optional<Symmetric_edge_span> span;
-      if (m_dims.entered_edge_angle().has_value())
-      {
-        const double angle_rad = to_radians(*m_dims.entered_edge_angle());
-        gp_Dir2d     dir(std::cos(angle_rad), std::sin(angle_rad));
-        if (m_dims.entered_edge_len().has_value())
-          span = symmetric_edge_from_center(center, dir, m_dims.entered_edge_len()->len);
-        else
-        {
-          gp_Vec2d     to_mouse(center, pt_b);
-          const double half = std::abs(to_mouse.Dot(gp_Vec2d(dir)));
-          span              = symmetric_edge_from_center(center, dir, half * 2.0);
-        }
-      }
-      else if (m_dims.entered_edge_len().has_value())
-        span = symmetric_edge_from_center(center, m_dims.entered_edge_len()->dir, m_dims.entered_edge_len()->len);
-      else
-        span = symmetric_edge_from_center_and_hint(center, pt_b);
-
-      if (!span)
-      {
-        if (edge.shp)
-        {
-          m_ctx.Remove(edge.shp, true);
-          edge.shp.Nullify();
-        }
-        m_dims.clear_tmp_dim_anno();
-        return;
-      }
-
-      const gp_Pnt2d& span_a = span->pt_a;
-      const gp_Pnt2d& span_b = span->pt_b;
-      update_edge_shp_(edge, span_a, span_b);
-
-      const double dist = span->full_len / m_view.get_dimension_scale();
-      m_dims.show_tmp_dim_preview(span_a, span_b);
-      m_dims.offer_dist_edit_for_segment(span_a, span_b, dist);
-      m_dims.offer_angle_edit_for_segment(center, pt_b,
-                                          to_degrees(std::atan2(gp_Vec2d(center, pt_b).Y(), gp_Vec2d(center, pt_b).X())));
-    };
-
-    move_sketch_pt_(screen_coords, l);
-    return;
-  }
-
-  auto l = [&](const std::optional<size_t>& node_idx_b, const gp_Pnt2d& pt_b)
-  {
-    if (m_tmp_edges.empty())
-      return;
-
-    Edge&           edge = m_tmp_edges.back();
-    const gp_Pnt2d& pt_a = m_nodes[edge.node_idx_a];
-
-    if (!unique(pt_a, pt_b))
-      // Cannot have a edge with zero length
-      return;
-
-    gp_Pnt2d final_pt_b = pt_b;
-
-    // Apply angle constraint if set - this takes priority
-    if (m_dims.entered_edge_angle().has_value())
-    {
-      // Calculate direction based on angle (0 degrees = positive X axis, counterclockwise)
-      double   angle_rad = to_radians(*m_dims.entered_edge_angle());
-      gp_Dir2d constrained_dir(std::cos(angle_rad), std::sin(angle_rad));
-
-      // If distance is also constrained, use that
-      if (m_dims.entered_edge_len().has_value())
-        // Use the constrained distance - angle constraint is always enforced
-        final_pt_b = gp_Pnt2d(pt_a).Translated(gp_Vec2d(constrained_dir) * m_dims.entered_edge_len()->len);
-      else
-      {
-        // Project the mouse point onto the angle-constrained line
-        // Find the distance along the constrained direction from pt_a to mouse position
-        gp_Vec2d to_mouse(pt_b.X() - pt_a.X(), pt_b.Y() - pt_a.Y());
-        double   dist_along_constrained = to_mouse.Dot(gp_Vec2d(constrained_dir));
-
-        // Calculate the point on the constrained line at this distance
-        // This ensures the angle is ALWAYS maintained
-        final_pt_b = gp_Pnt2d(pt_a).Translated(gp_Vec2d(constrained_dir) * dist_along_constrained);
-      }
-
-      // Disable snapping when angle constraint is active - angle takes priority
-      edge.node_idx_b = std::nullopt;
-    }
-    // Apply distance constraint if set (and angle is not set)
-    else if (m_dims.entered_edge_len().has_value())
-    {
-      final_pt_b      = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_dims.entered_edge_len()->dir) * m_dims.entered_edge_len()->len);
-      edge.node_idx_b = m_nodes.try_get_node_idx_snap(final_pt_b);
-    }
-    else
-    {
-      // No constraints - check for snap points at mouse position
-      edge.node_idx_b = m_nodes.try_get_node_idx_snap(final_pt_b);
-      if (edge.node_idx_b.has_value())
-        final_pt_b = m_nodes[edge.node_idx_b];
-    }
-
-    double dist = pt_a.Distance(final_pt_b) / m_view.get_dimension_scale();
-    m_dims.show_tmp_dim_preview(pt_a, final_pt_b);
-    m_dims.offer_dist_edit_for_segment(pt_a, final_pt_b, dist);
-
-    gp_Vec2d vec(pt_a, pt_b);
-    m_dims.offer_angle_edit_for_segment(pt_a, pt_b, to_degrees(std::atan2(vec.Y(), vec.X())));
-
-    if (unique(pt_a, final_pt_b))
-      update_edge_shp_(edge, pt_a, final_pt_b);
-
-    else if (edge.shp)
-    {
-      m_ctx.Remove(edge.shp, true);
-      edge.shp.Nullify();
-    }
-  };
-
-  move_sketch_pt_(screen_coords, l);
-}
-
-void Sketch::finalize_edges_(Sketch_op_recorder& rec)
-{
-  if (m_nodes.empty() || m_tmp_edges.empty())
-    return;
-
-  if (!m_tmp_edges.back().node_idx_b.has_value())
-  {
-    // Last edge was not finalized, remove it
-    m_ctx.Remove(m_tmp_edges.back().shp, false);
-    m_tmp_edges.pop_back();
-  }
-
-  if (m_tmp_edges.empty())
-    return;
-
-  // Record user-intent edges before any split/append side effects.
-  for (const Edge& te : m_tmp_edges)
-  {
-    EZY_ASSERT(te.node_idx_b.has_value());
-    rec.note_curr_linear_edge(m_nodes[te.node_idx_a], m_nodes[*te.node_idx_b]);
-  }
-
-  std::vector<size_t> split_mid_points;
-  for (Edge& e : m_tmp_edges)
-  {
-    EZY_ASSERT(e.node_idx_b.has_value());
-    if (m_nodes[e.node_idx_a].midpoint)
-      split_mid_points.push_back(e.node_idx_a);
-
-    if (m_nodes[e.node_idx_b].midpoint)
-      split_mid_points.push_back(*e.node_idx_b);
-  }
-
-  // Split any *existing* (pre this batch) linear edges that intersect or touch the
-  // new segments being committed (the tmp ones). This fulfills the requirement that
-  // adding edges from the GUI splits existing intersecting/touching edges.
-  std::vector<gp_Pnt2d> batch_inters;
-  {
-    for (const Edge& te : m_tmp_edges)
-    {
-      // All remaining tmp edges must be complete at this point:
-      // - The code above already popped any trailing incomplete one.
-      // - The split_mid_points loop immediately before this used EZY_ASSERT on every te.
-      // Therefore we can (and should) assert rather than silently continue.
-      // (A defensive "if (!...) continue" would be appropriate for filtering *old* edges
-      // in m_edges, which may contain arcs or other non-linear things, but not here.)
-      EZY_ASSERT(te.node_idx_b.has_value());
-
-      gp_Pnt2d pa = m_nodes[te.node_idx_a];
-      gp_Pnt2d pb = m_nodes[te.node_idx_b];
-      for (const Edge& oe : m_edges.edges()) // pre-batch olds only
-      {
-        if (!is_linear_edge_(oe))
-          continue;
-
-        gp_Pnt2d qa = m_nodes[oe.node_idx_a];
-        gp_Pnt2d qb = m_nodes[oe.node_idx_b];
-        if (auto inter = segment_intersection_2d(pa, pb, qa, qb, Segment_inclusion::Closed))
-        {
-          // The intersection point is now guaranteed (by the inclusion parameter)
-          // to lie on both finite closed segments. The previous custom verification
-          // has been moved into segment_intersection_2d for consistency.
-          add_unique_point(batch_inters, *inter);
-        }
-      }
-    }
-
-    // Only split olds at interior hits (avoid snap on endpoint-touch inters from the batch, same reason as add_edge_).
-    std::vector<gp_Pnt2d> batch_to_split;
-    for (const auto& ip : batch_inters)
-    {
-      bool is_old_interior = false;
-      for (const Edge& e : m_edges.edges())
-      {
-        if (!is_linear_edge_(e))
-          continue;
-
-        gp_Pnt2d qa = m_nodes[e.node_idx_a];
-        gp_Pnt2d qb = m_nodes[e.node_idx_b];
-        if (point_on_open_segment_2d(ip, qa, qb))
-        {
-          is_old_interior = true;
-          break;
-        }
-      }
-
-      if (is_old_interior)
-        add_unique_point(batch_to_split, ip);
-    }
-
-    for (const auto& ip : batch_to_split)
-      m_topo.split_linear_edges_at_node_if_interior(m_nodes.get_node_exact(ip), rec);
-  }
-
-  append(m_edges.edges(), m_tmp_edges);
-  m_tmp_edges.clear();
-
-  // Ensure topology is correct if snapping on a midpoint happened.
-  // These edges need to be split. (Kept for compatibility with current midpoint marking during draw.)
-  for (size_t mid_pt_idx : split_mid_points)
-    for (auto itr = m_edges.edges().begin(), end = m_edges.edges().end(); itr != end; ++itr)
-      if (itr->node_idx_mid.has_value() && *itr->node_idx_mid == mid_pt_idx)
-        // Cannot split arc circles.
-        if (!itr->node_idx_arc.has_value())
-        {
-          // Split the edge.
-          Edge edge_a{itr->node_idx_a, mid_pt_idx};
-          Edge edge_b{mid_pt_idx, *itr->node_idx_b};
-          update_edge_shp_(edge_a, m_nodes[itr->node_idx_a], m_nodes[mid_pt_idx]);
-          update_edge_shp_(edge_b, m_nodes[itr->node_idx_b], m_nodes[mid_pt_idx]);
-          rec.note_prev_linear_edge(itr->node_idx_a, *itr->node_idx_b, itr->node_idx_mid, itr->name);
-          // Set midpoints for the new split edges so they can be snapped to
-          edge_a.node_idx_mid = m_nodes.add_new_node(get_midpoint(m_nodes[itr->node_idx_a], m_nodes[mid_pt_idx]), true);
-          edge_b.node_idx_mid = m_nodes.add_new_node(get_midpoint(m_nodes[mid_pt_idx], m_nodes[itr->node_idx_b]), true);
-          rec.note_curr_node(edge_a.node_idx_mid.value());
-          rec.note_curr_node(edge_b.node_idx_mid.value());
-          m_ctx.Remove(itr->shp, false);
-          m_edges.edges().erase(itr);
-          m_nodes[mid_pt_idx].midpoint = false;
-          m_edges.edges().emplace_back(edge_a);
-          m_edges.edges().emplace_back(edge_b);
-          break;
-        }
-
-  // Subdivide any *newly committed* edges (the ones from m_tmp) at interior intersections
-  // discovered in the pre-pass. The pre-pass already handled olds; re-calling split here
-  // will target the news (olds' original long edges no longer exist). This ensures the
-  // GUI finalize path produces the same atomic edge count as direct add_edge_ (e.g. 4
-  // edges for a cross, whether or not the cross is at an existing mid).
-  for (const auto& ip : batch_inters)
-  {
-    const size_t nidx = m_nodes.get_node_exact(ip);
-    rec.note_curr_node(nidx);
-    m_topo.split_linear_edges_at_node_if_interior(nidx, rec);
-  }
-
-  m_nodes.hide_snap_annos();
-  update_faces_();
-}
-
-void Sketch::add_node_pt_(const ScreenCoords& screen_coords)
-{
-  auto commit_b = [this](size_t node_b)
-  {
-    Sketch_op_recorder rec(m_view, *this);
-    {
-      rec.note_curr_node(node_b);
-      m_topo.split_linear_edges_at_node_if_interior(node_b, rec);
-
-      // Add-node mode: the rubber band is only for placement (snap / dimension / angle). Do not create
-      // a sketch edge between the anchor and the new node - only nodes and interior splits matter.
-      m_tmp_node_idxs.clear();
-      clear_tmps_();
-      m_dims.clear_tmp_dim_anno();
-      m_nodes.hide_snap_annos();
-      update_faces_();
-      rec.commit();
-    }
-  };
-
-  if (m_dims.entered_edge_angle().has_value() && m_tmp_edges.size())
-  {
-    std::optional<gp_Pnt2d> pt_opt = m_view.pt_on_plane(screen_coords, m_pln);
-    if (!pt_opt)
-      return;
-
-    const gp_Pnt2d& pt_a      = m_nodes[m_tmp_edges.back().node_idx_a];
-    double          angle_rad = to_radians(*m_dims.entered_edge_angle());
-    gp_Dir2d        constrained_dir(std::cos(angle_rad), std::sin(angle_rad));
-    gp_Vec2d        to_click(pt_opt->X() - pt_a.X(), pt_opt->Y() - pt_a.Y());
-    double          dist_along = to_click.Dot(gp_Vec2d(constrained_dir));
-    gp_Pnt2d        final_pt   = gp_Pnt2d(pt_a).Translated(gp_Vec2d(constrained_dir) * dist_along);
-    if (!unique(pt_a, final_pt))
-      return;
-
-    const size_t node_idx = m_nodes.get_node_exact(final_pt, true);
-    commit_b(node_idx);
-    return;
-  }
-
-  if (!m_view.pt_on_plane(screen_coords, m_pln))
-    return;
-
-  auto check_node = [&](const std::optional<size_t>& snap_to_node, const gp_Pnt2d& pt)
-  {
-    if (!m_tmp_edges.empty())
-    {
-      Edge&  last   = m_tmp_edges.back();
-      size_t node_b = snap_to_node ? *snap_to_node : m_nodes.add_new_node(pt, false, true);
-      if (node_b == last.node_idx_a)
-        return;
-
-      commit_b(node_b);
-      return;
-    }
-
-    // No tmp edge yet: snapping to an existing node starts a rubber-band segment from that anchor;
-    // the next placement finishes the edge. Clear angle/dimension UI from any prior mode.
-    if (snap_to_node)
-    {
-      auto start_rubber_from_anchor = [this](size_t idx_a)
-      {
-        m_dims.entered_edge_angle() = std::nullopt;
-        m_dims.entered_edge_len()   = std::nullopt;
-        m_dims.set_show_angle_input(false);
-        m_dims.set_show_dim_input(false);
-        m_view.gui().hide_angle_edit();
-        m_tmp_edges.push_back({idx_a});
-      };
-
-      start_rubber_from_anchor(*snap_to_node);
-      return;
-    }
-
-    Sketch_op_recorder rec(m_view, *this);
-    {
-      const size_t ni = m_nodes.add_new_node(pt, false, true);
-      rec.note_curr_node(ni);
-      m_topo.split_linear_edges_at_node_if_interior(ni, rec);
-      m_dims.clear_tmp_dim_anno();
-      m_nodes.hide_snap_annos();
-      update_faces_();
-      rec.commit();
-    }
-  };
-
-  move_sketch_pt_(screen_coords, check_node);
-}
-
-void Sketch::move_add_node_pt_(const ScreenCoords& screen_coords)
-{
-  if (!m_tmp_edges.empty())
-    move_line_string_pt_(screen_coords);
-  else
-    move_sketch_pt_(screen_coords, [](const std::optional<size_t>&, const gp_Pnt2d&) {});
-}
+void Sketch::on_enter() { m_tools.on_enter(); }
 
 void Sketch::update_faces_() { m_topo.update_faces(); }
 
-// Arc circle related
-void Sketch::add_arc_circle_pt_(const ScreenCoords& screen_coords)
+void Sketch::add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b) { m_edges.add_edge(pt_a, pt_b); }
+
+void Sketch::add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder& rec)
 {
-  std::optional<size_t> node_idx = m_nodes.get_node(screen_coords);
-  if (!node_idx)
+  m_edges.add_edge(pt_a, pt_b, rec);
+}
+
+void Sketch::add_edge_raw_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b) { m_edges.add_edge_raw_(pt_a, pt_b); }
+
+void Sketch::sketch_json_add_linear_edge_(size_t idx_a, size_t idx_b, std::optional<size_t> idx_mid)
+{
+  m_edges.sketch_json_add_linear_edge(idx_a, idx_b, idx_mid);
+}
+
+void Sketch::sketch_json_set_operation_axis_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  if (!unique(pt_a, pt_b))
     return;
 
-  if (!m_start_arc_circle_node_idx)
-  {
-    EZY_ASSERT(m_tmp_node_idxs.empty());
-    m_start_arc_circle_node_idx = m_nodes.size();
-  }
+  clear_operation_axis();
 
-  if (contains(m_tmp_node_idxs, node_idx))
-    // Arc points must be unique.
-    return;
+  Edge axis{m_nodes.get_node_exact(pt_a)};
+  axis.node_idx_b = m_nodes.get_node_exact(pt_b);
+  update_edge_shp_(axis, pt_a, pt_b);
+  m_operation_axis = std::move(axis);
 
-  m_tmp_node_idxs.push_back(*node_idx);
-
-  if (m_tmp_node_idxs.size() == 3)
-  {
-    Sketch_op_recorder rec(m_view, *this);
-    {
-      const gp_Pnt2d& pt_a = m_nodes[m_tmp_node_idxs[0]];
-      const gp_Pnt2d& pt_c = m_nodes[m_tmp_node_idxs[1]];
-      const gp_Pnt2d& pt_b = m_nodes[m_tmp_node_idxs[2]];
-      add_arc_circle_(pt_a, pt_b, pt_c, rec);
-      m_tmp_node_idxs.clear();
-      update_faces_();
-      rec.commit();
-    }
-  }
-}
-
-void Sketch::move_arc_circle_pt_(const ScreenCoords& screen_coords)
-{
-  std::optional<gp_Pnt2d> pt = m_nodes.snap(screen_coords);
-  if (!pt)
-    // View plane and sketch plane must be perpendicular.
-    return;
-
-  if (m_tmp_node_idxs.size() != 2)
-    return;
-
-  gp_Pnt a = to_3d_(m_tmp_node_idxs[0]);
-  gp_Pnt b = to_3d(m_pln, *pt);
-  gp_Pnt c = to_3d_(m_tmp_node_idxs[1]);
-
-  Handle(Geom_TrimmedCurve) arc_circle = GC_MakeArcOfCircle(a, b, c);
-  if (!arc_circle)
-  {
-    m_view.remove(m_tmp_shp);
-    m_tmp_shp = nullptr;
-    return;
-  }
-
-  TopoDS_Edge edge = BRepBuilderAPI_MakeEdge(arc_circle);
-  show(m_ctx, m_tmp_shp, edge);
-}
-
-void Sketch::move_square_pt_(const ScreenCoords& screen_coords)
-{
-  move_line_string_pt_(screen_coords);
-
-  auto l = [&](Edge& e, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
-  {
-    TopoDS_Wire square = make_square_wire(m_pln, pt_a, *m_last_pt);
-    show(m_ctx, m_tmp_shp, square);
-  };
-
-  if_edge_pt_valid_(l);
-}
-
-void Sketch::finalize_square_(Sketch_op_recorder& rec)
-{
-  auto l = [this, &rec](Edge& e, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
-  {
-    std::array<gp_Pnt2d, 4> corners = square_corners(pt_a, pt_b);
-    add_edge_(corners[0], corners[1], rec);
-    add_edge_(corners[1], corners[2], rec);
-    add_edge_(corners[2], corners[3], rec);
-    add_edge_(corners[3], corners[0], rec);
-    clear_tmps_();
-    update_faces_();
-  };
-
-  if_edge_pt_valid_(l);
-}
-
-void Sketch::move_rectangle_pt_(const ScreenCoords& screen_coords)
-{
-  move_line_string_pt_(screen_coords);
-
-  auto l = [&](Edge& e, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
-  {
-    EZY_ASSERT(m_tmp_edges.size());
-
-    if (std::abs(pt_a.X() - pt_b.X()) > Precision::Confusion() && std::abs(pt_a.Y() - pt_b.Y()) > Precision::Confusion())
-    {
-      TopoDS_Wire rectangle = make_rectangle_wire(m_pln, pt_a, pt_b);
-      show(m_ctx, m_tmp_shp, rectangle);
-    }
-    else
-    {
-      m_ctx.Remove(m_tmp_shp, true);
-      m_tmp_shp.Nullify();
-    }
-  };
-
-  if_edge_pt_valid_(l);
-}
-
-void Sketch::finalize_rectangle_(Sketch_op_recorder& rec)
-{
-  auto l = [this, &rec](Edge& e, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
-  {
-    if (std::abs(pt_a.X() - pt_b.X()) > Precision::Confusion() && std::abs(pt_a.Y() - pt_b.Y()) > Precision::Confusion())
-    {
-      std::array<gp_Pnt2d, 4> corners = rectangle_corners(pt_a, pt_b);
-      add_edge_(corners[0], corners[1], rec);
-      add_edge_(corners[1], corners[2], rec);
-      add_edge_(corners[2], corners[3], rec);
-      add_edge_(corners[3], corners[0], rec);
-      clear_tmps_();
-      update_faces_();
-    }
-    else
-    {
-      // Start a new edge
-      EZY_ASSERT(e.node_idx_b.has_value());
-      m_tmp_edges.push_back({*e.node_idx_b});
-    }
-  };
-
-  if_edge_pt_valid_(l);
-}
-
-// Slot related
-void Sketch::move_slot_pt_(const ScreenCoords& screen_coords)
-{
-  move_line_string_pt_(screen_coords);
-  auto l = [&](Edge& e, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
-  {
-    if (m_tmp_edges.size() != 2)
-      return;
-
-    const gp_Pnt2d& pt_a = m_nodes[m_tmp_edges.front().node_idx_a];
-    if (unique(pt_a, pt_b, pt_c))
-      show(m_ctx, m_tmp_shp, make_slot_wire(m_pln, pt_a, pt_b, pt_c));
-  };
-  if_edge_pt_valid_(l);
-}
-
-void Sketch::finalize_slot_(Sketch_op_recorder& rec)
-{
-  EZY_ASSERT(m_tmp_edges.size() == 2);
-  EZY_ASSERT(m_tmp_edges[1].node_idx_b.has_value());
-
-  Slot_pnts pnts = get_slot_points(m_nodes[m_tmp_edges[0].node_idx_a], m_nodes[m_tmp_edges[1].node_idx_a],
-                                   m_nodes[m_tmp_edges[1].node_idx_b]);
-
-  add_edge_(pnts.a_top_2d, pnts.b_top_2d, rec);
-  add_edge_(pnts.a_bottom_2d, pnts.b_bottom_2d, rec);
-  add_arc_circle_(pnts.a_bottom_2d, pnts.a_mid_2d, pnts.a_top_2d, rec);
-  add_arc_circle_(pnts.b_bottom_2d, pnts.b_mid_2d, pnts.b_top_2d, rec);
-  clear_tmps_();
-  update_faces_();
-}
-
-// Operation axis related
-void Sketch::add_operation_axis_pt_(const ScreenCoords& screen_coords)
-{
-  // Axis definition only happens when !has_operation_axis() (guarded at the call site in GUI).
-  // To redefine, the caller must first clear via the Options "Clear axis" button.
-  add_line_string_pt_(screen_coords, Linestring_type::Single);
-}
-
-void Sketch::finalize_operation_axis_(Sketch_op_recorder& rec)
-{
-  m_operation_axis = std::move(m_tmp_edges.back());
-  if (m_operation_axis->node_idx_b.has_value())
-    rec.note_curr_operation_axis(m_nodes[m_operation_axis->node_idx_a], m_nodes[*m_operation_axis->node_idx_b]);
-
-  cancel_elm(); // Reset state, we have the operation axis
   sync_operation_axis_display_();
-  m_node_marks.sync();
-  m_nodes.hide_snap_annos();
 }
+
+std::vector<Sketch::Edge> Sketch::get_selected_edges_() const { return m_edges.get_selected(); }
+
+std::vector<Sketch_face_shp_ptr> Sketch::get_selected_faces_() const
+{
+  std::vector<Sketch_face_shp_ptr> ret;
+  for (const AIS_Shape_ptr& selected : m_view.get_selected())
+    for (const Sketch_face_shp_ptr& face : m_topo.faces())
+      if (face == selected)
+        ret.push_back(face);
+
+  return ret;
+}
+
+std::list<Sketch::Edge>::iterator Sketch::get_edge_at_(const ScreenCoords& screen_coords)
+{
+  return m_edges.get_at(screen_coords);
+}
+
+bool Sketch::try_remove_length_dimension(PrsDim_LengthDimension* dim) { return m_dims.try_remove_length_dimension(dim); }
+
+void Sketch::toggle_edge_dim_anno(const ScreenCoords& screen_coords) { m_dims.toggle_edge_dim_anno(screen_coords); }
+
+void Sketch::json_add_length_dimension_(size_t node_a, size_t node_b, const bool visible,
+                                        const std::optional<double> flyout_offset, const std::string& name)
+{
+  m_dims.json_add_length_dimension_(node_a, node_b, visible, flyout_offset, name);
+}
+
+void Sketch::remove_length_dimensions_referencing_node_(size_t node_idx)
+{
+  m_dims.remove_length_dimensions_referencing_node_(node_idx);
+}
+
+void Sketch::set_show_dims(bool show) { m_dims.set_show_dims(show); }
+
+bool Sketch::shows_dimensions() const { return m_dims.shows_dimensions(); }
+
+bool Sketch::dimension_visible(size_t dim_index) const { return m_dims.dimension_visible(dim_index); }
+
+void Sketch::set_dimension_visible(size_t dim_index, bool visible) { m_dims.set_dimension_visible(dim_index, visible); }
+
+size_t Sketch::dimension_node_lo(size_t dim_index) const { return m_dims.dimension_node_lo(dim_index); }
+
+size_t Sketch::dimension_node_hi(size_t dim_index) const { return m_dims.dimension_node_hi(dim_index); }
+
+double Sketch::dimension_offset(size_t dim_index) const { return m_dims.dimension_offset(dim_index); }
+
+void Sketch::set_dimension_offset(size_t dim_index, const double offset) { m_dims.set_dimension_offset(dim_index, offset); }
+
+std::string Sketch::dimension_name(size_t dim_index) const { return m_dims.dimension_name(dim_index); }
+
+void Sketch::set_dimension_name(size_t dim_index, const std::string& name) { m_dims.set_dimension_name(dim_index, name); }
+
+PrsDim_LengthDimension_ptr Sketch::length_dimension_handle(const size_t dim_index) const
+{
+  return m_dims.length_dimension_handle(dim_index);
+}
+
+void Sketch::refresh_annotations(const Sketch_annotation_refresh& refresh)
+{
+  if (refresh.length_dimensions)
+    m_dims.refresh_all_length_dimensions();
+
+  if (refresh.permanent_node_marks)
+    m_node_marks.sync();
+}
+
+size_t Sketch::length_dimension_count() const { return m_dims.length_dimension_count(); }
+
+std::vector<std::string> Sketch::inspector_dimension_labels() const { return m_dims.inspector_dimension_labels(); }
+
+std::vector<std::string> Sketch::inspector_node_labels() const
+{
+  std::vector<std::string> labels;
+  for (size_t i = 0; i < m_nodes.size(); ++i)
+  {
+    const Sketch_nodes::Node& n = m_nodes[i];
+    if (n.permanent && !n.deleted)
+    {
+      std::string lbl = n.name.empty() ? ("N" + std::to_string(i)) : n.name;
+      labels.push_back(std::move(lbl));
+    }
+  }
+
+  return labels;
+}
+
+void Sketch::finalize_elm() { m_tools.finalize(); }
+
+bool Sketch::cancel_elm()
+{
+  const bool operation_canceled = m_tools.cancel();
+  m_dims.clear_pick_state();
+  m_dims.clear_tmp_dim_anno();
+  m_nodes.hide_snap_annos();
+  m_nodes.cancel();
+
+  m_node_marks.trim_trailing();
+
+  return operation_canceled;
+}
+bool Sketch::s_add_mid_pt_edges = false;
+bool Sketch::s_edge_from_center = false;
+
+void Sketch::set_add_mid_pt_edges(bool on) { s_add_mid_pt_edges = on; }
+
+bool Sketch::get_add_mid_pt_edges() { return s_add_mid_pt_edges; }
+
+void Sketch::set_edge_from_center(bool on) { s_edge_from_center = on; }
+
+bool Sketch::get_edge_from_center() { return s_edge_from_center; }
+
+void Sketch::update_edge_end_pt_(Edge& edge, size_t end_pt_idx) { m_edges.update_end_pt(edge, end_pt_idx); }
+
+void Sketch::add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
+{
+  const size_t node_idx_a = m_nodes.get_node_exact(pt_a);
+  const size_t node_idx_c = m_nodes.get_node_exact(pt_c);
+  const size_t node_idx_b = m_nodes.get_node_exact(pt_b);
+  add_arc_circle_(std::vector<size_t>{node_idx_a, node_idx_c, node_idx_b});
+}
+
+void Sketch::add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c, Sketch_op_recorder& rec)
+{
+  const size_t node_idx_a = m_nodes.get_node_exact(pt_a);
+  const size_t node_idx_c = m_nodes.get_node_exact(pt_c);
+  const size_t node_idx_b = m_nodes.get_node_exact(pt_b);
+
+  rec.note_curr_arc_edge(pt_a, pt_b, pt_c);
+  rec.note_curr_node(node_idx_a);
+  rec.note_curr_node(node_idx_c);
+  rec.note_curr_node(node_idx_b);
+
+  add_arc_circle_(std::vector<size_t>{node_idx_a, node_idx_c, node_idx_b});
+}
+
+void Sketch::add_arc_circle_(const std::vector<size_t>& node_idxs) { m_edges.add_arc_circle_edges(node_idxs); }
 
 void Sketch::clear_operation_axis()
 {
@@ -1096,303 +487,6 @@ Shp_rslt Sketch::revolve_selected(const double angle)
     // Catch other unexpected errors
     return Shp_rslt(Result_status::User_error, "Unexpected error: " + std::string(e.what()));
   }
-}
-
-// General sketch point related
-template <typename Callback>
-void Sketch::add_sketch_pt_(const ScreenCoords& screen_coords, size_t required_num_pts, Callback&& callback)
-{
-  auto l = [&](const std::optional<size_t>& node_idx, const gp_Pnt2d& pt)
-  {
-    if (node_idx)
-      m_tmp_node_idxs.push_back(*node_idx);
-    else
-      m_tmp_node_idxs.push_back(m_nodes.add_new_node(pt));
-
-    if (m_tmp_node_idxs.size() >= required_num_pts)
-      callback(m_tmp_node_idxs.back());
-  };
-  move_sketch_pt_(screen_coords, l);
-}
-
-template <typename Callback> void Sketch::move_sketch_pt_(const ScreenCoords& screen_coords, Callback&& callback)
-{
-  m_last_pt = m_view.pt_on_plane(screen_coords, m_pln);
-  if (!m_last_pt)
-    // View plane and sketch plane must be perpendicular.
-    return;
-
-  std::optional<size_t> node_idx = m_nodes.try_get_node_idx_snap(*m_last_pt);
-
-  callback(node_idx, *m_last_pt);
-}
-
-/// Invokes callback(e, pt_a, pt_b) with the last tmp edge only when it exists and is non-degenerate.
-template <typename Callback> void Sketch::if_edge_pt_valid_(Callback&& callback)
-{
-  if (m_tmp_edges.empty())
-    return;
-
-  Edge&           e    = m_tmp_edges.back();
-  const gp_Pnt2d& pt_a = m_nodes[e.node_idx_a];
-  if (m_last_pt.has_value())
-    if (unique(pt_a, *m_last_pt))
-      callback(e, pt_a, *m_last_pt);
-}
-
-void Sketch::finalize_add_node_elm_cleanup_()
-{
-  if (!m_tmp_edges.empty() && !m_tmp_edges.back().node_idx_b.has_value())
-  {
-    m_ctx.Remove(m_tmp_edges.back().shp, false);
-    m_tmp_edges.pop_back();
-  }
-
-  m_nodes.hide_snap_annos();
-  update_faces_();
-}
-
-void Sketch::add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b) { m_edges.add_edge(pt_a, pt_b); }
-
-void Sketch::add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder& rec)
-{
-  m_edges.add_edge(pt_a, pt_b, rec);
-}
-
-void Sketch::add_edge_raw_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b) { m_edges.add_edge_raw_(pt_a, pt_b); }
-
-void Sketch::sketch_json_add_linear_edge_(size_t idx_a, size_t idx_b, std::optional<size_t> idx_mid)
-{
-  m_edges.sketch_json_add_linear_edge(idx_a, idx_b, idx_mid);
-}
-
-void Sketch::sketch_json_set_operation_axis_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
-{
-  if (!unique(pt_a, pt_b))
-    return;
-
-  clear_operation_axis();
-
-  Edge axis{m_nodes.get_node_exact(pt_a)};
-  axis.node_idx_b = m_nodes.get_node_exact(pt_b);
-  update_edge_shp_(axis, pt_a, pt_b);
-  m_operation_axis = std::move(axis);
-
-  sync_operation_axis_display_();
-}
-
-std::vector<Sketch::Edge> Sketch::get_selected_edges_() const { return m_edges.get_selected(); }
-
-std::vector<Sketch_face_shp_ptr> Sketch::get_selected_faces_() const
-{
-  std::vector<Sketch_face_shp_ptr> ret;
-  for (const AIS_Shape_ptr& selected : m_view.get_selected())
-    for (const Sketch_face_shp_ptr& face : m_topo.faces())
-      if (face == selected)
-        ret.push_back(face);
-
-  return ret;
-}
-
-std::list<Sketch::Edge>::iterator Sketch::get_edge_at_(const ScreenCoords& screen_coords)
-{
-  return m_edges.get_at(screen_coords);
-}
-bool Sketch::try_remove_length_dimension(PrsDim_LengthDimension* dim) { return m_dims.try_remove_length_dimension(dim); }
-
-void Sketch::toggle_edge_dim_anno(const ScreenCoords& screen_coords) { m_dims.toggle_edge_dim_anno(screen_coords); }
-
-void Sketch::json_add_length_dimension_(size_t node_a, size_t node_b, const bool visible,
-                                        const std::optional<double> flyout_offset, const std::string& name)
-{
-  m_dims.json_add_length_dimension_(node_a, node_b, visible, flyout_offset, name);
-}
-
-void Sketch::remove_length_dimensions_referencing_node_(size_t node_idx)
-{
-  m_dims.remove_length_dimensions_referencing_node_(node_idx);
-}
-
-void Sketch::set_show_dims(bool show) { m_dims.set_show_dims(show); }
-
-bool Sketch::shows_dimensions() const { return m_dims.shows_dimensions(); }
-
-bool Sketch::dimension_visible(size_t dim_index) const { return m_dims.dimension_visible(dim_index); }
-
-void Sketch::set_dimension_visible(size_t dim_index, bool visible) { m_dims.set_dimension_visible(dim_index, visible); }
-
-size_t Sketch::dimension_node_lo(size_t dim_index) const { return m_dims.dimension_node_lo(dim_index); }
-
-size_t Sketch::dimension_node_hi(size_t dim_index) const { return m_dims.dimension_node_hi(dim_index); }
-
-double Sketch::dimension_offset(size_t dim_index) const { return m_dims.dimension_offset(dim_index); }
-
-void Sketch::set_dimension_offset(size_t dim_index, const double offset) { m_dims.set_dimension_offset(dim_index, offset); }
-
-std::string Sketch::dimension_name(size_t dim_index) const { return m_dims.dimension_name(dim_index); }
-
-void Sketch::set_dimension_name(size_t dim_index, const std::string& name) { m_dims.set_dimension_name(dim_index, name); }
-
-PrsDim_LengthDimension_ptr Sketch::length_dimension_handle(const size_t dim_index) const
-{
-  return m_dims.length_dimension_handle(dim_index);
-}
-
-void Sketch::refresh_annotations(const Sketch_annotation_refresh& refresh)
-{
-  if (refresh.length_dimensions)
-    m_dims.refresh_all_length_dimensions();
-
-  if (refresh.permanent_node_marks)
-    m_node_marks.sync();
-}
-
-size_t Sketch::length_dimension_count() const { return m_dims.length_dimension_count(); }
-
-std::vector<std::string> Sketch::inspector_dimension_labels() const { return m_dims.inspector_dimension_labels(); }
-
-std::vector<std::string> Sketch::inspector_node_labels() const
-{
-  std::vector<std::string> labels;
-  for (size_t i = 0; i < m_nodes.size(); ++i)
-  {
-    const Sketch_nodes::Node& n = m_nodes[i];
-    if (n.permanent && !n.deleted)
-    {
-      std::string lbl = n.name.empty() ? ("N" + std::to_string(i)) : n.name;
-      labels.push_back(std::move(lbl));
-    }
-  }
-
-  return labels;
-}
-
-void Sketch::finalize_elm()
-{
-  Sketch_op_recorder rec(m_view, *this);
-  {
-    m_dims.on_finalize_elm_start();
-
-    switch (get_mode())
-    {
-      // clang-format off
-    
-    case Mode::Sketch_add_edge:
-    case Mode::Sketch_add_multi_edges:
-      finalize_edges_(rec);
-      break;
-
-    case Mode::Sketch_add_rectangle:
-    case Mode::Sketch_add_rectangle_center_pt:
-      finalize_rectangle_(rec);
-      break;
-
-    case Mode::Sketch_add_square:       finalize_square_(rec);            break;
-    case Mode::Sketch_add_circle:       finalize_circle_(rec);            break;
-    case Mode::Sketch_add_node:         finalize_add_node_elm_cleanup_(); break;
-    case Mode::Sketch_add_slot:         finalize_slot_(rec);              break;
-    case Mode::Sketch_operation_axis:   finalize_operation_axis_(rec);    break;
-      // clang-format on
-    default:
-      EZY_ASSERT(false);
-    }
-
-    rec.commit();
-  }
-}
-
-// Cancel related
-bool Sketch::cancel_elm()
-{
-  bool operation_canceled = clear_tmps_();
-  m_dims.clear_pick_state();
-  m_dims.clear_tmp_dim_anno();
-  m_nodes.hide_snap_annos();
-  m_nodes.cancel();
-
-  m_node_marks.trim_trailing();
-
-  return operation_canceled;
-}
-bool Sketch::s_add_mid_pt_edges = false;
-bool Sketch::s_edge_from_center = false;
-
-void Sketch::set_add_mid_pt_edges(bool on) { s_add_mid_pt_edges = on; }
-
-bool Sketch::get_add_mid_pt_edges() { return s_add_mid_pt_edges; }
-
-void Sketch::set_edge_from_center(bool on) { s_edge_from_center = on; }
-
-bool Sketch::get_edge_from_center() { return s_edge_from_center; }
-
-void Sketch::update_edge_end_pt_(Edge& edge, size_t end_pt_idx) { m_edges.update_end_pt(edge, end_pt_idx); }
-
-void Sketch::add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
-{
-  const size_t node_idx_a = m_nodes.get_node_exact(pt_a);
-  const size_t node_idx_c = m_nodes.get_node_exact(pt_c);
-  const size_t node_idx_b = m_nodes.get_node_exact(pt_b);
-  add_arc_circle_(std::vector<size_t>{node_idx_a, node_idx_c, node_idx_b});
-}
-
-void Sketch::add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c, Sketch_op_recorder& rec)
-{
-  const size_t node_idx_a = m_nodes.get_node_exact(pt_a);
-  const size_t node_idx_c = m_nodes.get_node_exact(pt_c);
-  const size_t node_idx_b = m_nodes.get_node_exact(pt_b);
-
-  rec.note_curr_arc_edge(pt_a, pt_b, pt_c);
-  rec.note_curr_node(node_idx_a);
-  rec.note_curr_node(node_idx_c);
-  rec.note_curr_node(node_idx_b);
-
-  add_arc_circle_(std::vector<size_t>{node_idx_a, node_idx_c, node_idx_b});
-}
-
-void Sketch::add_arc_circle_(const std::vector<size_t>& node_idxs) { m_edges.add_arc_circle_edges(node_idxs); }
-
-// Circle related
-void Sketch::move_circle_pt_(const ScreenCoords& screen_coords)
-{
-  move_line_string_pt_(screen_coords);
-  auto l = [&](Edge& e, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
-  {
-    TopoDS_Wire circle = make_circle_wire(m_pln, pt_a, *m_last_pt);
-    show(m_ctx, m_tmp_shp, circle);
-  };
-  if_edge_pt_valid_(l);
-}
-
-void Sketch::finalize_circle_(Sketch_op_recorder& rec)
-{
-  auto l = [this, &rec](Edge& e, const gp_Pnt2d& center, const gp_Pnt2d& edge_pt)
-  {
-    std::array<gp_Pnt2d, 4> points = xy_stencil_pnts(center, edge_pt);
-    add_arc_circle_(points[0], points[2], points[1], rec);
-    add_arc_circle_(points[0], points[3], points[1], rec);
-    clear_tmps_();
-    update_faces_();
-  };
-  if_edge_pt_valid_(l);
-}
-
-bool Sketch::clear_tmps_()
-{
-  m_view.remove(m_tmp_shp);
-  for (Edge& e : m_tmp_edges)
-    m_view.remove(e.shp);
-
-  if (m_tmp_shp)
-  {
-    m_ctx.Remove(m_tmp_shp, true);
-    m_tmp_shp = nullptr;
-  }
-
-  bool operation_canceled = m_tmp_edges.size();
-  clear_all(m_tmp_node_idxs, m_tmp_shp, m_tmp_edges);
-  m_dims.on_clear_tmps();
-
-  return operation_canceled;
 }
 
 void Sketch::on_mode()

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -15,6 +15,7 @@
 #include "sketch_node_marks.h"
 #include "sketch_nodes.h"
 #include "sketch_topo.h"
+#include "sketch_tools.h"
 #include "sketch_underlay.h"
 #include "utl_types.h"
 
@@ -56,7 +57,8 @@ public:
     Hidden
   };
 
-  using Edge = Sketch_edge;
+  using Edge            = Sketch_edge;
+  using Linestring_type = Sketch_tools::Linestring_type;
 
   // Add sketch related
   void add_sketch_pt(const ScreenCoords& screen_coords);
@@ -148,64 +150,11 @@ private:
   friend class Sketch_dims;
   friend class Sketch_edges;
   friend class Sketch_node_marks;
+  friend class Sketch_tools;
 
   static bool s_add_mid_pt_edges;
   static bool s_edge_from_center;
 
-  // Line string / segment related
-  enum class Linestring_type
-  {
-    Single,
-    Two,
-    Multiple
-  };
-
-  // Line string related
-  void add_line_string_pt_(const ScreenCoords& screen_coords, Linestring_type linestring_type);
-  void move_line_string_pt_(const ScreenCoords& screen_coords);
-  bool edge_from_center_active_() const;
-  bool complete_edge_from_center_(const ScreenCoords& screen_coords);
-  void finalize_edges_(Sketch_op_recorder& rec);
-
-  /// Add a single node (no new edge); splits any linear edge the node lies on in its interior.
-  void add_node_pt_(const ScreenCoords& screen_coords);
-  void move_add_node_pt_(const ScreenCoords& screen_coords);
-
-  // Arc circle related
-  void add_arc_circle_pt_(const ScreenCoords& screen_coords);
-  void move_arc_circle_pt_(const ScreenCoords& screen_coords);
-  void add_arc_circle_(const std::vector<size_t>& node_idxs);
-  void add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c);
-  void add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c, Sketch_op_recorder& rec);
-
-  // Circle related
-  void move_circle_pt_(const ScreenCoords& screen_coords);
-  void finalize_circle_(Sketch_op_recorder& rec);
-
-  // Square related
-  void move_square_pt_(const ScreenCoords& screen_coords);
-  void finalize_square_(Sketch_op_recorder& rec);
-
-  // Rectangle related
-  void move_rectangle_pt_(const ScreenCoords& screen_coords);
-  void finalize_rectangle_(Sketch_op_recorder& rec);
-
-  // Slot related
-  void move_slot_pt_(const ScreenCoords& screen_coords);
-  void finalize_slot_(Sketch_op_recorder& rec);
-
-  // Operation axis related
-  void add_operation_axis_pt_(const ScreenCoords& screen_coords);
-  void finalize_operation_axis_(Sketch_op_recorder& rec);
-
-  // General sketch point related
-  template <typename Callback>
-  void add_sketch_pt_(const ScreenCoords& screen_coords, size_t required_num_pts, Callback&& callback);
-  template <typename Callback> void move_sketch_pt_(const ScreenCoords& screen_coords, Callback&& callback);
-  /// Invokes callback(e, pt_a, pt_b) with the last tmp edge only when it exists and is non-degenerate.
-  template <typename Callback> void if_edge_pt_valid_(Callback&& callback);
-  /// Right-click / finalize: drop incomplete add-node preview (same idea as incomplete line).
-  void finalize_add_node_elm_cleanup_();
   void add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
   void add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder& rec);
   void add_edge_raw_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
@@ -216,12 +165,15 @@ private:
   /// JSON load: restore the sketch operation axis from two plane points.
   void sketch_json_set_operation_axis_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
 
+  void add_arc_circle_(const std::vector<size_t>& node_idxs);
+  void add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c);
+  void add_arc_circle_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c, Sketch_op_recorder& rec);
+
   // Selected related
   std::vector<Edge>                get_selected_edges_() const;
   std::vector<Sketch_face_shp_ptr> get_selected_faces_() const;
 
   void update_edge_end_pt_(Edge& e, size_t end_pt_idx);
-  bool clear_tmps_();
 
   void     update_faces_();
   void     update_edge_shp_(Edge& edge, const gp_Pnt2d& pt_t, const gp_Pnt2d& pt_b);
@@ -250,9 +202,6 @@ private:
 
   Edge_style m_edge_style{Edge_style::Full};
 
-  // Arc circle related.
-  std::optional<size_t> m_start_arc_circle_node_idx;
-
   // Outside sketch snapping related.
   std::vector<gp_Pnt> m_tmp_pts_3d;
 
@@ -275,15 +224,12 @@ private:
   AIS_Shape_ptr m_originating_face; // If this sketch was created from a face.
   gp_Pln        m_pln;              // Plane this sketch is on.
 
-  std::optional<gp_Pnt2d> m_last_pt;
-  Sketch_nodes            m_nodes;
-  Sketch_node_marks       m_node_marks;
-  Sketch_edges            m_edges;
-  Sketch_topo             m_topo;
-  Sketch_dims             m_dims;
-  Sketch_underlay         m_underlay;
-  std::vector<size_t>     m_tmp_node_idxs;
-  std::vector<Edge>       m_tmp_edges;
-  AIS_Shape_ptr           m_tmp_shp;
-  bool                    m_show_faces{true};
+  Sketch_nodes      m_nodes;
+  Sketch_node_marks m_node_marks;
+  Sketch_edges      m_edges;
+  Sketch_topo       m_topo;
+  Sketch_dims       m_dims;
+  Sketch_tools      m_tools;
+  Sketch_underlay   m_underlay;
+  bool              m_show_faces{true};
 };

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "shp.h"
+#include "sketch_dims.h"
 #include "sketch_nodes.h"
 #include "sketch_topo.h"
 #include "sketch_underlay.h"
@@ -160,27 +161,10 @@ private:
   friend class Sketch_delta;
   friend class Sketch_op_recorder;
   friend class Sketch_topo;
+  friend class Sketch_dims;
 
   static bool s_add_mid_pt_edges;
   static bool s_edge_from_center;
-
-  /// Linear distance between two sketch nodes (independent of which edge connects them).
-  struct Length_dimension
-  {
-    size_t                     node_idx_lo{};
-    size_t                     node_idx_hi{};
-    PrsDim_LengthDimension_ptr dim;
-    bool                       visible{true};
-    std::optional<double>      flyout_offset;
-    std::string                name;
-  };
-
-  // When user types in a edge length.
-  struct Edge_len
-  {
-    gp_Dir2d dir;
-    double   len;
-  };
 
   // Line string / segment related
   enum class Linestring_type
@@ -234,10 +218,6 @@ private:
   template <typename Callback> void move_sketch_pt_(const ScreenCoords& screen_coords, Callback&& callback);
   /// Invokes callback(e, pt_a, pt_b) with the last tmp edge only when it exists and is non-degenerate.
   template <typename Callback> void if_edge_pt_valid_(Callback&& callback);
-  void                              check_dimension_seg_(Linestring_type linestring_type);
-  /// Typed distance (Enter) while add-node rubber band is active - places node B, no edge.
-  /// Enter key / dist popup commit for rubber-band tmp edge (add node, square, circle, rectangle, ...).
-  void check_dimension_rubber_();
   /// Right-click / finalize: drop incomplete add-node preview (same idea as incomplete line).
   void finalize_add_node_elm_cleanup_();
   void add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
@@ -277,29 +257,17 @@ private:
   bool operation_axis_suppresses_sketch_snap_() const;
   void update_originating_face_style();
 
-  void rebuild_length_dimension_display_(Length_dimension& d);
-  void purge_stale_length_dimensions_();
-  void refresh_all_length_dimensions_();
-  void remove_length_dimensions_referencing_node_(size_t node_idx);
   void remove_permanent_node_mark_ais_at_(size_t node_idx);
   void remove_all_permanent_node_marks_();
   void erase_permanent_node_marks_();
   void trim_trailing_permanent_node_marks_();
-  /// Add if missing, remove if present (same unordered node pair).
-  void add_or_toggle_length_dim_between_node_indices_(size_t node_a, size_t node_b);
+
   void json_add_length_dimension_(size_t node_a, size_t node_b, bool visible = true,
                                   std::optional<double> flyout_offset = std::nullopt, const std::string& name = {});
-
-  /// Average of non-deleted node positions (3D on sketch plane); used to place edge dimensions outside loops.
-  std::optional<gp_Pnt> approx_sketch_interior_ref_3d_() const;
+  void remove_length_dimensions_referencing_node_(size_t node_idx);
 
   // Query related
   std::list<Edge>::iterator get_edge_at_(const ScreenCoords& screen_coords);
-
-  // Dimension input related
-  void clear_len_dim_rubber_line_();
-  void update_len_dim_rubber_line_(const ScreenCoords& screen_coords);
-  void clear_len_dim_pick_state_();
 
   // Style related
   Edge_style m_edge_style{Edge_style::Full};
@@ -325,12 +293,6 @@ private:
   // Mirror edges related;
   std::optional<Edge> m_operation_axis;
 
-  // Dimensions related
-  std::optional<Edge_len> m_entered_edge_len;
-  bool                    m_show_dim_input{false};
-  std::optional<double>   m_entered_edge_angle; // Angle in degrees
-  bool                    m_show_angle_input{false};
-
   // Geometry related
   AIS_Shape_ptr m_originating_face; // If this sketch was created from a face.
   gp_Pln        m_pln;              // Plane this sketch is on.
@@ -341,15 +303,10 @@ private:
   std::vector<Sketch_AIS_node_mark_ptr> m_permanent_node_marks;
   std::list<Edge>                       m_edges;
   Sketch_topo                           m_topo;
+  Sketch_dims                           m_dims;
   Sketch_underlay                       m_underlay;
-  std::vector<Length_dimension>         m_length_dimensions;
-  std::optional<size_t>                 m_len_dim_pick_anchor_node;
-  /// Preview segment from anchor node to cursor while picking the second node (dim mode).
-  AIS_Shape_ptr              m_len_dim_rubber_shp;
-  std::vector<size_t>        m_tmp_node_idxs;
-  std::vector<Edge>          m_tmp_edges;
-  AIS_Shape_ptr              m_tmp_shp;
-  PrsDim_LengthDimension_ptr m_tmp_dim_anno;
-  bool                       m_show_faces{true};
-  bool                       m_show_dims{true};
+  std::vector<size_t>                   m_tmp_node_idxs;
+  std::vector<Edge>                     m_tmp_edges;
+  AIS_Shape_ptr                         m_tmp_shp;
+  bool                                  m_show_faces{true};
 };

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -12,6 +12,7 @@
 #include "sketch_dims.h"
 #include "sketch_edge.h"
 #include "sketch_edges.h"
+#include "sketch_node_marks.h"
 #include "sketch_nodes.h"
 #include "sketch_topo.h"
 #include "sketch_underlay.h"
@@ -25,17 +26,12 @@ class TopoDS_Wire;
 class Sketch;
 enum class Mode;
 
-struct Sketch_AIS_node_mark;
-
 /// Selective refresh of sketch annotations after global settings or geometry changes.
 struct Sketch_annotation_refresh
 {
   bool length_dimensions    = false;
   bool permanent_node_marks = false;
 };
-
-/// If `shp` is a permanent sketch node mark, removes it from its owner sketch.
-bool try_remove_sketch_permanent_node_mark(AIS_Shape* shp);
 
 // The Sketch class provides a comprehensive set of methods for creating and manipulating 2D sketches in a 3D environment.
 // It supports adding and moving points, creating line segments, arcs, and mirror lines, and updating the sketch's
@@ -151,6 +147,7 @@ private:
   friend class Sketch_topo;
   friend class Sketch_dims;
   friend class Sketch_edges;
+  friend class Sketch_node_marks;
 
   static bool s_add_mid_pt_edges;
   static bool s_edge_from_center;
@@ -236,17 +233,10 @@ private:
 
   // Style related
   void update_edge_style_(AIS_Shape_ptr& shp);
-  void update_node_mark_style_(AIS_Shape_ptr& shp);
-  void sync_permanent_node_annos_();
   void sync_operation_axis_display_();
   bool show_operation_axis_() const;
   bool operation_axis_suppresses_sketch_snap_() const;
   void update_originating_face_style();
-
-  void remove_permanent_node_mark_ais_at_(size_t node_idx);
-  void remove_all_permanent_node_marks_();
-  void erase_permanent_node_marks_();
-  void trim_trailing_permanent_node_marks_();
 
   void json_add_length_dimension_(size_t node_a, size_t node_b, bool visible = true,
                                   std::optional<double> flyout_offset = std::nullopt, const std::string& name = {});
@@ -287,14 +277,13 @@ private:
 
   std::optional<gp_Pnt2d> m_last_pt;
   Sketch_nodes            m_nodes;
-  /// One entry per node index; only indices with permanent, non-deleted nodes hold a displayed + marker.
-  std::vector<Sketch_AIS_node_mark_ptr> m_permanent_node_marks;
-  Sketch_edges                          m_edges;
-  Sketch_topo                           m_topo;
-  Sketch_dims                           m_dims;
-  Sketch_underlay                       m_underlay;
-  std::vector<size_t>                   m_tmp_node_idxs;
-  std::vector<Edge>                     m_tmp_edges;
-  AIS_Shape_ptr                         m_tmp_shp;
-  bool                                  m_show_faces{true};
+  Sketch_node_marks       m_node_marks;
+  Sketch_edges            m_edges;
+  Sketch_topo             m_topo;
+  Sketch_dims             m_dims;
+  Sketch_underlay         m_underlay;
+  std::vector<size_t>     m_tmp_node_idxs;
+  std::vector<Edge>       m_tmp_edges;
+  AIS_Shape_ptr           m_tmp_shp;
+  bool                    m_show_faces{true};
 };

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -10,6 +10,8 @@
 
 #include "shp.h"
 #include "sketch_dims.h"
+#include "sketch_edge.h"
+#include "sketch_edges.h"
 #include "sketch_nodes.h"
 #include "sketch_topo.h"
 #include "sketch_underlay.h"
@@ -58,21 +60,7 @@ public:
     Hidden
   };
 
-  struct Edge
-  {
-    size_t                node_idx_a;
-    std::optional<size_t> node_idx_b;
-    std::optional<size_t> node_idx_arc; // Only valid for circle arc edges.
-    std::optional<size_t> node_idx_mid; // Midpoint of edge, used for snapping.
-
-    //  Used to identify the two `Edges` defining a circle arc.
-    Geom_TrimmedCurve_ptr circle_arc;
-    Sketch_AIS_edge_ptr   shp; // Current edge annotation.
-
-    std::string name;
-
-    bool reversed(size_t idx_a, size_t idx_b) const;
-  };
+  using Edge = Sketch_edge;
 
   // Add sketch related
   void add_sketch_pt(const ScreenCoords& screen_coords);
@@ -162,6 +150,7 @@ private:
   friend class Sketch_op_recorder;
   friend class Sketch_topo;
   friend class Sketch_dims;
+  friend class Sketch_edges;
 
   static bool s_add_mid_pt_edges;
   static bool s_edge_from_center;
@@ -222,10 +211,9 @@ private:
   void finalize_add_node_elm_cleanup_();
   void add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
   void add_edge_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder& rec);
-  void add_edge_impl_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder* rec);
   void add_edge_raw_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
   /// Helper used when walking edges for splitting / intersection logic.
-  static bool is_linear_edge_(const Edge& e);
+  static bool is_linear_edge_(const Edge& e) { return Sketch_edges::is_linear(e); }
   /// JSON load: linear edge using existing node indices (`idx_mid` is the edge midpoint node).
   void sketch_json_add_linear_edge_(size_t idx_a, size_t idx_b, std::optional<size_t> idx_mid);
   /// JSON load: restore the sketch operation axis from two plane points.
@@ -243,10 +231,8 @@ private:
   gp_Vec2d edge_incoming_dir_(size_t idx_a, size_t idx_b, const Edge& edge) const;
 
   // 3D point related
-  void   get_snap_pts_3d_(std::vector<gp_Pnt>& out);
-  void   get_originating_face_snp_pts_3d_(std::vector<gp_Pnt>& out);
-  gp_Pnt to_3d_(size_t node_idx) const;
-  gp_Pnt to_3d_(const std::optional<size_t>& node_idx) const;
+  void get_snap_pts_3d_(std::vector<gp_Pnt>& out);
+  void get_originating_face_snp_pts_3d_(std::vector<gp_Pnt>& out);
 
   // Style related
   void update_edge_style_(AIS_Shape_ptr& shp);
@@ -269,7 +255,9 @@ private:
   // Query related
   std::list<Edge>::iterator get_edge_at_(const ScreenCoords& screen_coords);
 
-  // Style related
+  gp_Pnt to_3d_(size_t node_idx) const;
+  gp_Pnt to_3d_(const std::optional<size_t>& node_idx) const;
+
   Edge_style m_edge_style{Edge_style::Full};
 
   // Arc circle related.
@@ -301,7 +289,7 @@ private:
   Sketch_nodes            m_nodes;
   /// One entry per node index; only indices with permanent, non-deleted nodes hold a displayed + marker.
   std::vector<Sketch_AIS_node_mark_ptr> m_permanent_node_marks;
-  std::list<Edge>                       m_edges;
+  Sketch_edges                          m_edges;
   Sketch_topo                           m_topo;
   Sketch_dims                           m_dims;
   Sketch_underlay                       m_underlay;

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -58,6 +58,22 @@ public:
     Hidden
   };
 
+  struct Edge
+  {
+    size_t                node_idx_a;
+    std::optional<size_t> node_idx_b;
+    std::optional<size_t> node_idx_arc; // Only valid for circle arc edges.
+    std::optional<size_t> node_idx_mid; // Midpoint of edge, used for snapping.
+
+    //  Used to identify the two `Edges` defining a circle arc.
+    Geom_TrimmedCurve_ptr circle_arc;
+    Sketch_AIS_edge_ptr   shp; // Current edge annotation.
+
+    std::string name;
+
+    bool reversed(size_t idx_a, size_t idx_b) const;
+  };
+
   // Add sketch related
   void add_sketch_pt(const ScreenCoords& screen_coords);
   void sketch_pt_move(const ScreenCoords& screen_coords);
@@ -139,12 +155,11 @@ public:
   static void set_edge_from_center(bool on);
   static bool get_edge_from_center();
 
-  // private:
+private:
   friend class Sketch_json;
   friend class Sketch_access;
   friend class Sketch_delta;
   friend class Sketch_op_recorder;
-  friend class Sketch_test; // TEST_F(Sketch_test, JsonSerializationDeserialization)
 
   static bool s_add_mid_pt_edges;
   static bool s_edge_from_center;
@@ -158,22 +173,6 @@ public:
     bool                       visible{true};
     std::optional<double>      flyout_offset;
     std::string                name;
-  };
-
-  struct Edge
-  {
-    size_t                node_idx_a;
-    std::optional<size_t> node_idx_b;
-    std::optional<size_t> node_idx_arc; // Only valid for circle arc edges.
-    std::optional<size_t> node_idx_mid; // Midpoint of edge, used for snapping.
-
-    //  Used to identify the two `Edges` defining a circle arc.
-    Geom_TrimmedCurve_ptr circle_arc;
-    Sketch_AIS_edge_ptr   shp; // Current edge annotation.
-
-    std::string name;
-
-    bool reversed(size_t idx_a, size_t idx_b) const;
   };
 
   struct Face_edge

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -1,17 +1,16 @@
 #pragma once
 
-#include <TopoDS_Face.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Pnt2d.hxx>
 #include <gp_Vec2d.hxx>
 #include <list>
-#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "shp.h"
 #include "sketch_nodes.h"
+#include "sketch_topo.h"
 #include "sketch_underlay.h"
 #include "utl_types.h"
 
@@ -160,6 +159,7 @@ private:
   friend class Sketch_access;
   friend class Sketch_delta;
   friend class Sketch_op_recorder;
+  friend class Sketch_topo;
 
   static bool s_add_mid_pt_edges;
   static bool s_edge_from_center;
@@ -175,23 +175,12 @@ private:
     std::string                name;
   };
 
-  struct Face_edge
-  {
-    const Edge& edge;
-    bool        reversed;
-    size_t      start_nd_idx() const;
-    size_t      end_nd_idx() const;
-  };
-
   // When user types in a edge length.
   struct Edge_len
   {
     gp_Dir2d dir;
     double   len;
   };
-
-  using Face       = std::vector<size_t>;
-  using Face_edges = std::vector<Face_edge>;
 
   // Line string / segment related
   enum class Linestring_type
@@ -211,14 +200,6 @@ private:
   /// Add a single node (no new edge); splits any linear edge the node lies on in its interior.
   void add_node_pt_(const ScreenCoords& screen_coords);
   void move_add_node_pt_(const ScreenCoords& screen_coords);
-
-  void split_linear_edges_at_node_if_interior_(size_t node_idx);
-  void split_linear_edges_at_node_if_interior_(size_t node_idx, Sketch_op_recorder& rec);
-  void split_linear_edges_at_node_if_interior_(size_t node_idx, Sketch_op_recorder* rec);
-
-  /// Move a newly placed node onto the nearest linear edge within pick tolerance so split + `used_nodes` sees it.
-  void   snap_placed_node_to_closest_linear_edge_interior_(size_t node_idx);
-  double plane_pick_snap_radius_world_() const;
 
   // Arc circle related
   void add_arc_circle_pt_(const ScreenCoords& screen_coords);
@@ -277,12 +258,9 @@ private:
   void update_edge_end_pt_(Edge& e, size_t end_pt_idx);
   bool clear_tmps_();
 
-  // Function to extract faces from the planar graph
-  void                update_faces_();
-  void                update_edge_shp_(Edge& edge, const gp_Pnt2d& pt_t, const gp_Pnt2d& pt_b);
-  bool                is_face_clockwise_(const Face_edges& face) const;
-  Sketch_face_shp_ptr create_face_shape_(const Face_edges& face);
-  gp_Vec2d            edge_incoming_dir_(size_t idx_a, size_t idx_b, const Edge& edge) const;
+  void     update_faces_();
+  void     update_edge_shp_(Edge& edge, const gp_Pnt2d& pt_t, const gp_Pnt2d& pt_b);
+  gp_Vec2d edge_incoming_dir_(size_t idx_a, size_t idx_b, const Edge& edge) const;
 
   // 3D point related
   void   get_snap_pts_3d_(std::vector<gp_Pnt>& out);
@@ -314,9 +292,6 @@ private:
 
   /// Average of non-deleted node positions (3D on sketch plane); used to place edge dimensions outside loops.
   std::optional<gp_Pnt> approx_sketch_interior_ref_3d_() const;
-
-  /// `m_faces` as `TopoDS_Face` for flyout tests (rebuilt in `update_faces_`).
-  void rebuild_dim_classifier_face_cache_();
 
   // Query related
   std::list<Edge>::iterator get_edge_at_(const ScreenCoords& screen_coords);
@@ -365,8 +340,7 @@ private:
   /// One entry per node index; only indices with permanent, non-deleted nodes hold a displayed + marker.
   std::vector<Sketch_AIS_node_mark_ptr> m_permanent_node_marks;
   std::list<Edge>                       m_edges;
-  std::vector<Sketch_face_shp_ptr>      m_faces;
-  std::vector<TopoDS_Face>              m_dim_classifier_faces;
+  Sketch_topo                           m_topo;
   std::vector<Length_dimension>         m_length_dimensions;
   std::optional<size_t>                 m_len_dim_pick_anchor_node;
   /// Preview segment from anchor node to cursor while picking the second node (dim mode).

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -117,6 +117,9 @@ public:
   const std::string& get_name() const;
   void               set_name(const std::string& name);
 
+  /// Stable identity for undo deltas and file I/O (display names may duplicate).
+  size_t get_id() const;
+
   /// True if this sketch has at least one edge (used e.g. to pick mode after undo/redo).
   bool   has_edges() const;
   size_t edge_count() const;
@@ -211,6 +214,7 @@ private:
 
   std::string m_dbg_str;
   std::string m_name;
+  size_t      m_id{0};
   bool        m_visible{true};
 
   // Extrusion related.

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -341,6 +341,7 @@ private:
   std::vector<Sketch_AIS_node_mark_ptr> m_permanent_node_marks;
   std::list<Edge>                       m_edges;
   Sketch_topo                           m_topo;
+  Sketch_underlay                       m_underlay;
   std::vector<Length_dimension>         m_length_dimensions;
   std::optional<size_t>                 m_len_dim_pick_anchor_node;
   /// Preview segment from anchor node to cursor while picking the second node (dim mode).
@@ -351,6 +352,4 @@ private:
   PrsDim_LengthDimension_ptr m_tmp_dim_anno;
   bool                       m_show_faces{true};
   bool                       m_show_dims{true};
-
-  Sketch_underlay m_underlay;
 };

--- a/src/sketch_ais.cpp
+++ b/src/sketch_ais.cpp
@@ -1,0 +1,36 @@
+#include "sketch_ais.h"
+
+#include "sketch.h"
+
+Sketch_AIS_edge::Sketch_AIS_edge(Sketch& owner, const TopoDS_Shape& shp)
+    : AIS_Shape(shp)
+    , owner_sketch(owner)
+{
+}
+
+Sketch_AIS_node_mark::Sketch_AIS_node_mark(Sketch& owner, size_t node_idx, const TopoDS_Shape& shp)
+    : AIS_Shape(shp)
+    , owner_sketch(owner)
+    , node_idx(node_idx)
+{
+}
+
+Sketch_face_shp::Sketch_face_shp(Sketch& owner, const TopoDS_Shape& face)
+    : owner_sketch(owner)
+    , AIS_Shape(face)
+{
+}
+
+bool try_remove_sketch_permanent_node_mark(AIS_Shape* shp)
+{
+  if (!shp)
+    return false;
+
+  if (auto* mark = dynamic_cast<Sketch_AIS_node_mark*>(shp))
+  {
+    mark->owner_sketch.remove_permanent_node_mark(*mark);
+    return true;
+  }
+
+  return false;
+}

--- a/src/sketch_ais.h
+++ b/src/sketch_ais.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <AIS_Shape.hxx>
+#include <gp_Pnt.hxx>
+#include <string>
+#include <vector>
+
+class Sketch;
+class TopoDS_Shape;
+
+/// Sketch edge wireframe annotation in the 3D viewer.
+struct Sketch_AIS_edge : public AIS_Shape
+{
+  Sketch_AIS_edge(Sketch& owner, const TopoDS_Shape& shp);
+  Sketch& owner_sketch;
+};
+
+/// Selectable "+" marker for user-placed permanent sketch nodes (add-node tool).
+struct Sketch_AIS_node_mark : public AIS_Shape
+{
+  Sketch_AIS_node_mark(Sketch& owner, size_t node_idx, const TopoDS_Shape& shp);
+  Sketch& owner_sketch;
+  size_t  node_idx{};
+};
+
+/// Shaded sketch face used for extrusion and face selection.
+struct Sketch_face_shp : public AIS_Shape
+{
+  Sketch_face_shp(Sketch& owner, const TopoDS_Shape& face);
+
+  Sketch&             owner_sketch;
+  std::vector<gp_Pnt> verts_3d; // Used for extruding the face
+  std::vector<size_t> vert_idxs;
+  std::string         name;
+};
+
+/// If `shp` is a permanent sketch node mark, removes it from its owner sketch.
+bool try_remove_sketch_permanent_node_mark(AIS_Shape* shp);

--- a/src/sketch_delta.cpp
+++ b/src/sketch_delta.cpp
@@ -2,7 +2,6 @@
 
 #include <Precision.hxx>
 #include <algorithm>
-#include <set>
 #include <utility>
 
 #include "utl_dbg.h"
@@ -16,6 +15,7 @@ namespace
 
 bool on_closed_segment_2d_(const gp_Pnt2d& p, const gp_Pnt2d& a, const gp_Pnt2d& b);
 bool is_linear_sketch_edge_(const Sketch::Edge& e);
+bool pts_equal_(const gp_Pnt2d& a, const gp_Pnt2d& b);
 
 } // namespace
 
@@ -26,10 +26,10 @@ public:
 
   struct Prev_edge_rec
   {
-    size_t                node_idx_a{};
-    size_t                node_idx_b{};
-    std::optional<size_t> node_idx_mid;
-    std::string           name;
+    gp_Pnt2d                pt_a;
+    gp_Pnt2d                pt_b;
+    std::optional<gp_Pnt2d> pt_mid;
+    std::string             name;
   };
 
   struct Curr_linear_edge_record
@@ -47,26 +47,27 @@ public:
 
   struct Length_dim_record
   {
-    size_t                node_idx_lo{};
-    size_t                node_idx_hi{};
+    gp_Pnt2d              pt_lo;
+    gp_Pnt2d              pt_hi;
     bool                  visible{true};
     std::optional<double> flyout_offset;
     std::string           name;
   };
 
   Sketch*                                m_sketch{nullptr};
-  std::string                            m_sketch_name;
+  size_t                                 m_sketch_id{0};
   std::vector<Prev_edge_rec>             prev_linear_edges;
   std::vector<Curr_linear_edge_record>   curr_linear_edges;
   std::vector<Arc_edge_record>           prev_arc_edges;
   std::vector<Arc_edge_record>           curr_arc_edges;
-  std::vector<size_t>                    curr_node_idxs;
+  std::vector<gp_Pnt2d>                    curr_node_pts;
   std::vector<Length_dim_record>         prev_length_dims;
   std::vector<Length_dim_record>         curr_length_dims;
   std::optional<Prev_edge_rec>           prev_operation_axis;
   std::optional<Curr_linear_edge_record> curr_operation_axis;
 
-  Impl(Sketch& sketch, std::string sketch_name);
+  explicit Impl(size_t sketch_id);
+  Impl(Sketch& sketch, size_t sketch_id);
 
   Sketch*                       resolve_sketch_(Occt_view& view) const;
   void                          apply_forward_(Sketch& sketch) const;
@@ -78,10 +79,10 @@ public:
   static bool arc_equal_(const Arc_edge_record& x, const Arc_edge_record& y);
   static bool length_dim_equal_(const Length_dim_record& x, const Length_dim_record& y);
   static void remove_linear_edges_on_segment_(Sketch& sketch, const gp_Pnt2d& seg_a, const gp_Pnt2d& seg_b);
-  static void remove_linear_edges_on_node_segment_(Sketch& sketch, size_t node_a, size_t node_b);
+  static void remove_linear_edges_on_node_segment_(Sketch& sketch, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
   static void remove_arc_edge_(Sketch& sketch, const Arc_edge_record& rec);
   static void remove_length_dim_(Sketch& sketch, const Length_dim_record& rec);
-  static void tombstone_node_(Sketch& sketch, size_t node_idx);
+  static void tombstone_node_at_pt_(Sketch& sketch, const gp_Pnt2d& pt);
   static void restore_prev_linear_edge_(Sketch& sketch, const Prev_edge_rec& rec);
   static void restore_length_dim_(Sketch& sketch, const Length_dim_record& rec);
   static void restore_prev_operation_axis_(Sketch& sketch, const Prev_edge_rec& rec);
@@ -97,7 +98,7 @@ public:
   Sketch_op_recorder*                            m_owner{nullptr};
   bool                                           m_active{true};
   bool                                           m_committed{false};
-  std::set<size_t>                               m_live_nodes_at_start;
+  std::vector<gp_Pnt2d>                          m_live_node_pts_at_start;
   std::vector<Sketch_delta::Impl::Prev_edge_rec> m_linear_edges_at_start;
   std::unique_ptr<Sketch_delta>                  m_delta;
 
@@ -124,8 +125,13 @@ private:
   void unregister_owner_();
 };
 
-Sketch_delta::Sketch_delta(Sketch& sketch, std::string sketch_name)
-    : m_impl(std::make_unique<Impl>(sketch, std::move(sketch_name)))
+Sketch_delta::Sketch_delta(Sketch& sketch, const size_t sketch_id)
+    : m_impl(std::make_unique<Impl>(sketch, sketch_id))
+{
+}
+
+Sketch_delta::Sketch_delta(const size_t sketch_id)
+    : m_impl(std::make_unique<Impl>(sketch_id))
 {
 }
 
@@ -134,14 +140,18 @@ Sketch_delta::~Sketch_delta() = default;
 void Sketch_delta::apply_forward(Occt_view& view)
 {
   Sketch* sketch = m_impl->resolve_sketch_(view);
-  EZY_ASSERT(sketch);
+  if (!sketch)
+    return;
+
   m_impl->apply_forward_(*sketch);
 }
 
 void Sketch_delta::apply_reverse(Occt_view& view)
 {
   Sketch* sketch = m_impl->resolve_sketch_(view);
-  EZY_ASSERT(sketch);
+  if (!sketch)
+    return;
+
   m_impl->apply_reverse_(*sketch);
 }
 
@@ -214,10 +224,10 @@ Sketch_op_recorder::Impl::Impl(Occt_view& view, Sketch& sketch)
 {
   for (size_t i = 0, n = sketch.m_nodes.size(); i < n; ++i)
     if (!sketch.m_nodes[i].deleted)
-      m_live_nodes_at_start.insert(i);
+      m_live_node_pts_at_start.push_back(sketch.m_nodes[i]);
 
   Sketch_delta::Impl::capture_linear_edges_at_start_(sketch, m_linear_edges_at_start);
-  m_delta = std::make_unique<Sketch_delta>(sketch, sketch.get_name());
+  m_delta = std::make_unique<Sketch_delta>(sketch, sketch.get_id());
 }
 
 void Sketch_op_recorder::Impl::register_owner_(Sketch_op_recorder& owner) { m_owner = &owner; }
@@ -237,7 +247,13 @@ void Sketch_op_recorder::Impl::note_prev_linear_edge(size_t node_idx_a, size_t n
   if (!m_active || !m_delta)
     return;
 
-  Sketch_delta::Impl::Prev_edge_rec rec{node_idx_a, node_idx_b, node_idx_mid, name};
+  const gp_Pnt2d pt_a = m_sketch.m_nodes[node_idx_a];
+  const gp_Pnt2d pt_b = m_sketch.m_nodes[node_idx_b];
+  std::optional<gp_Pnt2d> pt_mid;
+  if (node_idx_mid.has_value())
+    pt_mid = m_sketch.m_nodes[*node_idx_mid];
+
+  Sketch_delta::Impl::Prev_edge_rec rec{pt_a, pt_b, pt_mid, name};
   if (!Sketch_delta::Impl::linear_edge_at_op_start_(m_linear_edges_at_start, rec))
     return;
 
@@ -293,14 +309,18 @@ void Sketch_op_recorder::Impl::note_curr_node(size_t node_idx)
   if (!m_active || !m_delta)
     return;
 
-  if (m_live_nodes_at_start.count(node_idx))
-    return;
+  const gp_Pnt2d pt = m_sketch.m_nodes[node_idx];
 
-  std::vector<size_t>& nodes = m_delta->m_impl->curr_node_idxs;
-  if (std::find(nodes.begin(), nodes.end(), node_idx) != nodes.end())
-    return;
+  for (const gp_Pnt2d& live : m_live_node_pts_at_start)
+    if (pts_equal_(live, pt))
+      return;
 
-  nodes.push_back(node_idx);
+  std::vector<gp_Pnt2d>& nodes = m_delta->m_impl->curr_node_pts;
+  for (const gp_Pnt2d& x : nodes)
+    if (pts_equal_(x, pt))
+      return;
+
+  nodes.push_back(pt);
 }
 
 void Sketch_op_recorder::Impl::note_prev_length_dim(size_t lo, size_t hi, bool visible, std::optional<double> flyout,
@@ -309,7 +329,7 @@ void Sketch_op_recorder::Impl::note_prev_length_dim(size_t lo, size_t hi, bool v
   if (!m_active || !m_delta)
     return;
 
-  Sketch_delta::Impl::Length_dim_record rec{lo, hi, visible, flyout, name};
+  Sketch_delta::Impl::Length_dim_record rec{m_sketch.m_nodes[lo], m_sketch.m_nodes[hi], visible, flyout, name};
   for (const Sketch_delta::Impl::Length_dim_record& x : m_delta->m_impl->prev_length_dims)
     if (Sketch_delta::Impl::length_dim_equal_(x, rec))
       return;
@@ -323,7 +343,7 @@ void Sketch_op_recorder::Impl::note_curr_length_dim(size_t lo, size_t hi, bool v
   if (!m_active || !m_delta)
     return;
 
-  Sketch_delta::Impl::Length_dim_record rec{lo, hi, visible, flyout, name};
+  Sketch_delta::Impl::Length_dim_record rec{m_sketch.m_nodes[lo], m_sketch.m_nodes[hi], visible, flyout, name};
   for (const Sketch_delta::Impl::Length_dim_record& x : m_delta->m_impl->curr_length_dims)
     if (Sketch_delta::Impl::length_dim_equal_(x, rec))
       return;
@@ -336,7 +356,8 @@ void Sketch_op_recorder::Impl::note_prev_operation_axis(size_t node_idx_a, size_
   if (!m_active || !m_delta)
     return;
 
-  m_delta->m_impl->prev_operation_axis = Sketch_delta::Impl::Prev_edge_rec{node_idx_a, node_idx_b, std::nullopt, {}};
+  m_delta->m_impl->prev_operation_axis =
+      Sketch_delta::Impl::Prev_edge_rec{m_sketch.m_nodes[node_idx_a], m_sketch.m_nodes[node_idx_b], std::nullopt, {}};
 }
 
 void Sketch_op_recorder::Impl::note_curr_operation_axis(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
@@ -354,7 +375,7 @@ bool Sketch_op_recorder::Impl::empty_() const
 
   const Sketch_delta::Impl& d = *m_delta->m_impl;
   return d.prev_linear_edges.empty() && d.curr_linear_edges.empty() && d.prev_arc_edges.empty() && d.curr_arc_edges.empty() &&
-         d.curr_node_idxs.empty() && d.prev_length_dims.empty() && d.curr_length_dims.empty() &&
+         d.curr_node_pts.empty() && d.prev_length_dims.empty() && d.curr_length_dims.empty() &&
          !d.prev_operation_axis.has_value() && !d.curr_operation_axis.has_value();
 }
 
@@ -380,22 +401,32 @@ void Sketch_op_recorder::Impl::cancel()
   unregister_owner_();
 }
 
-Sketch_delta::Impl::Impl(Sketch& sketch, std::string sketch_name)
+Sketch_delta::Impl::Impl(const size_t sketch_id)
+    : m_sketch_id(sketch_id)
+{
+}
+
+Sketch_delta::Impl::Impl(Sketch& sketch, const size_t sketch_id)
     : m_sketch(&sketch)
-    , m_sketch_name(std::move(sketch_name))
+    , m_sketch_id(sketch_id)
 {
 }
 
 Sketch* Sketch_delta::Impl::resolve_sketch_(Occt_view& view) const
 {
-  if (m_sketch)
-    return m_sketch;
-
   for (const Sketch::sptr& s : view.get_sketches())
-    if (s->get_name() == m_sketch_name)
+    if (s->get_id() == m_sketch_id)
       return s.get();
 
-  return nullptr;
+  if (m_sketch)
+  {
+    for (const Sketch::sptr& s : view.get_sketches())
+      if (s.get() == m_sketch)
+        return m_sketch;
+  }
+
+  // Headless tests use a stack `Sketch` not registered in the view.
+  return m_sketch;
 }
 
 void Sketch_delta::Impl::apply_forward_(Sketch& sketch) const
@@ -442,8 +473,8 @@ void Sketch_delta::Impl::apply_reverse_(Sketch& sketch) const
   for (const Length_dim_record& d : prev_length_dims)
     restore_length_dim_(sketch, d);
 
-  for (size_t node_idx : curr_node_idxs)
-    tombstone_node_(sketch, node_idx);
+  for (const gp_Pnt2d& pt : curr_node_pts)
+    tombstone_node_at_pt_(sketch, pt);
 
   sketch.m_nodes.hide_snap_annos();
   sketch.update_faces_();
@@ -451,14 +482,14 @@ void Sketch_delta::Impl::apply_reverse_(Sketch& sketch) const
 
 std::unique_ptr<Sketch_delta> Sketch_delta::Impl::clone() const
 {
-  auto  copy                    = std::make_unique<Sketch_delta>(*m_sketch, m_sketch_name);
+  auto  copy                    = std::make_unique<Sketch_delta>(m_sketch_id);
   Impl& copy_impl               = *copy->m_impl;
   copy_impl.m_sketch            = m_sketch;
   copy_impl.prev_linear_edges   = prev_linear_edges;
   copy_impl.curr_linear_edges   = curr_linear_edges;
   copy_impl.prev_arc_edges      = prev_arc_edges;
   copy_impl.curr_arc_edges      = curr_arc_edges;
-  copy_impl.curr_node_idxs      = curr_node_idxs;
+  copy_impl.curr_node_pts      = curr_node_pts;
   copy_impl.prev_length_dims    = prev_length_dims;
   copy_impl.curr_length_dims    = curr_length_dims;
   copy_impl.prev_operation_axis = prev_operation_axis;
@@ -468,7 +499,16 @@ std::unique_ptr<Sketch_delta> Sketch_delta::Impl::clone() const
 
 bool Sketch_delta::Impl::prev_linear_equal_(const Prev_edge_rec& x, const Prev_edge_rec& y)
 {
-  return x.node_idx_a == y.node_idx_a && x.node_idx_b == y.node_idx_b && x.node_idx_mid == y.node_idx_mid;
+  if (!pts_equal_(x.pt_a, y.pt_a) || !pts_equal_(x.pt_b, y.pt_b))
+    return false;
+
+  if (x.pt_mid.has_value() != y.pt_mid.has_value())
+    return false;
+
+  if (x.pt_mid.has_value() && !pts_equal_(*x.pt_mid, *y.pt_mid))
+    return false;
+
+  return true;
 }
 
 bool Sketch_delta::Impl::curr_linear_equal_(const Curr_linear_edge_record& x, const Curr_linear_edge_record& y)
@@ -486,7 +526,7 @@ bool Sketch_delta::Impl::arc_equal_(const Arc_edge_record& x, const Arc_edge_rec
 
 bool Sketch_delta::Impl::length_dim_equal_(const Length_dim_record& x, const Length_dim_record& y)
 {
-  return x.node_idx_lo == y.node_idx_lo && x.node_idx_hi == y.node_idx_hi;
+  return pts_equal_(x.pt_lo, y.pt_lo) && pts_equal_(x.pt_hi, y.pt_hi);
 }
 
 void Sketch_delta::Impl::remove_linear_edges_on_segment_(Sketch& sketch, const gp_Pnt2d& seg_a, const gp_Pnt2d& seg_b)
@@ -511,28 +551,49 @@ void Sketch_delta::Impl::remove_linear_edges_on_segment_(Sketch& sketch, const g
   }
 }
 
-void Sketch_delta::Impl::remove_linear_edges_on_node_segment_(Sketch& sketch, size_t node_a, size_t node_b)
+void Sketch_delta::Impl::remove_linear_edges_on_node_segment_(Sketch& sketch, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
 {
-  remove_linear_edges_on_segment_(sketch, sketch.m_nodes[node_a], sketch.m_nodes[node_b]);
+  remove_linear_edges_on_segment_(sketch, pt_a, pt_b);
 }
 
 void Sketch_delta::Impl::remove_arc_edge_(Sketch& sketch, const Arc_edge_record& rec)
 {
   std::vector<Sketch_AIS_edge_ptr> shps_to_remove;
 
-  sketch.m_edges.for_each_arc(
-      [&](const Sketch_edge_arc& a)
+  for (auto itr = sketch.m_edges.edges().begin(); itr != sketch.m_edges.edges().end(); ++itr)
+  {
+    if (!itr->circle_arc || itr->shp.IsNull())
+      continue;
+
+    const Sketch::Edge* e1 = &*itr;
+    const Sketch::Edge* e2 = nullptr;
+
+    for (auto itr2 = sketch.m_edges.edges().begin(); itr2 != sketch.m_edges.edges().end(); ++itr2)
+      if (itr2 != itr && itr2->shp == e1->shp)
       {
-        const gp_Pnt2d start = sketch.m_nodes[a.node_start];
-        const gp_Pnt2d arc   = sketch.m_nodes[a.node_arc];
-        const gp_Pnt2d end   = sketch.m_nodes[a.node_end];
+        e2 = &*itr2;
+        break;
+      }
 
-        if (!arc_equal_({start, arc, end}, rec))
-          return;
+    if (!e2)
+      continue;
 
-        if (std::find(shps_to_remove.begin(), shps_to_remove.end(), a.shp) == shps_to_remove.end())
-          shps_to_remove.push_back(a.shp);
-      });
+    const Sketch::Edge* first  = e1->node_idx_arc.has_value() ? e1 : (e2->node_idx_arc.has_value() ? e2 : nullptr);
+    const Sketch::Edge* second = first == e1 ? e2 : e1;
+    if (!first || !first->node_idx_arc.has_value() || !second->node_idx_b.has_value())
+      continue;
+
+    const gp_Pnt2d start = sketch.m_nodes[first->node_idx_a];
+    const gp_Pnt2d arc   = sketch.m_nodes[*first->node_idx_arc];
+    const gp_Pnt2d end   = sketch.m_nodes[*second->node_idx_b];
+
+    if (!arc_equal_({start, arc, end}, rec))
+      continue;
+
+    const Sketch_AIS_edge_ptr& shp = e1->shp;
+    if (std::find(shps_to_remove.begin(), shps_to_remove.end(), shp) == shps_to_remove.end())
+      shps_to_remove.push_back(shp);
+  }
 
   for (const Sketch_AIS_edge_ptr& shp : shps_to_remove)
   {
@@ -548,32 +609,54 @@ void Sketch_delta::Impl::remove_arc_edge_(Sketch& sketch, const Arc_edge_record&
 void Sketch_delta::Impl::remove_length_dim_(Sketch& sketch, const Length_dim_record& rec)
 {
   for (auto it = sketch.m_dims.dimensions().begin(); it != sketch.m_dims.dimensions().end(); ++it)
-    if (it->node_idx_lo == rec.node_idx_lo && it->node_idx_hi == rec.node_idx_hi)
-    {
-      if (!it->dim.IsNull())
-        sketch.m_ctx.Remove(it->dim, true);
+  {
+    const gp_Pnt2d& lo = sketch.m_nodes[it->node_idx_lo];
+    const gp_Pnt2d& hi = sketch.m_nodes[it->node_idx_hi];
+    if (!pts_equal_(lo, rec.pt_lo) || !pts_equal_(hi, rec.pt_hi))
+      continue;
 
-      sketch.m_dims.dimensions().erase(it);
-      return;
-    }
+    if (!it->dim.IsNull())
+      sketch.m_ctx.Remove(it->dim, true);
+
+    sketch.m_dims.dimensions().erase(it);
+    return;
+  }
 }
 
-void Sketch_delta::Impl::tombstone_node_(Sketch& sketch, size_t node_idx)
+void Sketch_delta::Impl::tombstone_node_at_pt_(Sketch& sketch, const gp_Pnt2d& pt)
 {
-  EZY_ASSERT(node_idx < sketch.m_nodes.size());
-  sketch.m_nodes[node_idx].deleted = true;
-  sketch.remove_length_dimensions_referencing_node_(node_idx);
-  sketch.m_node_marks.remove_at(node_idx);
+  for (size_t i = 0, n = sketch.m_nodes.size(); i < n; ++i)
+  {
+    if (sketch.m_nodes[i].deleted)
+      continue;
+
+    if (!pts_equal_(sketch.m_nodes[i], pt))
+      continue;
+
+    sketch.m_nodes[i].deleted = true;
+    sketch.remove_length_dimensions_referencing_node_(i);
+    sketch.m_node_marks.remove_at(i);
+    return;
+  }
 }
 
 void Sketch_delta::Impl::restore_prev_linear_edge_(Sketch& sketch, const Prev_edge_rec& rec)
 {
-  remove_linear_edges_on_node_segment_(sketch, rec.node_idx_a, rec.node_idx_b);
-  sketch.sketch_json_add_linear_edge_(rec.node_idx_a, rec.node_idx_b, rec.node_idx_mid);
+  remove_linear_edges_on_segment_(sketch, rec.pt_a, rec.pt_b);
+
+  const size_t idx_a = sketch.m_nodes.get_node_exact(rec.pt_a);
+  const size_t idx_b = sketch.m_nodes.get_node_exact(rec.pt_b);
+  std::optional<size_t> idx_mid;
+  if (rec.pt_mid.has_value())
+    idx_mid = sketch.m_nodes.get_node_exact(*rec.pt_mid);
+
+  sketch.sketch_json_add_linear_edge_(idx_a, idx_b, idx_mid);
   if (!rec.name.empty())
     for (Sketch::Edge& e : sketch.m_edges.edges())
-      if (!e.circle_arc && e.node_idx_a == rec.node_idx_a && e.node_idx_b.has_value() && *e.node_idx_b == rec.node_idx_b &&
-          e.node_idx_mid == rec.node_idx_mid)
+      if (!e.circle_arc && e.node_idx_b.has_value() && pts_equal_(sketch.m_nodes[e.node_idx_a], rec.pt_a) &&
+          pts_equal_(sketch.m_nodes[*e.node_idx_b], rec.pt_b) &&
+          ((!rec.pt_mid.has_value() && !e.node_idx_mid.has_value()) ||
+           (rec.pt_mid.has_value() && e.node_idx_mid.has_value() && pts_equal_(sketch.m_nodes[*e.node_idx_mid], *rec.pt_mid))))
       {
         e.name = rec.name;
         break;
@@ -582,14 +665,14 @@ void Sketch_delta::Impl::restore_prev_linear_edge_(Sketch& sketch, const Prev_ed
 
 void Sketch_delta::Impl::restore_length_dim_(Sketch& sketch, const Length_dim_record& rec)
 {
-  sketch.json_add_length_dimension_(rec.node_idx_lo, rec.node_idx_hi, rec.visible, rec.flyout_offset, rec.name);
+  const size_t lo = sketch.m_nodes.get_node_exact(rec.pt_lo);
+  const size_t hi = sketch.m_nodes.get_node_exact(rec.pt_hi);
+  sketch.json_add_length_dimension_(lo, hi, rec.visible, rec.flyout_offset, rec.name);
 }
 
 void Sketch_delta::Impl::restore_prev_operation_axis_(Sketch& sketch, const Prev_edge_rec& rec)
 {
-  const gp_Pnt2d pt_a = sketch.m_nodes[rec.node_idx_a];
-  const gp_Pnt2d pt_b = sketch.m_nodes[rec.node_idx_b];
-  sketch.sketch_json_set_operation_axis_(pt_a, pt_b);
+  sketch.sketch_json_set_operation_axis_(rec.pt_a, rec.pt_b);
 }
 
 void Sketch_delta::Impl::capture_linear_edges_at_start_(Sketch& sketch, std::vector<Prev_edge_rec>& out)
@@ -599,7 +682,9 @@ void Sketch_delta::Impl::capture_linear_edges_at_start_(Sketch& sketch, std::vec
     if (!is_linear_sketch_edge_(e))
       continue;
 
-    Prev_edge_rec rec{e.node_idx_a, *e.node_idx_b, e.node_idx_mid, e.name};
+    Prev_edge_rec rec{sketch.m_nodes[e.node_idx_a], sketch.m_nodes[*e.node_idx_b], std::nullopt, e.name};
+    if (e.node_idx_mid.has_value())
+      rec.pt_mid = sketch.m_nodes[*e.node_idx_mid];
     if (std::find_if(out.begin(), out.end(), [&](const Prev_edge_rec& x) { return prev_linear_equal_(x, rec); }) == out.end())
       out.push_back(std::move(rec));
   }
@@ -628,6 +713,11 @@ bool on_closed_segment_2d_(const gp_Pnt2d& p, const gp_Pnt2d& a, const gp_Pnt2d&
 bool is_linear_sketch_edge_(const Sketch::Edge& e)
 {
   return !e.circle_arc && e.node_idx_b.has_value() && !e.node_idx_arc.has_value();
+}
+
+bool pts_equal_(const gp_Pnt2d& a, const gp_Pnt2d& b)
+{
+  return a.SquareDistance(b) <= Precision::SquareConfusion();
 }
 
 } // namespace

--- a/src/sketch_delta.cpp
+++ b/src/sketch_delta.cpp
@@ -568,13 +568,13 @@ void Sketch_delta::Impl::remove_arc_edge_(Sketch& sketch, const Arc_edge_record&
 
 void Sketch_delta::Impl::remove_length_dim_(Sketch& sketch, const Length_dim_record& rec)
 {
-  for (auto it = sketch.m_length_dimensions.begin(); it != sketch.m_length_dimensions.end(); ++it)
+  for (auto it = sketch.m_dims.dimensions().begin(); it != sketch.m_dims.dimensions().end(); ++it)
     if (it->node_idx_lo == rec.node_idx_lo && it->node_idx_hi == rec.node_idx_hi)
     {
       if (!it->dim.IsNull())
         sketch.m_ctx.Remove(it->dim, true);
 
-      sketch.m_length_dimensions.erase(it);
+      sketch.m_dims.dimensions().erase(it);
       return;
     }
 }

--- a/src/sketch_delta.cpp
+++ b/src/sketch_delta.cpp
@@ -491,7 +491,7 @@ bool Sketch_delta::Impl::length_dim_equal_(const Length_dim_record& x, const Len
 
 void Sketch_delta::Impl::remove_linear_edges_on_segment_(Sketch& sketch, const gp_Pnt2d& seg_a, const gp_Pnt2d& seg_b)
 {
-  for (auto itr = sketch.m_edges.begin(); itr != sketch.m_edges.end();)
+  for (auto itr = sketch.m_edges.edges().begin(); itr != sketch.m_edges.edges().end();)
   {
     if (itr->circle_arc || !itr->node_idx_b.has_value())
     {
@@ -504,7 +504,7 @@ void Sketch_delta::Impl::remove_linear_edges_on_segment_(Sketch& sketch, const g
     if (on_closed_segment_2d_(pa, seg_a, seg_b) && on_closed_segment_2d_(pb, seg_a, seg_b))
     {
       sketch.m_ctx.Remove(itr->shp, false);
-      itr = sketch.m_edges.erase(itr);
+      itr = sketch.m_edges.edges().erase(itr);
     }
     else
       ++itr;
@@ -520,47 +520,26 @@ void Sketch_delta::Impl::remove_arc_edge_(Sketch& sketch, const Arc_edge_record&
 {
   std::vector<Sketch_AIS_edge_ptr> shps_to_remove;
 
-  for (auto itr = sketch.m_edges.begin(); itr != sketch.m_edges.end(); ++itr)
-  {
-    if (!itr->circle_arc || itr->shp.IsNull())
-      continue;
-
-    const Sketch::Edge* e1 = &*itr;
-    const Sketch::Edge* e2 = nullptr;
-
-    for (auto itr2 = sketch.m_edges.begin(); itr2 != sketch.m_edges.end(); ++itr2)
-      if (itr2 != itr && itr2->shp == e1->shp)
+  sketch.m_edges.for_each_arc(
+      [&](const Sketch_edge_arc& a)
       {
-        e2 = &*itr2;
-        break;
-      }
+        const gp_Pnt2d start = sketch.m_nodes[a.node_start];
+        const gp_Pnt2d arc   = sketch.m_nodes[a.node_arc];
+        const gp_Pnt2d end   = sketch.m_nodes[a.node_end];
 
-    if (!e2)
-      continue;
+        if (!arc_equal_({start, arc, end}, rec))
+          return;
 
-    const Sketch::Edge* first  = e1->node_idx_arc.has_value() ? e1 : (e2->node_idx_arc.has_value() ? e2 : nullptr);
-    const Sketch::Edge* second = first == e1 ? e2 : e1;
-    if (!first || !first->node_idx_arc.has_value() || !second->node_idx_b.has_value())
-      continue;
-
-    const gp_Pnt2d start = sketch.m_nodes[first->node_idx_a];
-    const gp_Pnt2d arc   = sketch.m_nodes[*first->node_idx_arc];
-    const gp_Pnt2d end   = sketch.m_nodes[*second->node_idx_b];
-
-    if (!arc_equal_({start, arc, end}, rec))
-      continue;
-
-    const Sketch_AIS_edge_ptr& shp = e1->shp;
-    if (std::find(shps_to_remove.begin(), shps_to_remove.end(), shp) == shps_to_remove.end())
-      shps_to_remove.push_back(shp);
-  }
+        if (std::find(shps_to_remove.begin(), shps_to_remove.end(), a.shp) == shps_to_remove.end())
+          shps_to_remove.push_back(a.shp);
+      });
 
   for (const Sketch_AIS_edge_ptr& shp : shps_to_remove)
   {
     sketch.m_ctx.Remove(shp, false);
-    for (auto itr = sketch.m_edges.begin(); itr != sketch.m_edges.end();)
+    for (auto itr = sketch.m_edges.edges().begin(); itr != sketch.m_edges.edges().end();)
       if (itr->shp == shp)
-        itr = sketch.m_edges.erase(itr);
+        itr = sketch.m_edges.edges().erase(itr);
       else
         ++itr;
   }
@@ -592,7 +571,7 @@ void Sketch_delta::Impl::restore_prev_linear_edge_(Sketch& sketch, const Prev_ed
   remove_linear_edges_on_node_segment_(sketch, rec.node_idx_a, rec.node_idx_b);
   sketch.sketch_json_add_linear_edge_(rec.node_idx_a, rec.node_idx_b, rec.node_idx_mid);
   if (!rec.name.empty())
-    for (Sketch::Edge& e : sketch.m_edges)
+    for (Sketch::Edge& e : sketch.m_edges.edges())
       if (!e.circle_arc && e.node_idx_a == rec.node_idx_a && e.node_idx_b.has_value() && *e.node_idx_b == rec.node_idx_b &&
           e.node_idx_mid == rec.node_idx_mid)
       {
@@ -615,7 +594,7 @@ void Sketch_delta::Impl::restore_prev_operation_axis_(Sketch& sketch, const Prev
 
 void Sketch_delta::Impl::capture_linear_edges_at_start_(Sketch& sketch, std::vector<Prev_edge_rec>& out)
 {
-  for (const Sketch::Edge& e : sketch.m_edges)
+  for (const Sketch::Edge& e : sketch.m_edges.edges())
   {
     if (!is_linear_sketch_edge_(e))
       continue;

--- a/src/sketch_delta.cpp
+++ b/src/sketch_delta.cpp
@@ -563,7 +563,7 @@ void Sketch_delta::Impl::tombstone_node_(Sketch& sketch, size_t node_idx)
   EZY_ASSERT(node_idx < sketch.m_nodes.size());
   sketch.m_nodes[node_idx].deleted = true;
   sketch.remove_length_dimensions_referencing_node_(node_idx);
-  sketch.remove_permanent_node_mark_ais_at_(node_idx);
+  sketch.m_node_marks.remove_at(node_idx);
 }
 
 void Sketch_delta::Impl::restore_prev_linear_edge_(Sketch& sketch, const Prev_edge_rec& rec)

--- a/src/sketch_delta.h
+++ b/src/sketch_delta.h
@@ -46,8 +46,11 @@ private:
 class Sketch_delta : public Delta
 {
 public:
-  Sketch_delta(Sketch& sketch, std::string sketch_name);
+  Sketch_delta(Sketch& sketch, size_t sketch_id);
   ~Sketch_delta() override;
+
+  /// Clone path: identity by stable sketch id (no live `Sketch` pointer).
+  explicit Sketch_delta(size_t sketch_id);
 
   Sketch_delta(const Sketch_delta&)            = delete;
   Sketch_delta& operator=(const Sketch_delta&) = delete;

--- a/src/sketch_dims.cpp
+++ b/src/sketch_dims.cpp
@@ -1,0 +1,626 @@
+#include "sketch_dims.h"
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <Precision.hxx>
+#include <imgui.h>
+
+#include <functional>
+
+#include <glm/glm.hpp>
+
+#include "gui.h"
+#include "mode.h"
+#include "occt_view.h"
+#include "sketch.h"
+#include "sketch_delta.h"
+#include "utl_geom.h"
+
+using namespace glm;
+
+namespace
+{
+struct Symmetric_edge_span
+{
+  gp_Pnt2d pt_a;
+  gp_Pnt2d pt_b;
+  double   full_len;
+};
+
+std::optional<Symmetric_edge_span> symmetric_edge_from_center(const gp_Pnt2d& center, const gp_Dir2d& dir, double full_len)
+{
+  if (full_len <= Precision::Confusion())
+    return std::nullopt;
+
+  const double   half = full_len * 0.5;
+  const gp_Vec2d v(dir);
+  return Symmetric_edge_span{center.Translated(-v * half), center.Translated(v * half), full_len};
+}
+} // namespace
+
+Sketch_dims::Sketch_dims(Sketch& sketch)
+    : m_sketch(sketch)
+{
+}
+
+void Sketch_dims::begin_dimension_input() { m_show_dim_input = true; }
+
+void Sketch_dims::begin_angle_input() { m_show_angle_input = true; }
+
+void Sketch_dims::remove_displayed()
+{
+  for (Length_dimension& ld : m_length_dimensions)
+    if (!ld.dim.IsNull())
+      m_sketch.m_ctx.Remove(ld.dim, false);
+
+  m_length_dimensions.clear();
+
+  if (m_len_dim_rubber_shp)
+    m_sketch.m_ctx.Remove(m_len_dim_rubber_shp, false);
+
+  m_len_dim_rubber_shp.Nullify();
+}
+
+void Sketch_dims::clear_tmp_dim_anno()
+{
+  m_sketch.m_ctx.Remove(m_tmp_dim_anno, true);
+  m_tmp_dim_anno.Nullify();
+}
+
+void Sketch_dims::on_finalize_elm_start()
+{
+  m_show_dim_input     = false;
+  m_show_angle_input   = false;
+  m_entered_edge_angle = std::nullopt;
+  m_sketch.m_view.gui().hide_angle_edit();
+  clear_tmp_dim_anno();
+}
+
+void Sketch_dims::on_clear_tmps() { clear_all(m_entered_edge_len, m_show_dim_input, m_entered_edge_angle, m_show_angle_input); }
+
+void Sketch_dims::clear_typed_constraints()
+{
+  m_entered_edge_angle = std::nullopt;
+  m_entered_edge_len   = std::nullopt;
+  m_show_angle_input   = false;
+  m_show_dim_input     = false;
+}
+
+std::optional<gp_Pnt> Sketch_dims::approx_sketch_interior_ref_3d_() const
+{
+  gp_XYZ acc(0., 0., 0.);
+  size_t n = 0;
+  for (size_t i = 0; i < m_sketch.m_nodes.size(); ++i)
+  {
+    if (m_sketch.m_nodes[i].deleted)
+      continue;
+
+    acc += m_sketch.to_3d_(i).XYZ();
+    ++n;
+  }
+  if (n == 0)
+    return std::nullopt;
+
+  return gp_Pnt(acc / static_cast<double>(n));
+}
+
+void Sketch_dims::rebuild_length_dimension_display_(Length_dimension& d)
+{
+  if (!d.dim.IsNull())
+    m_sketch.m_ctx.Remove(d.dim, false);
+
+  d.dim = create_distance_annotation(m_sketch.m_nodes[d.node_idx_lo], m_sketch.m_nodes[d.node_idx_hi], m_sketch.m_pln,
+                                     m_sketch.m_view.gui().length_dimension_style(), approx_sketch_interior_ref_3d_(),
+                                     m_sketch.m_topo.dim_classifier_faces().empty() ? nullptr
+                                                                                    : &m_sketch.m_topo.dim_classifier_faces());
+
+  const double dist = m_sketch.m_nodes[d.node_idx_lo].Distance(m_sketch.m_nodes[d.node_idx_hi]);
+  d.dim->SetCustomValue(dist / m_sketch.m_view.get_dimension_scale());
+  if (d.flyout_offset.has_value() && *d.flyout_offset > 0.0)
+  {
+    const double f    = d.dim->GetFlyout();
+    const double sign = f < 0.0 ? -1.0 : 1.0;
+    d.dim->SetFlyout(static_cast<double>(sign * *d.flyout_offset));
+  }
+
+  if (m_sketch.m_visible && m_show_dims && d.visible)
+    m_sketch.m_ctx.Display(d.dim, false);
+}
+
+void Sketch_dims::purge_stale_length_dimensions()
+{
+  for (auto it = m_length_dimensions.begin(); it != m_length_dimensions.end();)
+  {
+    const bool bad = it->node_idx_lo >= m_sketch.m_nodes.size() || it->node_idx_hi >= m_sketch.m_nodes.size() ||
+                     m_sketch.m_nodes[it->node_idx_lo].deleted || m_sketch.m_nodes[it->node_idx_hi].deleted;
+    if (bad)
+    {
+      if (!it->dim.IsNull())
+        m_sketch.m_ctx.Remove(it->dim, true);
+
+      it = m_length_dimensions.erase(it);
+    }
+    else
+      ++it;
+  }
+}
+
+void Sketch_dims::refresh_all_length_dimensions()
+{
+  for (Length_dimension& d : m_length_dimensions)
+    rebuild_length_dimension_display_(d);
+}
+
+void Sketch_dims::remove_length_dimensions_referencing_node_(size_t node_idx)
+{
+  for (auto it = m_length_dimensions.begin(); it != m_length_dimensions.end();)
+    if (it->node_idx_lo == node_idx || it->node_idx_hi == node_idx)
+    {
+      if (!it->dim.IsNull())
+        m_sketch.m_ctx.Remove(it->dim, true);
+
+      it = m_length_dimensions.erase(it);
+    }
+    else
+      ++it;
+}
+
+void Sketch_dims::add_or_toggle_length_dim_between_node_indices_(size_t node_a, size_t node_b)
+{
+  const size_t lo = std::min(node_a, node_b);
+  const size_t hi = std::max(node_a, node_b);
+  if (lo == hi)
+    return;
+
+  for (auto it = m_length_dimensions.begin(); it != m_length_dimensions.end(); ++it)
+    if (it->node_idx_lo == lo && it->node_idx_hi == hi)
+    {
+      Sketch_op_recorder rec(m_sketch.m_view, m_sketch);
+      rec.note_prev_length_dim(lo, hi, it->visible, it->flyout_offset, it->name);
+      if (!it->dim.IsNull())
+        m_sketch.m_ctx.Remove(it->dim, true);
+
+      m_length_dimensions.erase(it);
+      rec.commit();
+      return;
+    }
+
+  Sketch_op_recorder rec(m_sketch.m_view, m_sketch);
+  {
+    Length_dimension d;
+    d.node_idx_lo = lo;
+    d.node_idx_hi = hi;
+    m_length_dimensions.push_back(std::move(d));
+    rebuild_length_dimension_display_(m_length_dimensions.back());
+    rec.note_curr_length_dim(lo, hi, m_length_dimensions.back().visible, m_length_dimensions.back().flyout_offset,
+                             m_length_dimensions.back().name);
+    rec.commit();
+  }
+}
+
+void Sketch_dims::json_add_length_dimension_(size_t node_a, size_t node_b, const bool visible,
+                                             const std::optional<double> flyout_offset, const std::string& name)
+{
+  const size_t lo = std::min(node_a, node_b);
+  const size_t hi = std::max(node_a, node_b);
+  if (lo == hi)
+    return;
+
+  for (const Length_dimension& x : m_length_dimensions)
+    if (x.node_idx_lo == lo && x.node_idx_hi == hi)
+      return;
+
+  Length_dimension d;
+  d.node_idx_lo   = lo;
+  d.node_idx_hi   = hi;
+  d.visible       = visible;
+  d.flyout_offset = flyout_offset;
+  d.name          = name;
+  m_length_dimensions.push_back(std::move(d));
+  rebuild_length_dimension_display_(m_length_dimensions.back());
+}
+
+bool Sketch_dims::try_remove_length_dimension(PrsDim_LengthDimension* dim)
+{
+  if (!dim)
+    return false;
+
+  for (auto it = m_length_dimensions.begin(); it != m_length_dimensions.end(); ++it)
+    if (it->dim.get() == dim)
+    {
+      m_sketch.m_ctx.Remove(it->dim, true);
+      m_length_dimensions.erase(it);
+      return true;
+    }
+
+  return false;
+}
+
+void Sketch_dims::toggle_edge_dim_anno(const ScreenCoords& screen_coords)
+{
+  if (std::optional<size_t> n = m_sketch.m_nodes.try_pick_existing_node(screen_coords))
+  {
+    if (!m_len_dim_pick_anchor_node.has_value())
+    {
+      m_len_dim_pick_anchor_node = *n;
+      update_len_dim_rubber_line_(screen_coords);
+      return;
+    }
+
+    if (*m_len_dim_pick_anchor_node != *n)
+      add_or_toggle_length_dim_between_node_indices_(*m_len_dim_pick_anchor_node, *n);
+
+    clear_pick_state();
+    return;
+  }
+
+  if (std::list<Sketch::Edge>::iterator itr = m_sketch.get_edge_at_(screen_coords); itr != m_sketch.m_edges.end())
+    if (!itr->circle_arc && itr->node_idx_b.has_value() && !itr->node_idx_arc.has_value())
+    {
+      add_or_toggle_length_dim_between_node_indices_(itr->node_idx_a, *itr->node_idx_b);
+      clear_pick_state();
+      return;
+    }
+
+  clear_pick_state();
+}
+
+void Sketch_dims::clear_len_dim_rubber_line_()
+{
+  if (m_len_dim_rubber_shp)
+  {
+    m_sketch.m_ctx.Remove(m_len_dim_rubber_shp, false);
+    m_len_dim_rubber_shp.Nullify();
+  }
+}
+
+void Sketch_dims::clear_pick_state()
+{
+  m_len_dim_pick_anchor_node.reset();
+  clear_len_dim_rubber_line_();
+}
+
+void Sketch_dims::update_len_dim_rubber_line_(const ScreenCoords& screen_coords)
+{
+  if (!m_len_dim_pick_anchor_node.has_value())
+  {
+    clear_len_dim_rubber_line_();
+    return;
+  }
+
+  const gp_Pnt2d&         pt_a   = m_sketch.m_nodes[*m_len_dim_pick_anchor_node];
+  std::optional<gp_Pnt2d> pt_opt = m_sketch.m_view.pt_on_plane(screen_coords, m_sketch.m_pln);
+  if (!pt_opt)
+    return;
+
+  gp_Pnt2d pt_b = *pt_opt;
+  (void)m_sketch.m_nodes.try_get_node_idx_snap(pt_b);
+
+  if (!unique(pt_a, pt_b))
+  {
+    clear_len_dim_rubber_line_();
+    return;
+  }
+
+  const TopoDS_Shape edge_shape = BRepBuilderAPI_MakeEdge(to_3d(m_sketch.m_pln, pt_a), to_3d(m_sketch.m_pln, pt_b)).Edge();
+
+  if (m_len_dim_rubber_shp)
+  {
+    m_len_dim_rubber_shp->Set(edge_shape);
+    m_sketch.update_edge_style_(m_len_dim_rubber_shp);
+    m_sketch.m_ctx.Redisplay(m_len_dim_rubber_shp, true);
+  }
+  else
+  {
+    m_len_dim_rubber_shp = new AIS_Shape(edge_shape);
+    m_sketch.update_edge_style_(m_len_dim_rubber_shp);
+    m_sketch.m_ctx.Display(m_len_dim_rubber_shp, AIS_WireFrame, 0, true);
+  }
+}
+
+void Sketch_dims::show_tmp_dim_preview(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  m_sketch.m_ctx.Remove(m_tmp_dim_anno, true);
+  if (!unique(pt_a, pt_b))
+  {
+    m_tmp_dim_anno.Nullify();
+    return;
+  }
+
+  const double dist = pt_a.Distance(pt_b) / m_sketch.m_view.get_dimension_scale();
+  m_tmp_dim_anno    = create_distance_annotation(
+      pt_a, pt_b, m_sketch.m_pln, m_sketch.m_view.gui().length_dimension_style(), approx_sketch_interior_ref_3d_(),
+      m_sketch.m_topo.dim_classifier_faces().empty() ? nullptr : &m_sketch.m_topo.dim_classifier_faces());
+  m_tmp_dim_anno->SetCustomValue(dist);
+  m_sketch.m_ctx.Display(m_tmp_dim_anno, true);
+}
+
+void Sketch_dims::offer_dist_edit_for_segment(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, double dist)
+{
+  if (!m_show_dim_input || !unique(pt_a, pt_b))
+    return;
+
+  const gp_Dir2d     edge_dir = get_unit_dir(pt_a, pt_b);
+  const ScreenCoords spos     = m_sketch.m_view.get_screen_coords(to_3d(m_sketch.m_pln, center_point(pt_a, pt_b)));
+
+  auto cb = [this, edge_dir](float new_dist, bool is_finial)
+  {
+    m_entered_edge_len = {edge_dir, new_dist * m_sketch.m_view.get_dimension_scale()};
+    m_show_dim_input   = !is_finial;
+    if (is_finial)
+      m_sketch.on_enter();
+  };
+
+  m_sketch.m_view.gui().set_dist_edit(static_cast<float>(dist), std::move(std::function<void(float, bool)>(cb)), spos);
+}
+
+void Sketch_dims::offer_angle_edit_for_segment(const gp_Pnt2d& pt_a, const gp_Pnt2d& mouse_pt, double current_angle_deg)
+{
+  if (!m_show_angle_input)
+    return;
+
+  const ScreenCoords spos = m_sketch.m_view.get_screen_coords(to_3d(m_sketch.m_pln, center_point(pt_a, mouse_pt)));
+
+  auto cb = [this](float new_angle, bool is_finial)
+  {
+    m_entered_edge_angle = new_angle;
+    m_show_angle_input   = !is_finial;
+    const ScreenCoords current_pos(dvec2(ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y));
+    m_sketch.sketch_pt_move(current_pos);
+  };
+
+  const float angle_to_show = m_entered_edge_angle.has_value() ? float(*m_entered_edge_angle) : float(current_angle_deg);
+  m_sketch.m_view.gui().set_angle_edit(angle_to_show, std::move(std::function<void(float, bool)>(cb)), spos);
+}
+
+void Sketch_dims::check_dimension_seg_(int kind)
+{
+  const auto linestring_type = static_cast<Sketch::Linestring_type>(kind);
+
+  if (!m_entered_edge_len.has_value())
+    return;
+
+  if (m_entered_edge_len->len <= Precision::Confusion())
+    return;
+
+  EZY_ASSERT(m_sketch.m_tmp_edges.size());
+
+  Sketch::Edge& edge = m_sketch.m_tmp_edges.back();
+  if (m_sketch.edge_from_center_active_() && linestring_type == Sketch::Linestring_type::Single)
+  {
+    const gp_Pnt2d&                    center = m_sketch.m_nodes[edge.node_idx_a];
+    std::optional<Symmetric_edge_span> span =
+        symmetric_edge_from_center(center, m_entered_edge_len->dir, m_entered_edge_len->len);
+
+    if (span)
+    {
+      edge.node_idx_a = m_sketch.m_nodes.get_node_exact(span->pt_a);
+      m_sketch.update_edge_end_pt_(edge, m_sketch.m_nodes.get_node_exact(span->pt_b));
+      clear_all(m_entered_edge_len);
+      m_sketch.finalize_elm();
+    }
+    return;
+  }
+
+  const gp_Pnt2d& pt_a = m_sketch.m_nodes[edge.node_idx_a];
+  m_sketch.m_last_pt   = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_entered_edge_len->dir) * m_entered_edge_len->len);
+
+  m_sketch.update_edge_end_pt_(edge, m_sketch.m_nodes.get_node_exact(*m_sketch.m_last_pt));
+
+  EZY_ASSERT(edge.node_idx_b.has_value());
+
+  clear_all(m_entered_edge_len);
+
+  if (linestring_type == Sketch::Linestring_type::Single)
+    m_sketch.finalize_elm();
+
+  else if (linestring_type == Sketch::Linestring_type::Two)
+  {
+    switch (m_sketch.m_tmp_edges.size())
+    {
+    case 1:
+      m_entered_edge_angle = std::nullopt;
+      m_show_angle_input   = false;
+      m_sketch.m_view.gui().hide_angle_edit();
+      m_sketch.m_tmp_edges.push_back({*edge.node_idx_b});
+      break;
+
+    case 2:
+      m_sketch.finalize_elm();
+      break;
+
+    default:
+      EZY_ASSERT(false);
+    }
+  }
+  else
+  {
+    m_entered_edge_angle = std::nullopt;
+    m_show_angle_input   = false;
+    m_sketch.m_view.gui().hide_angle_edit();
+    m_sketch.m_tmp_edges.push_back({*edge.node_idx_b});
+  }
+}
+
+void Sketch_dims::check_dimension_rubber_()
+{
+  if (!m_entered_edge_len.has_value())
+    return;
+
+  if (m_entered_edge_len->len <= Precision::Confusion())
+    return;
+
+  if (m_sketch.m_tmp_edges.empty())
+    return;
+
+  Sketch::Edge&   edge = m_sketch.m_tmp_edges.back();
+  const gp_Pnt2d& pt_a = m_sketch.m_nodes[edge.node_idx_a];
+  m_sketch.m_last_pt   = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_entered_edge_len->dir) * m_entered_edge_len->len);
+
+  if (!unique(pt_a, *m_sketch.m_last_pt))
+    return;
+
+  const Mode mode = m_sketch.get_mode();
+  if (mode == Mode::Sketch_add_square || mode == Mode::Sketch_add_circle || mode == Mode::Sketch_add_rectangle ||
+      mode == Mode::Sketch_add_rectangle_center_pt)
+  {
+    m_sketch.update_edge_end_pt_(edge, m_sketch.m_nodes.get_node_exact(*m_sketch.m_last_pt));
+    EZY_ASSERT(edge.node_idx_b.has_value());
+    clear_all(m_entered_edge_len);
+    m_sketch.finalize_elm();
+    return;
+  }
+
+  EZY_ASSERT(mode == Mode::Sketch_add_node);
+  const size_t b = m_sketch.m_nodes.get_node_exact(*m_sketch.m_last_pt, true);
+  clear_all(m_entered_edge_len);
+
+  Sketch_op_recorder rec(m_sketch.m_view, m_sketch);
+  {
+    rec.note_curr_node(b);
+    m_sketch.m_topo.split_linear_edges_at_node_if_interior(b, rec);
+
+    m_sketch.m_tmp_node_idxs.clear();
+    m_sketch.clear_tmps_();
+    clear_tmp_dim_anno();
+    m_sketch.m_nodes.hide_snap_annos();
+    m_sketch.update_faces_();
+    rec.commit();
+  }
+}
+
+size_t Sketch_dims::length_dimension_count() const { return m_length_dimensions.size(); }
+
+std::vector<std::string> Sketch_dims::inspector_dimension_labels() const
+{
+  std::vector<std::string> labels;
+  labels.reserve(m_length_dimensions.size());
+  for (size_t i = 0; i < m_length_dimensions.size(); ++i)
+  {
+    const Length_dimension& d   = m_length_dimensions[i];
+    std::string             lbl = d.name.empty() ? ("D" + std::to_string(i)) : d.name;
+    labels.push_back(std::move(lbl));
+  }
+
+  return labels;
+}
+
+bool Sketch_dims::dimension_visible(size_t dim_index) const
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  return m_length_dimensions[dim_index].visible;
+}
+
+void Sketch_dims::set_dimension_visible(size_t dim_index, bool visible)
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  Length_dimension& d = m_length_dimensions[dim_index];
+  if (d.visible == visible)
+    return;
+
+  d.visible = visible;
+  if (!d.dim.IsNull())
+  {
+    if (visible && m_sketch.m_visible && m_show_dims)
+      m_sketch.m_ctx.Display(d.dim, false);
+    else
+      m_sketch.m_ctx.Erase(d.dim, false);
+  }
+}
+
+size_t Sketch_dims::dimension_node_lo(size_t dim_index) const
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  return m_length_dimensions[dim_index].node_idx_lo;
+}
+
+size_t Sketch_dims::dimension_node_hi(size_t dim_index) const
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  return m_length_dimensions[dim_index].node_idx_hi;
+}
+
+double Sketch_dims::dimension_offset(size_t dim_index) const
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  const Length_dimension& d = m_length_dimensions[dim_index];
+  if (d.flyout_offset.has_value())
+    return *d.flyout_offset;
+
+  if (!d.dim.IsNull())
+    return std::abs(static_cast<double>(d.dim->GetFlyout()));
+
+  return 0.0;
+}
+
+void Sketch_dims::set_dimension_offset(size_t dim_index, const double offset)
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  Length_dimension& d = m_length_dimensions[dim_index];
+
+  const double off = std::max(0.0, offset);
+  if (off <= 0.0)
+    d.flyout_offset.reset();
+  else
+    d.flyout_offset = off;
+
+  rebuild_length_dimension_display_(d);
+}
+
+std::string Sketch_dims::dimension_name(size_t dim_index) const
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  return m_length_dimensions[dim_index].name;
+}
+
+void Sketch_dims::set_dimension_name(size_t dim_index, const std::string& name)
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  Length_dimension& d = m_length_dimensions[dim_index];
+  if (d.name == name)
+    return;
+
+  d.name = name;
+}
+
+PrsDim_LengthDimension_ptr Sketch_dims::length_dimension_handle(const size_t dim_index) const
+{
+  EZY_ASSERT(dim_index < m_length_dimensions.size());
+  return m_length_dimensions[dim_index].dim;
+}
+
+void Sketch_dims::set_show_dims(bool show)
+{
+  m_show_dims = show;
+  if (show && m_sketch.m_visible)
+  {
+    for (Length_dimension& ld : m_length_dimensions)
+      if (!ld.dim.IsNull() && ld.visible)
+        m_sketch.m_ctx.Display(ld.dim, false);
+  }
+  else
+  {
+    for (Length_dimension& ld : m_length_dimensions)
+      if (!ld.dim.IsNull())
+        m_sketch.m_ctx.Erase(ld.dim, false);
+  }
+}
+
+bool Sketch_dims::shows_dimensions() const { return m_show_dims; }
+
+void Sketch_dims::on_sketch_shown()
+{
+  if (m_len_dim_rubber_shp && m_len_dim_pick_anchor_node.has_value())
+    m_sketch.m_ctx.Display(m_len_dim_rubber_shp, AIS_WireFrame, 0, false);
+
+  if (m_show_dims)
+    for (Length_dimension& ld : m_length_dimensions)
+      if (!ld.dim.IsNull() && ld.visible)
+        m_sketch.m_ctx.Display(ld.dim, false);
+}
+
+void Sketch_dims::on_sketch_hidden()
+{
+  for (Length_dimension& ld : m_length_dimensions)
+    if (!ld.dim.IsNull())
+      m_sketch.m_ctx.Erase(ld.dim, false);
+}

--- a/src/sketch_dims.cpp
+++ b/src/sketch_dims.cpp
@@ -382,10 +382,10 @@ void Sketch_dims::check_dimension_seg_(int kind)
   if (m_entered_edge_len->len <= Precision::Confusion())
     return;
 
-  EZY_ASSERT(m_sketch.m_tmp_edges.size());
+  EZY_ASSERT(m_sketch.m_tools.tmp_edges().size());
 
-  Sketch::Edge& edge = m_sketch.m_tmp_edges.back();
-  if (m_sketch.edge_from_center_active_() && linestring_type == Sketch::Linestring_type::Single)
+  Sketch_edge& edge = m_sketch.m_tools.tmp_edges().back();
+  if (m_sketch.m_tools.edge_from_center_active() && linestring_type == Sketch::Linestring_type::Single)
   {
     const gp_Pnt2d&                    center = m_sketch.m_nodes[edge.node_idx_a];
     std::optional<Symmetric_edge_span> span =
@@ -401,10 +401,10 @@ void Sketch_dims::check_dimension_seg_(int kind)
     return;
   }
 
-  const gp_Pnt2d& pt_a = m_sketch.m_nodes[edge.node_idx_a];
-  m_sketch.m_last_pt   = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_entered_edge_len->dir) * m_entered_edge_len->len);
+  const gp_Pnt2d& pt_a       = m_sketch.m_nodes[edge.node_idx_a];
+  m_sketch.m_tools.last_pt() = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_entered_edge_len->dir) * m_entered_edge_len->len);
 
-  m_sketch.update_edge_end_pt_(edge, m_sketch.m_nodes.get_node_exact(*m_sketch.m_last_pt));
+  m_sketch.update_edge_end_pt_(edge, m_sketch.m_nodes.get_node_exact(*m_sketch.m_tools.last_pt()));
 
   EZY_ASSERT(edge.node_idx_b.has_value());
 
@@ -415,13 +415,13 @@ void Sketch_dims::check_dimension_seg_(int kind)
 
   else if (linestring_type == Sketch::Linestring_type::Two)
   {
-    switch (m_sketch.m_tmp_edges.size())
+    switch (m_sketch.m_tools.tmp_edges().size())
     {
     case 1:
       m_entered_edge_angle = std::nullopt;
       m_show_angle_input   = false;
       m_sketch.m_view.gui().hide_angle_edit();
-      m_sketch.m_tmp_edges.push_back({*edge.node_idx_b});
+      m_sketch.m_tools.tmp_edges().push_back({*edge.node_idx_b});
       break;
 
     case 2:
@@ -437,7 +437,7 @@ void Sketch_dims::check_dimension_seg_(int kind)
     m_entered_edge_angle = std::nullopt;
     m_show_angle_input   = false;
     m_sketch.m_view.gui().hide_angle_edit();
-    m_sketch.m_tmp_edges.push_back({*edge.node_idx_b});
+    m_sketch.m_tools.tmp_edges().push_back({*edge.node_idx_b});
   }
 }
 
@@ -449,21 +449,21 @@ void Sketch_dims::check_dimension_rubber_()
   if (m_entered_edge_len->len <= Precision::Confusion())
     return;
 
-  if (m_sketch.m_tmp_edges.empty())
+  if (m_sketch.m_tools.tmp_edges().empty())
     return;
 
-  Sketch::Edge&   edge = m_sketch.m_tmp_edges.back();
-  const gp_Pnt2d& pt_a = m_sketch.m_nodes[edge.node_idx_a];
-  m_sketch.m_last_pt   = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_entered_edge_len->dir) * m_entered_edge_len->len);
+  Sketch_edge&    edge       = m_sketch.m_tools.tmp_edges().back();
+  const gp_Pnt2d& pt_a       = m_sketch.m_nodes[edge.node_idx_a];
+  m_sketch.m_tools.last_pt() = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_entered_edge_len->dir) * m_entered_edge_len->len);
 
-  if (!unique(pt_a, *m_sketch.m_last_pt))
+  if (!unique(pt_a, *m_sketch.m_tools.last_pt()))
     return;
 
   const Mode mode = m_sketch.get_mode();
   if (mode == Mode::Sketch_add_square || mode == Mode::Sketch_add_circle || mode == Mode::Sketch_add_rectangle ||
       mode == Mode::Sketch_add_rectangle_center_pt)
   {
-    m_sketch.update_edge_end_pt_(edge, m_sketch.m_nodes.get_node_exact(*m_sketch.m_last_pt));
+    m_sketch.update_edge_end_pt_(edge, m_sketch.m_nodes.get_node_exact(*m_sketch.m_tools.last_pt()));
     EZY_ASSERT(edge.node_idx_b.has_value());
     clear_all(m_entered_edge_len);
     m_sketch.finalize_elm();
@@ -471,7 +471,7 @@ void Sketch_dims::check_dimension_rubber_()
   }
 
   EZY_ASSERT(mode == Mode::Sketch_add_node);
-  const size_t b = m_sketch.m_nodes.get_node_exact(*m_sketch.m_last_pt, true);
+  const size_t b = m_sketch.m_nodes.get_node_exact(*m_sketch.m_tools.last_pt(), true);
   clear_all(m_entered_edge_len);
 
   Sketch_op_recorder rec(m_sketch.m_view, m_sketch);
@@ -479,8 +479,8 @@ void Sketch_dims::check_dimension_rubber_()
     rec.note_curr_node(b);
     m_sketch.m_topo.split_linear_edges_at_node_if_interior(b, rec);
 
-    m_sketch.m_tmp_node_idxs.clear();
-    m_sketch.clear_tmps_();
+    m_sketch.m_tools.clear_tmp_node_idxs();
+    m_sketch.m_tools.clear_tmps();
     clear_tmp_dim_anno();
     m_sketch.m_nodes.hide_snap_annos();
     m_sketch.update_faces_();

--- a/src/sketch_dims.cpp
+++ b/src/sketch_dims.cpp
@@ -253,7 +253,7 @@ void Sketch_dims::toggle_edge_dim_anno(const ScreenCoords& screen_coords)
     return;
   }
 
-  if (std::list<Sketch::Edge>::iterator itr = m_sketch.get_edge_at_(screen_coords); itr != m_sketch.m_edges.end())
+  if (std::list<Sketch::Edge>::iterator itr = m_sketch.get_edge_at_(screen_coords); itr != m_sketch.m_edges.edges().end())
     if (!itr->circle_arc && itr->node_idx_b.has_value() && !itr->node_idx_arc.has_value())
     {
       add_or_toggle_length_dim_between_node_indices_(itr->node_idx_a, *itr->node_idx_b);

--- a/src/sketch_dims.h
+++ b/src/sketch_dims.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <gp_Dir2d.hxx>
+#include <gp_Pnt.hxx>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "utl_types.h"
+
+class Sketch;
+
+/// Length dimensions, typed distance/angle input while drawing, and dimension-tool pick state.
+class Sketch_dims
+{
+public:
+  /// When user types in an edge length while drawing.
+  struct Edge_len
+  {
+    gp_Dir2d dir;
+    double   len;
+  };
+
+  /// Linear distance between two sketch nodes (independent of which edge connects them).
+  struct Length_dimension
+  {
+    size_t                     node_idx_lo{};
+    size_t                     node_idx_hi{};
+    PrsDim_LengthDimension_ptr dim;
+    bool                       visible{true};
+    std::optional<double>      flyout_offset;
+    std::string                name;
+  };
+
+  explicit Sketch_dims(Sketch& sketch);
+
+  void begin_dimension_input();
+  void begin_angle_input();
+
+  bool                       dimension_visible(size_t dim_index) const;
+  void                       set_dimension_visible(size_t dim_index, bool visible);
+  size_t                     dimension_node_lo(size_t dim_index) const;
+  size_t                     dimension_node_hi(size_t dim_index) const;
+  double                     dimension_offset(size_t dim_index) const;
+  void                       set_dimension_offset(size_t dim_index, double offset);
+  std::string                dimension_name(size_t dim_index) const;
+  void                       set_dimension_name(size_t dim_index, const std::string& name);
+  PrsDim_LengthDimension_ptr length_dimension_handle(size_t dim_index) const;
+
+  void toggle_edge_dim_anno(const ScreenCoords& screen_coords);
+  bool try_remove_length_dimension(PrsDim_LengthDimension* dim);
+
+  [[nodiscard]] size_t     length_dimension_count() const;
+  std::vector<std::string> inspector_dimension_labels() const;
+
+  void               set_show_dims(bool show);
+  [[nodiscard]] bool shows_dimensions() const;
+
+  void refresh_all_length_dimensions();
+  void purge_stale_length_dimensions();
+  void remove_length_dimensions_referencing_node_(size_t node_idx);
+
+  void json_add_length_dimension_(size_t node_a, size_t node_b, bool visible = true,
+                                  std::optional<double> flyout_offset = std::nullopt, const std::string& name = {});
+
+  void remove_displayed();
+  void clear_pick_state();
+  void clear_tmp_dim_anno();
+  void on_finalize_elm_start();
+  void on_clear_tmps();
+
+  void update_len_dim_rubber_line_(const ScreenCoords& screen_coords);
+
+  /// `kind` is `static_cast<int>(Sketch::Linestring_type)`.
+  void check_dimension_seg_(int kind);
+  void check_dimension_rubber_();
+
+  void show_tmp_dim_preview(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
+  void offer_dist_edit_for_segment(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, double dist);
+  void offer_angle_edit_for_segment(const gp_Pnt2d& pt_a, const gp_Pnt2d& mouse_pt, double current_angle_deg);
+
+  void on_sketch_shown();
+  void on_sketch_hidden();
+
+  [[nodiscard]] const std::vector<Length_dimension>& dimensions() const { return m_length_dimensions; }
+  [[nodiscard]] std::vector<Length_dimension>&       dimensions() { return m_length_dimensions; }
+
+  [[nodiscard]] std::optional<Edge_len>&       entered_edge_len() { return m_entered_edge_len; }
+  [[nodiscard]] const std::optional<Edge_len>& entered_edge_len() const { return m_entered_edge_len; }
+  [[nodiscard]] std::optional<double>&         entered_edge_angle() { return m_entered_edge_angle; }
+  [[nodiscard]] const std::optional<double>&   entered_edge_angle() const { return m_entered_edge_angle; }
+  [[nodiscard]] bool                           show_dim_input() const { return m_show_dim_input; }
+  void                                         set_show_dim_input(bool on) { m_show_dim_input = on; }
+  [[nodiscard]] bool                           show_angle_input() const { return m_show_angle_input; }
+  void                                         set_show_angle_input(bool on) { m_show_angle_input = on; }
+
+  void clear_typed_constraints();
+
+private:
+  friend class Sketch;
+
+  std::optional<gp_Pnt> approx_sketch_interior_ref_3d_() const;
+  void                  rebuild_length_dimension_display_(Length_dimension& d);
+  void                  add_or_toggle_length_dim_between_node_indices_(size_t node_a, size_t node_b);
+  void                  clear_len_dim_rubber_line_();
+
+  Sketch& m_sketch;
+
+  std::optional<Edge_len> m_entered_edge_len;
+  bool                    m_show_dim_input{false};
+  std::optional<double>   m_entered_edge_angle;
+  bool                    m_show_angle_input{false};
+
+  std::vector<Length_dimension> m_length_dimensions;
+  std::optional<size_t>         m_len_dim_pick_anchor_node;
+  AIS_Shape_ptr                 m_len_dim_rubber_shp;
+  PrsDim_LengthDimension_ptr    m_tmp_dim_anno;
+  bool                          m_show_dims{true};
+};

--- a/src/sketch_display.cpp
+++ b/src/sketch_display.cpp
@@ -1,0 +1,199 @@
+// Sketch viewer display: visibility, edge styling, sketch switching, list hover.
+#include "sketch.h"
+
+#include <Quantity_Color.hxx>
+#include <V3d_Viewer.hxx>
+
+#include "occt_view.h"
+#include "utl.h"
+
+void Sketch::update_edge_style_(AIS_Shape_ptr& shp)
+{
+  switch (m_edge_style)
+  {
+  case Edge_style::Full:
+    shp->SetWidth(1.0);
+    shp->SetColor(Quantity_Color(0.0, 1.0, 0.0, Quantity_TOC_RGB));
+    shp->SetTransparency(0.0);
+    break;
+
+  case Edge_style::Background:
+    shp->SetWidth(1.0);
+    shp->SetColor(Quantity_Color(0.3, 0.3, 0.3, Quantity_TOC_RGB));
+    shp->SetTransparency(0.7);
+    break;
+
+  default:
+    EZY_ASSERT(false);
+  }
+}
+
+void Sketch::update_originating_face_style()
+{
+  if (!m_originating_face)
+    return;
+
+  switch (m_edge_style)
+  {
+  case Edge_style::Full:
+    m_originating_face->SetWidth(1.0);
+    m_originating_face->SetColor(Quantity_Color(0.3, 0.0, 0.0, Quantity_TOC_RGB));
+    m_originating_face->SetTransparency(0.0);
+    break;
+
+  case Edge_style::Background:
+    m_originating_face->SetWidth(1.0);
+    m_originating_face->SetColor(Quantity_Color(0.3, 0.3, 0.3, Quantity_TOC_RGB));
+    m_originating_face->SetTransparency(0.7);
+    break;
+
+  default:
+    EZY_ASSERT(false);
+  }
+
+  m_ctx.Redisplay(m_originating_face, true);
+}
+
+void Sketch::set_visible(bool state)
+{
+  m_visible = state;
+
+  if (state)
+  {
+    if (m_show_faces)
+      for (AIS_Shape_ptr& face : m_topo.faces())
+        m_ctx.Display(face, AIS_Shaded, 0, false);
+
+    for (Edge& e : m_edges.edges())
+      m_ctx.Display(e.shp, AIS_WireFrame, 0, false);
+
+    m_dims.on_sketch_shown();
+
+    if (m_originating_face)
+      m_ctx.Display(m_originating_face, AIS_WireFrame, 0, false);
+
+    if (m_underlay.has_image())
+      m_underlay.rebuild_and_display(m_pln);
+
+    sync_operation_axis_display_();
+    m_node_marks.sync();
+  }
+  else
+  {
+    for (AIS_Shape_ptr& face : m_topo.faces())
+      m_ctx.Erase(face, false);
+
+    for (Edge& e : m_edges.edges())
+      m_ctx.Erase(e.shp, false);
+
+    m_dims.on_sketch_hidden();
+
+    if (m_originating_face)
+      m_ctx.Erase(m_originating_face, false);
+
+    m_underlay.ctx_erase();
+
+    if (m_operation_axis.has_value())
+      m_ctx.Erase(m_operation_axis->shp, false);
+
+    m_nodes.hide_snap_annos();
+    cancel_elm();
+
+    m_node_marks.erase_all();
+  }
+
+  m_ctx.UpdateCurrentViewer();
+
+  m_view.curr_sketch().set_current();
+}
+
+bool Sketch::is_visible() const { return m_visible; }
+
+void Sketch::set_show_faces(bool show)
+{
+  if (show && m_visible)
+    for (AIS_Shape_ptr& face : m_topo.faces())
+      m_ctx.Display(face, AIS_Shaded, 0, false);
+  else
+    for (AIS_Shape_ptr& face : m_topo.faces())
+      m_ctx.Erase(face, false);
+
+  m_show_faces = show;
+}
+
+void Sketch::set_show_edges(bool show)
+{
+  if (show && m_visible)
+    for (Edge& e : m_edges.edges())
+      m_ctx.Display(e.shp, AIS_WireFrame, 0, false);
+  else
+    for (Edge& e : m_edges.edges())
+      m_ctx.Erase(e.shp, false);
+}
+
+void Sketch::append_list_hover_ais(std::vector<AIS_InteractiveObject_ptr>& out) const
+{
+  if (!m_visible)
+    return;
+
+  for (const Edge& e : m_edges.edges())
+    if (!e.shp.IsNull())
+      out.push_back(e.shp);
+
+  if (m_show_faces)
+    for (const Sketch_face_shp_ptr& face : m_topo.faces())
+      if (!face.IsNull())
+        out.push_back(face);
+
+  if (m_originating_face)
+    out.push_back(m_originating_face);
+
+  if (m_operation_axis.has_value() && !m_operation_axis->shp.IsNull())
+    out.push_back(m_operation_axis->shp);
+
+  if (m_underlay.has_image() && m_underlay.visible())
+    m_underlay.append_list_hover_ais(out);
+}
+
+bool Sketch::is_current() const { return this == &m_view.curr_sketch(); }
+
+void Sketch::set_current()
+{
+  m_ctx.CurrentViewer()->SetPrivilegedPlane(m_pln.Position());
+  set_edge_style(Edge_style::Full);
+  m_nodes.clear_outside_snap_pnts();
+
+  m_tmp_pts_3d.clear();
+  get_originating_face_snp_pts_3d_(m_tmp_pts_3d);
+
+  for (const gp_Pnt& pt3d : m_tmp_pts_3d)
+    m_nodes.add_outside_snap_pnt(pt3d);
+
+  for (Sketch_ptr& sketch : m_view.get_sketches())
+    if (sketch.get() != this)
+    {
+      sketch->set_edge_style(Edge_style::Background);
+
+      if (sketch->m_operation_axis.has_value())
+        m_ctx.Erase(sketch->m_operation_axis->shp, false);
+
+      if (sketch->is_visible())
+      {
+        sketch->get_snap_pts_3d_(m_tmp_pts_3d);
+        for (const gp_Pnt& pt3d : m_tmp_pts_3d)
+          m_nodes.add_outside_snap_pnt(pt3d);
+      }
+    }
+
+  sync_operation_axis_display_();
+}
+
+void Sketch::set_edge_style(Edge_style style)
+{
+  m_edge_style = style;
+
+  for (Edge& e : m_edges.edges())
+    update_edge_style_(e.shp);
+
+  update_originating_face_style();
+}

--- a/src/sketch_display.cpp
+++ b/src/sketch_display.cpp
@@ -155,7 +155,7 @@ void Sketch::append_list_hover_ais(std::vector<AIS_InteractiveObject_ptr>& out) 
     m_underlay.append_list_hover_ais(out);
 }
 
-bool Sketch::is_current() const { return this == &m_view.curr_sketch(); }
+bool Sketch::is_current() const { return m_view.current_sketch_if_any() == this; }
 
 void Sketch::set_current()
 {

--- a/src/sketch_edge.cpp
+++ b/src/sketch_edge.cpp
@@ -1,0 +1,17 @@
+#include "sketch_edge.h"
+
+#include "utl.h"
+
+bool Sketch_edge::reversed(size_t idx_a, size_t idx_b) const
+{
+  if (node_idx_a == idx_a && node_idx_b == idx_b)
+    return false;
+
+  if (node_idx_a == idx_b && node_idx_b == idx_a)
+    return true;
+
+  EZY_ASSERT(false);
+  return false;
+}
+
+bool sketch_edge_is_linear(const Sketch_edge& e) { return !e.circle_arc && e.node_idx_b.has_value(); }

--- a/src/sketch_edge.h
+++ b/src/sketch_edge.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "utl_types.h"
+
+/// One sketch edge segment (linear or part of a circle arc).
+struct Sketch_edge
+{
+  size_t                node_idx_a;
+  std::optional<size_t> node_idx_b;
+  std::optional<size_t> node_idx_arc; // Only valid for circle arc edges.
+  std::optional<size_t> node_idx_mid; // Midpoint of edge, used for snapping.
+
+  // Used to identify the two `Sketch_edge`s defining a circle arc.
+  Geom_TrimmedCurve_ptr circle_arc;
+  Sketch_AIS_edge_ptr   shp; // Current edge annotation.
+
+  std::string name;
+
+  bool reversed(size_t idx_a, size_t idx_b) const;
+};
+
+[[nodiscard]] bool sketch_edge_is_linear(const Sketch_edge& e);
+
+/// Read-only linear edge (node indices only).
+struct Sketch_edge_linear
+{
+  size_t                node_a;
+  size_t                node_b;
+  std::optional<size_t> node_mid;
+};
+
+/// Read-only circle-arc edge (start, arc point, end); both arc halves share `shp`.
+struct Sketch_edge_arc
+{
+  size_t              node_start;
+  size_t              node_arc;
+  size_t              node_end;
+  Sketch_AIS_edge_ptr shp;
+};

--- a/src/sketch_edges.cpp
+++ b/src/sketch_edges.cpp
@@ -1,0 +1,243 @@
+#include "sketch_edges.h"
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <GC_MakeArcOfCircle.hxx>
+#include <Precision.hxx>
+#include <algorithm>
+#include <vector>
+
+#include "occt_view.h"
+#include "sketch.h"
+#include "sketch_delta.h"
+#include "sketch_topo.h"
+#include "utl_geom.h"
+#include "utl.h"
+
+Sketch_edges::Sketch_edges(Sketch& sketch)
+    : m_sketch(sketch)
+{
+}
+
+void Sketch_edges::remove_displayed()
+{
+  for (Sketch_edge& e : m_edges)
+    m_sketch.m_ctx.Remove(e.shp, false);
+
+  m_edges.clear();
+}
+
+void Sketch_edges::remove_by_ais(const Sketch_AIS_edge& to_remove)
+{
+  // Some shapes are composed with multiple edges, so we cannot break when an edge is found.
+  for (std::list<Sketch_edge>::iterator itr = m_edges.begin(); itr != m_edges.end();)
+    if (itr->shp.get() == &to_remove)
+      itr = m_edges.erase(itr);
+    else
+      ++itr;
+}
+
+void Sketch_edges::add_edge_raw_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  Sketch_edge edge{m_sketch.m_nodes.get_node_exact(pt_a)};
+  update_end_pt(edge, m_sketch.m_nodes.get_node_exact(pt_b));
+  m_edges.emplace_back(edge);
+  m_sketch.m_nodes.finalize();
+}
+
+void Sketch_edges::add_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b) { add_edge_impl_(pt_a, pt_b, nullptr); }
+
+void Sketch_edges::add_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder& rec)
+{
+  rec.note_curr_linear_edge(pt_a, pt_b);
+  add_edge_impl_(pt_a, pt_b, &rec);
+}
+
+void Sketch_edges::add_edge_impl_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder* rec)
+{
+  if (!unique(pt_a, pt_b))
+    return;
+
+  // Find intersections (crossings or T-touches) between this new segment and all *currently existing* linear edges.
+  // We will split the existing ones at interior intersections, and subdivide this new one as needed.
+  std::vector<gp_Pnt2d> inters;
+  for (const Sketch_edge& e : m_edges)
+  {
+    if (!is_linear(e))
+      continue;
+
+    gp_Pnt2d qa = m_sketch.m_nodes[e.node_idx_a];
+    gp_Pnt2d qb = m_sketch.m_nodes[e.node_idx_b];
+
+    if (auto inter = segment_intersection_2d(pt_a, pt_b, qa, qb, Segment_inclusion::Closed))
+      add_unique_point(inters, *inter);
+  }
+
+  // Collect only the *interior* hits on existing edges for splitting.
+  std::vector<gp_Pnt2d> inters_to_split;
+  for (const auto& ip : inters)
+  {
+    bool is_old_interior = false;
+    for (const Sketch_edge& e : m_edges)
+    {
+      if (!is_linear(e))
+        continue;
+
+      gp_Pnt2d qa = m_sketch.m_nodes[e.node_idx_a];
+      gp_Pnt2d qb = m_sketch.m_nodes[e.node_idx_b];
+      if (point_on_open_segment_2d(ip, qa, qb))
+      {
+        is_old_interior = true;
+        break;
+      }
+    }
+    if (is_old_interior)
+      add_unique_point(inters_to_split, ip);
+  }
+
+  std::vector<gp_Pnt2d> div_pts{pt_a, pt_b};
+  div_pts.insert(div_pts.end(), inters.begin(), inters.end());
+
+  gp_Vec2d dir(pt_a, pt_b);
+  double   len2 = dir.SquareMagnitude();
+  if (len2 < Precision::Confusion() * Precision::Confusion())
+    return;
+
+  std::sort(div_pts.begin(), div_pts.end(),
+            [&](const gp_Pnt2d& u, const gp_Pnt2d& v) { return gp_Vec2d(pt_a, u).Dot(dir) < gp_Vec2d(pt_a, v).Dot(dir); });
+
+  std::vector<gp_Pnt2d> pts;
+  for (const auto& p : div_pts)
+  {
+    if (pts.empty() || pts.back().Distance(p) > Precision::Confusion())
+      pts.push_back(p);
+  }
+
+  if (pts.size() < 2)
+    return;
+
+  std::vector<size_t> div_node_idxs;
+  for (const auto& p : pts)
+    div_node_idxs.push_back(m_sketch.m_nodes.get_node_exact(p));
+
+  for (const auto& inter_p : inters_to_split)
+  {
+    const size_t nidx = m_sketch.m_nodes.get_node_exact(inter_p);
+    if (rec)
+      rec->note_curr_node(nidx);
+
+    m_sketch.m_topo.split_linear_edges_at_node_if_interior(nidx, rec);
+  }
+
+  for (size_t i = 0; i + 1 < div_node_idxs.size(); ++i)
+  {
+    const gp_Pnt2d& pa = m_sketch.m_nodes[div_node_idxs[i]];
+    const gp_Pnt2d& pb = m_sketch.m_nodes[div_node_idxs[i + 1]];
+    add_edge_raw_(pa, pb);
+  }
+}
+
+void Sketch_edges::sketch_json_add_linear_edge(size_t idx_a, size_t idx_b, std::optional<size_t> idx_mid)
+{
+  EZY_ASSERT(idx_a < m_sketch.m_nodes.size() && idx_b < m_sketch.m_nodes.size());
+  if (idx_mid.has_value())
+    EZY_ASSERT(*idx_mid < m_sketch.m_nodes.size());
+
+  Sketch_edge edge{idx_a};
+  edge.node_idx_b      = idx_b;
+  edge.node_idx_mid    = idx_mid;
+  const gp_Pnt2d& pt_a = m_sketch.m_nodes[idx_a];
+  const gp_Pnt2d& pt_b = m_sketch.m_nodes[idx_b];
+  m_sketch.update_edge_shp_(edge, pt_a, pt_b);
+  m_edges.emplace_back(edge);
+  m_sketch.m_nodes.finalize();
+}
+
+void Sketch_edges::update_end_pt(Sketch_edge& edge, size_t end_pt_idx)
+{
+  EZY_ASSERT(end_pt_idx < m_sketch.m_nodes.size());
+  edge.node_idx_b      = end_pt_idx;
+  const gp_Pnt2d& pt_a = m_sketch.m_nodes[edge.node_idx_a];
+  const gp_Pnt2d& pt_b = m_sketch.m_nodes[end_pt_idx];
+  m_sketch.update_edge_shp_(edge, pt_a, pt_b);
+  if (Sketch::get_add_mid_pt_edges())
+    edge.node_idx_mid = m_sketch.m_nodes.add_new_node(get_midpoint(pt_a, pt_b), true);
+  else
+    edge.node_idx_mid = std::nullopt;
+}
+
+void Sketch_edges::add_arc_circle_edges(const std::vector<size_t>& node_idxs)
+{
+  EZY_ASSERT(node_idxs.size() == 3);
+  Geom_TrimmedCurve_ptr arc_of_circle =
+      GC_MakeArcOfCircle(m_sketch.to_3d_(node_idxs[0]), m_sketch.to_3d_(node_idxs[2]), m_sketch.to_3d_(node_idxs[1]));
+
+  Sketch_AIS_edge_ptr shp = new Sketch_AIS_edge(m_sketch, BRepBuilderAPI_MakeEdge(arc_of_circle));
+  m_sketch.update_edge_style_(shp);
+  m_sketch.m_ctx.Display(shp, false);
+
+  // Split into two edges for valid planer graph topology.
+  m_edges.push_back({node_idxs[0], node_idxs[2], node_idxs[2], std::nullopt, arc_of_circle, shp});
+  m_edges.push_back({node_idxs[2], node_idxs[1], std::nullopt, std::nullopt, arc_of_circle, shp});
+}
+
+void Sketch_edges::for_each_linear(const Linear_visitor& fn) const
+{
+  for (const Sketch_edge& e : m_edges)
+  {
+    if (!is_linear(e))
+      continue;
+
+    EZY_ASSERT(e.node_idx_b.has_value());
+    fn(Sketch_edge_linear{e.node_idx_a, *e.node_idx_b, e.node_idx_mid});
+  }
+}
+
+void Sketch_edges::for_each_arc(const Arc_visitor& fn) const
+{
+  const Sketch_edge* last_arc_half = nullptr;
+
+  for (const Sketch_edge& e : m_edges)
+  {
+    if (!e.circle_arc)
+      continue;
+
+    EZY_ASSERT(e.node_idx_b.has_value());
+
+    if (last_arc_half)
+    {
+      EZY_ASSERT(last_arc_half->circle_arc.get() == e.circle_arc.get());
+      EZY_ASSERT(last_arc_half->node_idx_arc.has_value());
+      fn(Sketch_edge_arc{last_arc_half->node_idx_a, *last_arc_half->node_idx_arc, *e.node_idx_b, last_arc_half->shp});
+      last_arc_half = nullptr;
+    }
+    else
+    {
+      EZY_ASSERT(e.node_idx_arc.has_value());
+      EZY_ASSERT(*e.node_idx_b == *e.node_idx_arc);
+      last_arc_half = &e;
+    }
+  }
+}
+
+std::vector<Sketch_edge> Sketch_edges::get_selected() const
+{
+  std::vector<Sketch_edge> ret;
+  for (const AIS_Shape_ptr& selected : m_sketch.m_view.get_selected())
+    for (const Sketch_edge& e : m_edges)
+      if (e.shp == selected)
+        ret.push_back(e);
+
+  return ret;
+}
+
+std::list<Sketch_edge>::iterator Sketch_edges::get_at(const ScreenCoords& screen_coords)
+{
+  AIS_Shape_ptr shp = m_sketch.m_view.get_shape(screen_coords);
+  if (auto edge = dynamic_cast<Sketch_AIS_edge*>(shp.get()); edge)
+    if (&edge->owner_sketch == &m_sketch)
+      for (std::list<Sketch_edge>::iterator itr = m_edges.begin(); itr != m_edges.end(); ++itr)
+        if (itr->shp.get() == edge)
+          return itr;
+
+  return m_edges.end();
+}

--- a/src/sketch_edges.h
+++ b/src/sketch_edges.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <functional>
+#include <gp_Pnt2d.hxx>
+#include <list>
+#include <optional>
+#include <vector>
+
+#include "sketch_edge.h"
+#include "utl_types.h"
+
+class Sketch;
+class Sketch_op_recorder;
+
+/// Persistent sketch edge list and edge CRUD (add, pick, remove, JSON load).
+class Sketch_edges
+{
+public:
+  explicit Sketch_edges(Sketch& sketch);
+
+  void add_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
+  void add_edge(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder& rec);
+  void sketch_json_add_linear_edge(size_t idx_a, size_t idx_b, std::optional<size_t> idx_mid);
+
+  void update_end_pt(Sketch_edge& edge, size_t end_pt_idx);
+  void add_arc_circle_edges(const std::vector<size_t>& node_idxs);
+
+  void remove_by_ais(const Sketch_AIS_edge& to_remove);
+  void remove_displayed();
+
+  [[nodiscard]] std::list<Sketch_edge>::iterator get_at(const ScreenCoords& screen_coords);
+  [[nodiscard]] std::vector<Sketch_edge>         get_selected() const;
+
+  [[nodiscard]] bool   empty() const { return m_edges.empty(); }
+  [[nodiscard]] size_t size() const { return m_edges.size(); }
+
+  [[nodiscard]] const std::list<Sketch_edge>& edges() const { return m_edges; }
+  [[nodiscard]] std::list<Sketch_edge>&       edges() { return m_edges; }
+
+  static bool is_linear(const Sketch_edge& e) { return sketch_edge_is_linear(e); }
+
+  using Linear_visitor = std::function<void(const Sketch_edge_linear&)>;
+  using Arc_visitor    = std::function<void(const Sketch_edge_arc&)>;
+
+  void for_each_linear(const Linear_visitor& fn) const;
+  void for_each_arc(const Arc_visitor& fn) const;
+
+private:
+  friend class Sketch;
+  friend class Sketch_topo;
+  friend class Sketch_delta;
+
+  void add_edge_raw_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
+  void add_edge_impl_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b, Sketch_op_recorder* rec);
+
+  Sketch&                m_sketch;
+  std::list<Sketch_edge> m_edges;
+};

--- a/src/sketch_json.cpp
+++ b/src/sketch_json.cpp
@@ -213,7 +213,7 @@ nlohmann::json Sketch_json::to_json(const Sketch& sketch, const Ezy_asset_store&
   }
 
   json& len_dims_json = j["length_dimensions"] = json::array();
-  for (const Sketch::Length_dimension& ld : sketch.m_length_dimensions)
+  for (const Sketch_dims::Length_dimension& ld : sketch.m_dims.dimensions())
   {
     json e = json::array({remap(ld.node_idx_lo), remap(ld.node_idx_hi), ld.visible});
     if (ld.flyout_offset.has_value())

--- a/src/sketch_json.cpp
+++ b/src/sketch_json.cpp
@@ -142,6 +142,7 @@ nlohmann::json Sketch_json::to_json(const Sketch& sketch, const Ezy_asset_store&
 {
   json j;
   j["isCurrent"] = sketch.is_current();
+  j["id"]        = sketch.get_id();
   j["name"]      = sketch.get_name();
   j["plane"]     = ::to_json(sketch.m_pln);
 
@@ -296,6 +297,12 @@ Sketch::sptr Sketch_json::from_json(Occt_view& view, const nlohmann::json& j)
     const gp_Pnt2d pt_a = ::from_json_pnt2d(j["operation_axis"][0]);
     const gp_Pnt2d pt_b = ::from_json_pnt2d(j["operation_axis"][1]);
     ret->sketch_json_set_operation_axis_(pt_a, pt_b);
+  }
+
+  if (j.contains("id") && j["id"].is_number_unsigned())
+  {
+    ret->m_id = j["id"].get<size_t>();
+    view.adopt_sketch_id(ret->m_id);
   }
 
   if (j["isCurrent"])

--- a/src/sketch_json.cpp
+++ b/src/sketch_json.cpp
@@ -156,8 +156,6 @@ nlohmann::json Sketch_json::to_json(const Sketch& sketch, const Ezy_asset_store&
   json& edges_json = j["edges"] = json::array();
   json& arc_edges_json = j["arc_edges"] = json::array();
 
-  const Sketch::Edge* last_arc_circle_edge = nullptr;
-
   const auto& sketch_nodes = sketch.m_nodes;
 
   std::vector<std::optional<size_t>> dense_of_sparse(sketch_nodes.size());
@@ -182,35 +180,18 @@ nlohmann::json Sketch_json::to_json(const Sketch& sketch, const Ezy_asset_store&
     return *dense_of_sparse[sparse_idx];
   };
 
-  for (const auto& edge : sketch.m_edges)
-  {
-    EZY_ASSERT(edge.node_idx_b.has_value());
+  sketch.m_edges.for_each_linear(
+      [&](const Sketch_edge_linear& e)
+      {
+        if (e.node_mid.has_value())
+          edges_json.push_back(json::array({remap(e.node_a), remap(e.node_b), remap(*e.node_mid)}));
+        else
+          edges_json.push_back(json::array({remap(e.node_a), remap(e.node_b)}));
+      });
 
-    if (!edge.circle_arc)
-    {
-      if (edge.node_idx_mid.has_value())
-        edges_json.push_back(json::array({remap(edge.node_idx_a), remap(*edge.node_idx_b), remap(*edge.node_idx_mid)}));
-      else
-        edges_json.push_back(json::array({remap(edge.node_idx_a), remap(*edge.node_idx_b)}));
-    }
-    else
-    {
-      if (last_arc_circle_edge)
-      {
-        EZY_ASSERT(last_arc_circle_edge->circle_arc.get() == edge.circle_arc.get());
-        EZY_ASSERT(last_arc_circle_edge->node_idx_arc.has_value());
-        arc_edges_json.push_back(json::array(
-            {remap(last_arc_circle_edge->node_idx_a), remap(*last_arc_circle_edge->node_idx_arc), remap(*edge.node_idx_b)}));
-        last_arc_circle_edge = nullptr;
-      }
-      else
-      {
-        EZY_ASSERT(edge.node_idx_arc.has_value());
-        EZY_ASSERT(*edge.node_idx_b == *edge.node_idx_arc);
-        last_arc_circle_edge = &edge;
-      }
-    }
-  }
+  sketch.m_edges.for_each_arc(
+      [&](const Sketch_edge_arc& a)
+      { arc_edges_json.push_back(json::array({remap(a.node_start), remap(a.node_arc), remap(a.node_end)})); });
 
   json& len_dims_json = j["length_dimensions"] = json::array();
   for (const Sketch_dims::Length_dimension& ld : sketch.m_dims.dimensions())

--- a/src/sketch_node_marks.cpp
+++ b/src/sketch_node_marks.cpp
@@ -1,0 +1,113 @@
+#include "sketch_node_marks.h"
+
+#include <Precision.hxx>
+#include <Quantity_Color.hxx>
+
+#include "gui.h"
+#include "mode.h"
+#include "occt_view.h"
+#include "sketch.h"
+#include "sketch_nodes.h"
+#include "sketch_topo.h"
+#include "utl_geom.h"
+
+Sketch_node_marks::Sketch_node_marks(Sketch& sketch)
+    : m_sketch(sketch)
+{
+}
+
+void Sketch_node_marks::apply_style_(AIS_Shape_ptr& shp) const
+{
+  // Keep permanent node markers visually stable across sketch switching.
+  shp->SetWidth(1.25);
+  shp->SetColor(Quantity_NOC_RED);
+  shp->SetTransparency(0.0);
+}
+
+void Sketch_node_marks::sync()
+{
+  if (m_marks.size() < m_sketch.m_nodes.size())
+    m_marks.resize(m_sketch.m_nodes.size());
+
+  const double size_scale = std::max(static_cast<double>(m_sketch.m_view.gui().permanent_node_anno_scale()), 0.0);
+  const double half_arm =
+      std::max(m_sketch.m_topo.plane_pick_snap_radius_world() * 0.45 * size_scale, Precision::Confusion() * 50.0);
+
+  const Mode mode = m_sketch.get_mode();
+  // Show "+" markers for permanent user nodes in sketch modes and polar duplicate (which snaps to sketch nodes).
+  // Hide during face extrude so face selection is unobstructed.
+  const bool show_permanent_marks =
+      mode != Mode::Sketch_face_extrude && (is_sketch_mode(mode) || mode == Mode::Shape_polar_duplicate);
+  const bool hide_for_operation_axis = m_sketch.operation_axis_suppresses_sketch_snap_();
+
+  for (size_t i = 0, n = m_sketch.m_nodes.size(); i < n; ++i)
+  {
+    const Sketch_nodes::Node& node = m_sketch.m_nodes[i];
+    const bool show = m_sketch.m_visible && node.permanent && !node.deleted && show_permanent_marks && !hide_for_operation_axis;
+
+    if (!show)
+    {
+      if (m_marks[i])
+      {
+        m_sketch.m_ctx.Remove(m_marks[i], false);
+        m_marks[i].Nullify();
+      }
+      continue;
+    }
+
+    const gp_Pnt2d     p2(node.X(), node.Y());
+    const gp_Pnt       c3    = to_3d(m_sketch.m_pln, p2);
+    const TopoDS_Shape cross = create_plus_cross_shape(m_sketch.m_pln, c3, half_arm);
+
+    if (m_marks[i])
+    {
+      m_marks[i]->Set(cross);
+      apply_style_(m_marks[i]);
+      m_sketch.m_ctx.Redisplay(m_marks[i], true);
+    }
+    else
+    {
+      Sketch_AIS_node_mark_ptr mk = new Sketch_AIS_node_mark(m_sketch, i, cross);
+      apply_style_(mk);
+      m_marks[i] = mk;
+      m_sketch.m_ctx.Display(mk, AIS_WireFrame, 0, false);
+    }
+  }
+}
+
+void Sketch_node_marks::remove_at(size_t node_idx)
+{
+  if (node_idx >= m_marks.size() || m_marks[node_idx].IsNull())
+    return;
+
+  m_sketch.m_ctx.Remove(m_marks[node_idx], false);
+  m_marks[node_idx].Nullify();
+}
+
+void Sketch_node_marks::remove_all()
+{
+  for (Sketch_AIS_node_mark_ptr& mk : m_marks)
+    if (mk)
+      m_sketch.m_ctx.Remove(mk, false);
+
+  m_marks.clear();
+}
+
+void Sketch_node_marks::erase_all()
+{
+  for (Sketch_AIS_node_mark_ptr& mk : m_marks)
+    if (mk)
+      m_sketch.m_ctx.Erase(mk, false);
+}
+
+void Sketch_node_marks::trim_trailing()
+{
+  while (m_marks.size() > m_sketch.m_nodes.size())
+  {
+    const size_t last = m_marks.size() - 1;
+    if (m_marks[last])
+      m_sketch.m_ctx.Remove(m_marks[last], false);
+
+    m_marks.pop_back();
+  }
+}

--- a/src/sketch_node_marks.h
+++ b/src/sketch_node_marks.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <vector>
+
+#include "sketch_ais.h"
+#include "utl_types.h"
+
+class Sketch;
+
+/// Permanent sketch-node '+' markers (display, sync, and removal).
+class Sketch_node_marks
+{
+public:
+  explicit Sketch_node_marks(Sketch& sketch);
+
+  void sync();
+  void remove_at(size_t node_idx);
+  void remove_all();
+  void erase_all();
+  void trim_trailing();
+
+private:
+  friend class Sketch_delta;
+
+  void apply_style_(AIS_Shape_ptr& shp) const;
+
+  Sketch&                               m_sketch;
+  std::vector<Sketch_AIS_node_mark_ptr> m_marks;
+};

--- a/src/sketch_operations.cpp
+++ b/src/sketch_operations.cpp
@@ -1,0 +1,180 @@
+// Sketch mirror/revolve and operation-axis helpers (state remains on Sketch).
+#include "sketch.h"
+
+#include <BRepPrimAPI_MakeRevol.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <TopoDS.hxx>
+#include <map>
+#include <set>
+
+#include "gui.h"
+#include "mode.h"
+#include "sketch_delta.h"
+#include "utl_geom.h"
+#include "utl_occt.h"
+#include "utl.h"
+
+void Sketch::sketch_json_set_operation_axis_(const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  if (!unique(pt_a, pt_b))
+    return;
+
+  clear_operation_axis();
+
+  Edge axis{m_nodes.get_node_exact(pt_a)};
+  axis.node_idx_b = m_nodes.get_node_exact(pt_b);
+  update_edge_shp_(axis, pt_a, pt_b);
+  m_operation_axis = std::move(axis);
+
+  sync_operation_axis_display_();
+}
+
+void Sketch::clear_operation_axis()
+{
+  if (m_operation_axis.has_value())
+    m_ctx.Remove(m_operation_axis->shp, false);
+
+  m_operation_axis = std::nullopt;
+  m_node_marks.sync();
+  m_nodes.hide_snap_annos();
+}
+
+bool Sketch::has_operation_axis() const { return m_operation_axis.has_value(); }
+
+void Sketch::mirror_selected_edges()
+{
+  EZY_ASSERT(m_operation_axis.has_value());
+  Sketch_op_recorder rec(m_view, *this);
+
+  const std::vector<Edge> mirror_edges = get_selected_edges_();
+  if (mirror_edges.empty())
+  {
+    rec.cancel();
+    m_view.gui().show_message(ERROR_NO_EDGES_SELECTED);
+    return;
+  }
+
+  EZY_ASSERT(!m_operation_axis->shp.IsNull());
+  const auto [mirror_pt_a, mirror_pt_b] = get_edge_endpoints(m_pln, TopoDS::Edge(m_operation_axis->shp->Shape()));
+
+  std::vector<std::pair<gp_Pnt2d, gp_Pnt2d>>     mirrored_edges;
+  std::map<AIS_Shape_ptr, std::set<const Edge*>> arc_circles;
+
+  for (const Edge& e : m_edges.edges())
+    for (const Edge& selected : mirror_edges)
+      if (e.shp == selected.shp || e.circle_arc == selected.circle_arc)
+      {
+        if (e.circle_arc)
+        {
+          std::set<const Edge*>& arc_circle_edges = arc_circles[e.shp];
+          arc_circle_edges.insert(&e);
+          if (arc_circle_edges.size() == 2)
+            break;
+        }
+        else
+        {
+          const gp_Pnt2d a = mirror_point(mirror_pt_a, mirror_pt_b, m_nodes[e.node_idx_a]);
+          const gp_Pnt2d b = mirror_point(mirror_pt_a, mirror_pt_b, m_nodes[e.node_idx_b]);
+          mirrored_edges.push_back({a, b});
+          break;
+        }
+      }
+
+  for (const auto& [a, b] : mirrored_edges)
+    add_edge_(a, b, rec);
+
+  for (auto& [_, arc_circle_edges] : arc_circles)
+  {
+    EZY_ASSERT(arc_circle_edges.size() == 2);
+    const Edge* a = nullptr;
+    const Edge* b = nullptr;
+    for (const Edge* e : arc_circle_edges)
+      if (e->node_idx_arc.has_value())
+        a = e;
+      else
+        b = e;
+
+    EZY_ASSERT(a && b);
+    EZY_ASSERT(a->node_idx_arc.has_value());
+    EZY_ASSERT(b->node_idx_b);
+    const gp_Pnt2d pt_a = mirror_point(mirror_pt_a, mirror_pt_b, m_nodes[a->node_idx_a]);
+    const gp_Pnt2d pt_b = mirror_point(mirror_pt_a, mirror_pt_b, m_nodes[a->node_idx_arc]);
+    const gp_Pnt2d pt_c = mirror_point(mirror_pt_a, mirror_pt_b, m_nodes[b->node_idx_b]);
+    add_arc_circle_(pt_a, pt_b, pt_c, rec);
+  }
+
+  m_nodes.hide_snap_annos();
+  update_faces_();
+  rec.commit();
+}
+
+Shp_rslt Sketch::revolve_selected(const double angle)
+{
+  EZY_ASSERT_MSG(m_operation_axis.has_value(), "No defined operation axis.");
+
+  TopoDS_Compound compound;
+  BRep_Builder    builder;
+  builder.MakeCompound(compound);
+
+  const std::vector<Sketch_face_shp_ptr> faces          = get_selected_faces_();
+  const std::vector<Edge>                selected_edges = get_selected_edges_();
+  if (selected_edges.size())
+  {
+    std::set<AIS_Shape*> seen;
+    for (const Edge& e : selected_edges)
+      if (!seen.count(e.shp.get()))
+      {
+        seen.insert(e.shp.get());
+        builder.Add(compound, e.shp->Shape());
+      }
+  }
+  else if (faces.size())
+    for (const Sketch_face_shp_ptr& face : faces)
+      builder.Add(compound, face->Shape());
+
+  else
+    return Shp_rslt(Result_status::User_error, "No selected faces or edges.");
+
+  try
+  {
+    const auto [pt_a, pt_b] = get_edge_endpoints(TopoDS::Edge(m_operation_axis->shp->Shape()));
+
+    const gp_Dir direction((pt_b.XYZ() - pt_a.XYZ()).Normalized());
+    const gp_Ax1 axis(pt_a, direction);
+
+    BRepPrimAPI_MakeRevol revolMaker(compound, axis, angle);
+    return Shp_rslt(new Shp(m_ctx, try_make_solid(revolMaker.Shape())));
+  }
+  catch (const Standard_Failure& e)
+  {
+    std::string error_msg = "Revolution failed: ";
+    const char* msg       = e.what();
+    error_msg += msg ? msg : "Unknown OCCT error";
+    return Shp_rslt(Result_status::Topo_error, error_msg);
+  }
+  catch (const std::exception& e)
+  {
+    return Shp_rslt(Result_status::User_error, "Unexpected error: " + std::string(e.what()));
+  }
+}
+
+bool Sketch::show_operation_axis_() const
+{
+  return m_operation_axis.has_value() && m_visible && is_current() && get_mode() == Mode::Sketch_operation_axis;
+}
+
+bool Sketch::operation_axis_suppresses_sketch_snap_() const
+{
+  return get_mode() == Mode::Sketch_operation_axis && m_operation_axis.has_value();
+}
+
+void Sketch::sync_operation_axis_display_()
+{
+  if (!m_operation_axis.has_value())
+    return;
+
+  if (show_operation_axis_())
+    m_ctx.Display(m_operation_axis->shp, AIS_WireFrame, 0, false);
+  else
+    m_ctx.Erase(m_operation_axis->shp, false);
+}

--- a/src/sketch_tools.cpp
+++ b/src/sketch_tools.cpp
@@ -1,0 +1,953 @@
+#include "sketch_tools.h"
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <GC_MakeArcOfCircle.hxx>
+#include <Precision.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Wire.hxx>
+#include <array>
+#include <cmath>
+#include <functional>
+
+#include "gui.h"
+#include "mode.h"
+#include "occt_view.h"
+#include "sketch.h"
+#include "sketch_delta.h"
+#include "utl_geom.h"
+#include "utl_occt.h"
+#include "utl.h"
+
+using namespace glm;
+
+namespace
+{
+struct Symmetric_edge_span
+{
+  gp_Pnt2d pt_a;
+  gp_Pnt2d pt_b;
+  double   full_len;
+};
+
+std::optional<Symmetric_edge_span> symmetric_edge_from_center(const gp_Pnt2d& center, const gp_Dir2d& dir, double full_len)
+{
+  if (full_len <= Precision::Confusion())
+    return std::nullopt;
+
+  const double   half = full_len * 0.5;
+  const gp_Vec2d v(dir);
+  return Symmetric_edge_span{center.Translated(-v * half), center.Translated(v * half), full_len};
+}
+
+std::optional<Symmetric_edge_span> symmetric_edge_from_center_and_hint(const gp_Pnt2d& center, const gp_Pnt2d& dir_hint_pt)
+{
+  gp_Vec2d     v(center, dir_hint_pt);
+  const double half = v.Magnitude();
+  if (half <= Precision::Confusion())
+    return std::nullopt;
+
+  return symmetric_edge_from_center(center, gp_Dir2d(v), half * 2.0);
+}
+} // namespace
+
+Sketch_tools::Sketch_tools(Sketch& sketch)
+    : m_sketch(sketch)
+{
+}
+
+void Sketch_tools::on_click(const ScreenCoords& screen_coords)
+{
+  switch (m_sketch.get_mode())
+  {
+    // clang-format off
+    case Mode::Sketch_add_square:
+    case Mode::Sketch_add_circle:
+    case Mode::Sketch_add_rectangle:
+    case Mode::Sketch_add_rectangle_center_pt:
+      add_line_string_pt_(screen_coords, Linestring_type::Single);
+      break;
+
+    case Mode::Sketch_add_node:           add_node_pt_          (screen_coords);                            break;
+    case Mode::Sketch_add_edge:           add_line_string_pt_   (screen_coords, Linestring_type::Single);   break;
+    case Mode::Sketch_add_slot:           add_line_string_pt_   (screen_coords, Linestring_type::Two);      break;
+    case Mode::Sketch_add_multi_edges:    add_line_string_pt_   (screen_coords, Linestring_type::Multiple); break;
+    case Mode::Sketch_add_seg_circle_arc: add_arc_circle_pt_    (screen_coords);                            break;
+    case Mode::Sketch_operation_axis:     add_operation_axis_pt_(screen_coords);                            break;
+    default:
+      EZY_ASSERT(false);
+    // clang-format on
+  }
+}
+
+void Sketch_tools::on_move(const ScreenCoords& screen_coords)
+{
+  switch (m_sketch.get_mode())
+  {
+    // clang-format off
+    case Mode::Sketch_add_node:            move_add_node_pt_    (screen_coords); break;
+    case Mode::Sketch_add_seg_circle_arc:  move_arc_circle_pt_  (screen_coords); break;
+    case Mode::Sketch_add_square:          move_square_pt_      (screen_coords); break;
+    case Mode::Sketch_add_circle:          move_circle_pt_      (screen_coords); break;
+    case Mode::Sketch_add_slot:            move_slot_pt_        (screen_coords); break;
+
+    case Mode::Sketch_add_edge:
+    case Mode::Sketch_operation_axis:
+    case Mode::Sketch_add_multi_edges:
+      move_line_string_pt_ (screen_coords);
+      break;
+
+    case Mode::Sketch_add_rectangle:
+    case Mode::Sketch_add_rectangle_center_pt:
+      move_rectangle_pt_(screen_coords);
+      break;
+    // clang-format on
+  default:
+    break;
+  }
+}
+
+void Sketch_tools::on_enter()
+{
+  switch (m_sketch.get_mode())
+  {
+    // clang-format off
+    case Mode::Sketch_add_square:
+    case Mode::Sketch_add_rectangle:
+    case Mode::Sketch_add_rectangle_center_pt:
+    case Mode::Sketch_add_circle:
+    case Mode::Sketch_add_node:
+      m_sketch.m_dims.check_dimension_rubber_();
+      break;
+
+    case Mode::Sketch_add_edge:
+      m_sketch.m_dims.check_dimension_seg_(static_cast<int>(Linestring_type::Single));
+      break;
+
+    case Mode::Sketch_add_slot:
+      m_sketch.m_dims.check_dimension_seg_(static_cast<int>(Linestring_type::Two));
+      break;
+
+    case Mode::Sketch_add_multi_edges:
+      m_sketch.m_dims.check_dimension_seg_(static_cast<int>(Linestring_type::Multiple));
+      break;
+    // clang-format on
+  default:
+    break;
+  }
+}
+
+void Sketch_tools::finalize()
+{
+  Sketch_op_recorder rec(m_sketch.m_view, m_sketch);
+  {
+    m_sketch.m_dims.on_finalize_elm_start();
+
+    switch (m_sketch.get_mode())
+    {
+      // clang-format off
+    case Mode::Sketch_add_edge:
+    case Mode::Sketch_add_multi_edges:
+      finalize_edges_(rec);
+      break;
+
+    case Mode::Sketch_add_rectangle:
+    case Mode::Sketch_add_rectangle_center_pt:
+      finalize_rectangle_(rec);
+      break;
+
+    case Mode::Sketch_add_square:       finalize_square_(rec);            break;
+    case Mode::Sketch_add_circle:       finalize_circle_(rec);            break;
+    case Mode::Sketch_add_node:         finalize_add_node_elm_cleanup_(); break;
+    case Mode::Sketch_add_slot:         finalize_slot_(rec);              break;
+    case Mode::Sketch_operation_axis:   finalize_operation_axis_(rec);    break;
+      // clang-format on
+    default:
+      EZY_ASSERT(false);
+    }
+
+    rec.commit();
+  }
+}
+
+bool Sketch_tools::cancel() { return clear_tmps(); }
+
+bool Sketch_tools::edge_from_center_active() const
+{
+  return Sketch::get_edge_from_center() && m_sketch.get_mode() == Mode::Sketch_add_edge && !m_tmp_edges.empty() &&
+         !m_tmp_edges.back().node_idx_b.has_value();
+}
+
+bool Sketch_tools::complete_edge_from_center_(const ScreenCoords& screen_coords)
+{
+  if (!edge_from_center_active())
+    return false;
+
+  Sketch_edge&    edge   = m_tmp_edges.back();
+  const gp_Pnt2d& center = m_sketch.m_nodes[edge.node_idx_a];
+
+  std::optional<Symmetric_edge_span> span;
+  if (m_sketch.m_dims.entered_edge_len().has_value())
+    span = symmetric_edge_from_center(center, m_sketch.m_dims.entered_edge_len()->dir, m_sketch.m_dims.entered_edge_len()->len);
+
+  else if (m_sketch.m_dims.entered_edge_angle().has_value())
+  {
+    std::optional<gp_Pnt2d> pt_opt = m_sketch.m_view.pt_on_plane(screen_coords, m_sketch.m_pln);
+    if (!pt_opt)
+      return true;
+
+    const double angle_rad = to_radians(*m_sketch.m_dims.entered_edge_angle());
+    gp_Dir2d     dir(std::cos(angle_rad), std::sin(angle_rad));
+    gp_Vec2d     to_click(center, *pt_opt);
+    const double half = std::abs(to_click.Dot(gp_Vec2d(dir)));
+    span              = symmetric_edge_from_center(center, dir, half * 2.0);
+  }
+  else
+  {
+    std::optional<gp_Pnt2d> pt_opt = m_sketch.m_view.pt_on_plane(screen_coords, m_sketch.m_pln);
+    if (!pt_opt)
+      return true;
+
+    span = symmetric_edge_from_center_and_hint(center, *pt_opt);
+  }
+
+  if (!span)
+    return true;
+
+  edge.node_idx_a = m_sketch.m_nodes.get_node_exact(span->pt_a);
+  m_sketch.update_edge_end_pt_(edge, m_sketch.m_nodes.get_node_exact(span->pt_b));
+  m_sketch.m_dims.entered_edge_angle() = std::nullopt;
+  m_sketch.m_dims.entered_edge_len()   = std::nullopt;
+  m_sketch.m_dims.set_show_angle_input(false);
+  m_sketch.m_dims.set_show_dim_input(false);
+  m_sketch.m_view.gui().hide_angle_edit();
+  finalize();
+  return true;
+}
+
+void Sketch_tools::add_line_string_pt_(const ScreenCoords& screen_coords, Sketch_tools::Linestring_type linestring_type)
+{
+  if (edge_from_center_active() && linestring_type == Sketch_tools::Linestring_type::Single)
+  {
+    complete_edge_from_center_(screen_coords);
+    return;
+  }
+
+  auto on_line_string = [&](size_t node_idx)
+  {
+    if (m_tmp_edges.size())
+    {
+      Sketch_edge& last_edge = m_tmp_edges.back();
+      if (node_idx == last_edge.node_idx_a)
+        // We cannot have edges with zero length.
+        return;
+
+      m_sketch.update_edge_end_pt_(last_edge, node_idx);
+
+      if (linestring_type == Sketch_tools::Linestring_type::Single)
+      {
+        finalize();
+        return;
+      }
+      else if (linestring_type == Sketch_tools::Linestring_type::Two)
+        if (m_tmp_edges.size() == 2)
+        {
+          finalize();
+          return;
+        }
+    }
+
+    // Start a new edge - clear constraints for fresh start (click path for multi-line)
+    m_sketch.m_dims.entered_edge_angle() = std::nullopt;
+    m_sketch.m_dims.entered_edge_len()   = std::nullopt;
+    m_sketch.m_dims.set_show_angle_input(false);
+    m_sketch.m_view.gui().hide_angle_edit();
+    m_tmp_edges.push_back({node_idx});
+  };
+
+  // When angle constraint is active, finalize on the constrained line (project click onto it)
+  if (m_sketch.m_dims.entered_edge_angle().has_value() && m_tmp_edges.size())
+  {
+    if (edge_from_center_active())
+    {
+      complete_edge_from_center_(screen_coords);
+      return;
+    }
+
+    std::optional<gp_Pnt2d> pt_opt = m_sketch.m_view.pt_on_plane(screen_coords, m_sketch.m_pln);
+    if (!pt_opt)
+      return;
+
+    const gp_Pnt2d& pt_a      = m_sketch.m_nodes[m_tmp_edges.back().node_idx_a];
+    double          angle_rad = to_radians(*m_sketch.m_dims.entered_edge_angle());
+    gp_Dir2d        constrained_dir(std::cos(angle_rad), std::sin(angle_rad));
+    gp_Vec2d        to_click(pt_opt->X() - pt_a.X(), pt_opt->Y() - pt_a.Y());
+    double          dist_along = to_click.Dot(gp_Vec2d(constrained_dir));
+    gp_Pnt2d        final_pt   = gp_Pnt2d(pt_a).Translated(gp_Vec2d(constrained_dir) * dist_along);
+    if (!unique(pt_a, final_pt))
+      return;
+
+    // Do not run try_get_node_idx_snap here: it can move the point off the angle ray (axis snap).
+    const size_t node_idx = m_sketch.m_nodes.get_node_exact(final_pt);
+    m_tmp_node_idxs.push_back(node_idx);
+    on_line_string(node_idx);
+    return;
+  }
+
+  add_sketch_pt_(screen_coords, 1, on_line_string);
+}
+
+void Sketch_tools::move_line_string_pt_(const ScreenCoords& screen_coords)
+{
+  if (edge_from_center_active())
+  {
+    auto l = [&](const std::optional<size_t>&, const gp_Pnt2d& pt_b)
+    {
+      Sketch_edge&    edge   = m_tmp_edges.back();
+      const gp_Pnt2d& center = m_sketch.m_nodes[edge.node_idx_a];
+
+      std::optional<Symmetric_edge_span> span;
+      if (m_sketch.m_dims.entered_edge_angle().has_value())
+      {
+        const double angle_rad = to_radians(*m_sketch.m_dims.entered_edge_angle());
+        gp_Dir2d     dir(std::cos(angle_rad), std::sin(angle_rad));
+        if (m_sketch.m_dims.entered_edge_len().has_value())
+          span = symmetric_edge_from_center(center, dir, m_sketch.m_dims.entered_edge_len()->len);
+        else
+        {
+          gp_Vec2d     to_mouse(center, pt_b);
+          const double half = std::abs(to_mouse.Dot(gp_Vec2d(dir)));
+          span              = symmetric_edge_from_center(center, dir, half * 2.0);
+        }
+      }
+      else if (m_sketch.m_dims.entered_edge_len().has_value())
+        span = symmetric_edge_from_center(center, m_sketch.m_dims.entered_edge_len()->dir,
+                                          m_sketch.m_dims.entered_edge_len()->len);
+      else
+        span = symmetric_edge_from_center_and_hint(center, pt_b);
+
+      if (!span)
+      {
+        if (edge.shp)
+        {
+          m_sketch.m_ctx.Remove(edge.shp, true);
+          edge.shp.Nullify();
+        }
+        m_sketch.m_dims.clear_tmp_dim_anno();
+        return;
+      }
+
+      const gp_Pnt2d& span_a = span->pt_a;
+      const gp_Pnt2d& span_b = span->pt_b;
+      m_sketch.update_edge_shp_(edge, span_a, span_b);
+
+      const double dist = span->full_len / m_sketch.m_view.get_dimension_scale();
+      m_sketch.m_dims.show_tmp_dim_preview(span_a, span_b);
+      m_sketch.m_dims.offer_dist_edit_for_segment(span_a, span_b, dist);
+      m_sketch.m_dims.offer_angle_edit_for_segment(
+          center, pt_b, to_degrees(std::atan2(gp_Vec2d(center, pt_b).Y(), gp_Vec2d(center, pt_b).X())));
+    };
+
+    move_sketch_pt_(screen_coords, l);
+    return;
+  }
+
+  auto l = [&](const std::optional<size_t>& node_idx_b, const gp_Pnt2d& pt_b)
+  {
+    if (m_tmp_edges.empty())
+      return;
+
+    Sketch_edge&    edge = m_tmp_edges.back();
+    const gp_Pnt2d& pt_a = m_sketch.m_nodes[edge.node_idx_a];
+
+    if (!unique(pt_a, pt_b))
+      // Cannot have a edge with zero length
+      return;
+
+    gp_Pnt2d final_pt_b = pt_b;
+
+    // Apply angle constraint if set - this takes priority
+    if (m_sketch.m_dims.entered_edge_angle().has_value())
+    {
+      // Calculate direction based on angle (0 degrees = positive X axis, counterclockwise)
+      double   angle_rad = to_radians(*m_sketch.m_dims.entered_edge_angle());
+      gp_Dir2d constrained_dir(std::cos(angle_rad), std::sin(angle_rad));
+
+      // If distance is also constrained, use that
+      if (m_sketch.m_dims.entered_edge_len().has_value())
+        // Use the constrained distance - angle constraint is always enforced
+        final_pt_b = gp_Pnt2d(pt_a).Translated(gp_Vec2d(constrained_dir) * m_sketch.m_dims.entered_edge_len()->len);
+      else
+      {
+        // Project the mouse point onto the angle-constrained line
+        // Find the distance along the constrained direction from pt_a to mouse position
+        gp_Vec2d to_mouse(pt_b.X() - pt_a.X(), pt_b.Y() - pt_a.Y());
+        double   dist_along_constrained = to_mouse.Dot(gp_Vec2d(constrained_dir));
+
+        // Calculate the point on the constrained line at this distance
+        // This ensures the angle is ALWAYS maintained
+        final_pt_b = gp_Pnt2d(pt_a).Translated(gp_Vec2d(constrained_dir) * dist_along_constrained);
+      }
+
+      // Disable snapping when angle constraint is active - angle takes priority
+      edge.node_idx_b = std::nullopt;
+    }
+    // Apply distance constraint if set (and angle is not set)
+    else if (m_sketch.m_dims.entered_edge_len().has_value())
+    {
+      final_pt_b      = gp_Pnt2d(pt_a).Translated(gp_Vec2d(m_sketch.m_dims.entered_edge_len()->dir) *
+                                                  m_sketch.m_dims.entered_edge_len()->len);
+      edge.node_idx_b = m_sketch.m_nodes.try_get_node_idx_snap(final_pt_b);
+    }
+    else
+    {
+      // No constraints - check for snap points at mouse position
+      edge.node_idx_b = m_sketch.m_nodes.try_get_node_idx_snap(final_pt_b);
+      if (edge.node_idx_b.has_value())
+        final_pt_b = m_sketch.m_nodes[edge.node_idx_b];
+    }
+
+    double dist = pt_a.Distance(final_pt_b) / m_sketch.m_view.get_dimension_scale();
+    m_sketch.m_dims.show_tmp_dim_preview(pt_a, final_pt_b);
+    m_sketch.m_dims.offer_dist_edit_for_segment(pt_a, final_pt_b, dist);
+
+    gp_Vec2d vec(pt_a, pt_b);
+    m_sketch.m_dims.offer_angle_edit_for_segment(pt_a, pt_b, to_degrees(std::atan2(vec.Y(), vec.X())));
+
+    if (unique(pt_a, final_pt_b))
+      m_sketch.update_edge_shp_(edge, pt_a, final_pt_b);
+
+    else if (edge.shp)
+    {
+      m_sketch.m_ctx.Remove(edge.shp, true);
+      edge.shp.Nullify();
+    }
+  };
+
+  move_sketch_pt_(screen_coords, l);
+}
+
+void Sketch_tools::finalize_edges_(Sketch_op_recorder& rec)
+{
+  if (m_sketch.m_nodes.empty() || m_tmp_edges.empty())
+    return;
+
+  if (!m_tmp_edges.back().node_idx_b.has_value())
+  {
+    // Last edge was not finalized, remove it
+    m_sketch.m_ctx.Remove(m_tmp_edges.back().shp, false);
+    m_tmp_edges.pop_back();
+  }
+
+  if (m_tmp_edges.empty())
+    return;
+
+  // Record user-intent edges before any split/append side effects.
+  for (const Sketch_edge& te : m_tmp_edges)
+  {
+    EZY_ASSERT(te.node_idx_b.has_value());
+    rec.note_curr_linear_edge(m_sketch.m_nodes[te.node_idx_a], m_sketch.m_nodes[*te.node_idx_b]);
+  }
+
+  std::vector<size_t> split_mid_points;
+  for (Sketch_edge& e : m_tmp_edges)
+  {
+    EZY_ASSERT(e.node_idx_b.has_value());
+    if (m_sketch.m_nodes[e.node_idx_a].midpoint)
+      split_mid_points.push_back(e.node_idx_a);
+
+    if (m_sketch.m_nodes[e.node_idx_b].midpoint)
+      split_mid_points.push_back(*e.node_idx_b);
+  }
+
+  // Split any *existing* (pre this batch) linear edges that intersect or touch the
+  // new segments being committed (the tmp ones). This fulfills the requirement that
+  // adding edges from the GUI splits existing intersecting/touching edges.
+  std::vector<gp_Pnt2d> batch_inters;
+  {
+    for (const Sketch_edge& te : m_tmp_edges)
+    {
+      // All remaining tmp edges must be complete at this point:
+      // - The code above already popped any trailing incomplete one.
+      // - The split_mid_points loop immediately before this used EZY_ASSERT on every te.
+      // Therefore we can (and should) assert rather than silently continue.
+      // (A defensive "if (!...) continue" would be appropriate for filtering *old* edges
+      // in m_sketch.m_edges, which may contain arcs or other non-linear things, but not here.)
+      EZY_ASSERT(te.node_idx_b.has_value());
+
+      gp_Pnt2d pa = m_sketch.m_nodes[te.node_idx_a];
+      gp_Pnt2d pb = m_sketch.m_nodes[te.node_idx_b];
+      for (const Sketch_edge& oe : m_sketch.m_edges.edges()) // pre-batch olds only
+      {
+        if (!Sketch::is_linear_edge_(oe))
+          continue;
+
+        gp_Pnt2d qa = m_sketch.m_nodes[oe.node_idx_a];
+        gp_Pnt2d qb = m_sketch.m_nodes[oe.node_idx_b];
+        if (auto inter = segment_intersection_2d(pa, pb, qa, qb, Segment_inclusion::Closed))
+        {
+          // The intersection point is now guaranteed (by the inclusion parameter)
+          // to lie on both finite closed segments. The previous custom verification
+          // has been moved into segment_intersection_2d for consistency.
+          add_unique_point(batch_inters, *inter);
+        }
+      }
+    }
+
+    // Only split olds at interior hits (avoid snap on endpoint-touch inters from the batch, same reason as add_edge_).
+    std::vector<gp_Pnt2d> batch_to_split;
+    for (const auto& ip : batch_inters)
+    {
+      bool is_old_interior = false;
+      for (const Sketch_edge& e : m_sketch.m_edges.edges())
+      {
+        if (!Sketch::is_linear_edge_(e))
+          continue;
+
+        gp_Pnt2d qa = m_sketch.m_nodes[e.node_idx_a];
+        gp_Pnt2d qb = m_sketch.m_nodes[e.node_idx_b];
+        if (point_on_open_segment_2d(ip, qa, qb))
+        {
+          is_old_interior = true;
+          break;
+        }
+      }
+
+      if (is_old_interior)
+        add_unique_point(batch_to_split, ip);
+    }
+
+    for (const auto& ip : batch_to_split)
+      m_sketch.m_topo.split_linear_edges_at_node_if_interior(m_sketch.m_nodes.get_node_exact(ip), rec);
+  }
+
+  append(m_sketch.m_edges.edges(), m_tmp_edges);
+  m_tmp_edges.clear();
+
+  // Ensure topology is correct if snapping on a midpoint happened.
+  // These edges need to be split. (Kept for compatibility with current midpoint marking during draw.)
+  for (size_t mid_pt_idx : split_mid_points)
+    for (auto itr = m_sketch.m_edges.edges().begin(), end = m_sketch.m_edges.edges().end(); itr != end; ++itr)
+      if (itr->node_idx_mid.has_value() && *itr->node_idx_mid == mid_pt_idx)
+        // Cannot split arc circles.
+        if (!itr->node_idx_arc.has_value())
+        {
+          // Split the edge.
+          Sketch_edge edge_a{itr->node_idx_a, mid_pt_idx};
+          Sketch_edge edge_b{mid_pt_idx, *itr->node_idx_b};
+          m_sketch.update_edge_shp_(edge_a, m_sketch.m_nodes[itr->node_idx_a], m_sketch.m_nodes[mid_pt_idx]);
+          m_sketch.update_edge_shp_(edge_b, m_sketch.m_nodes[itr->node_idx_b], m_sketch.m_nodes[mid_pt_idx]);
+          rec.note_prev_linear_edge(itr->node_idx_a, *itr->node_idx_b, itr->node_idx_mid, itr->name);
+          // Set midpoints for the new split edges so they can be snapped to
+          edge_a.node_idx_mid = m_sketch.m_nodes.add_new_node(
+              get_midpoint(m_sketch.m_nodes[itr->node_idx_a], m_sketch.m_nodes[mid_pt_idx]), true);
+          edge_b.node_idx_mid = m_sketch.m_nodes.add_new_node(
+              get_midpoint(m_sketch.m_nodes[mid_pt_idx], m_sketch.m_nodes[itr->node_idx_b]), true);
+          rec.note_curr_node(edge_a.node_idx_mid.value());
+          rec.note_curr_node(edge_b.node_idx_mid.value());
+          m_sketch.m_ctx.Remove(itr->shp, false);
+          m_sketch.m_edges.edges().erase(itr);
+          m_sketch.m_nodes[mid_pt_idx].midpoint = false;
+          m_sketch.m_edges.edges().emplace_back(edge_a);
+          m_sketch.m_edges.edges().emplace_back(edge_b);
+          break;
+        }
+
+  // Subdivide any *newly committed* edges (the ones from m_tmp) at interior intersections
+  // discovered in the pre-pass. The pre-pass already handled olds; re-calling split here
+  // will target the news (olds' original long edges no longer exist). This ensures the
+  // GUI finalize path produces the same atomic edge count as direct add_edge_ (e.g. 4
+  // edges for a cross, whether or not the cross is at an existing mid).
+  for (const auto& ip : batch_inters)
+  {
+    const size_t nidx = m_sketch.m_nodes.get_node_exact(ip);
+    rec.note_curr_node(nidx);
+    m_sketch.m_topo.split_linear_edges_at_node_if_interior(nidx, rec);
+  }
+
+  m_sketch.m_nodes.hide_snap_annos();
+  m_sketch.update_faces_();
+}
+
+void Sketch_tools::add_node_pt_(const ScreenCoords& screen_coords)
+{
+  auto commit_b = [this](size_t node_b)
+  {
+    Sketch_op_recorder rec(m_sketch.m_view, m_sketch);
+    {
+      rec.note_curr_node(node_b);
+      m_sketch.m_topo.split_linear_edges_at_node_if_interior(node_b, rec);
+
+      // Add-node mode: the rubber band is only for placement (snap / dimension / angle). Do not create
+      // a sketch edge between the anchor and the new node - only nodes and interior splits matter.
+      m_tmp_node_idxs.clear();
+      clear_tmps();
+      m_sketch.m_dims.clear_tmp_dim_anno();
+      m_sketch.m_nodes.hide_snap_annos();
+      m_sketch.update_faces_();
+      rec.commit();
+    }
+  };
+
+  if (m_sketch.m_dims.entered_edge_angle().has_value() && m_tmp_edges.size())
+  {
+    std::optional<gp_Pnt2d> pt_opt = m_sketch.m_view.pt_on_plane(screen_coords, m_sketch.m_pln);
+    if (!pt_opt)
+      return;
+
+    const gp_Pnt2d& pt_a      = m_sketch.m_nodes[m_tmp_edges.back().node_idx_a];
+    double          angle_rad = to_radians(*m_sketch.m_dims.entered_edge_angle());
+    gp_Dir2d        constrained_dir(std::cos(angle_rad), std::sin(angle_rad));
+    gp_Vec2d        to_click(pt_opt->X() - pt_a.X(), pt_opt->Y() - pt_a.Y());
+    double          dist_along = to_click.Dot(gp_Vec2d(constrained_dir));
+    gp_Pnt2d        final_pt   = gp_Pnt2d(pt_a).Translated(gp_Vec2d(constrained_dir) * dist_along);
+    if (!unique(pt_a, final_pt))
+      return;
+
+    const size_t node_idx = m_sketch.m_nodes.get_node_exact(final_pt, true);
+    commit_b(node_idx);
+    return;
+  }
+
+  if (!m_sketch.m_view.pt_on_plane(screen_coords, m_sketch.m_pln))
+    return;
+
+  auto check_node = [&](const std::optional<size_t>& snap_to_node, const gp_Pnt2d& pt)
+  {
+    if (!m_tmp_edges.empty())
+    {
+      Sketch_edge& last   = m_tmp_edges.back();
+      size_t       node_b = snap_to_node ? *snap_to_node : m_sketch.m_nodes.add_new_node(pt, false, true);
+      if (node_b == last.node_idx_a)
+        return;
+
+      commit_b(node_b);
+      return;
+    }
+
+    // No tmp edge yet: snapping to an existing node starts a rubber-band segment from that anchor;
+    // the next placement finishes the edge. Clear angle/dimension UI from any prior mode.
+    if (snap_to_node)
+    {
+      auto start_rubber_from_anchor = [this](size_t idx_a)
+      {
+        m_sketch.m_dims.entered_edge_angle() = std::nullopt;
+        m_sketch.m_dims.entered_edge_len()   = std::nullopt;
+        m_sketch.m_dims.set_show_angle_input(false);
+        m_sketch.m_dims.set_show_dim_input(false);
+        m_sketch.m_view.gui().hide_angle_edit();
+        m_tmp_edges.push_back({idx_a});
+      };
+
+      start_rubber_from_anchor(*snap_to_node);
+      return;
+    }
+
+    Sketch_op_recorder rec(m_sketch.m_view, m_sketch);
+    {
+      const size_t ni = m_sketch.m_nodes.add_new_node(pt, false, true);
+      rec.note_curr_node(ni);
+      m_sketch.m_topo.split_linear_edges_at_node_if_interior(ni, rec);
+      m_sketch.m_dims.clear_tmp_dim_anno();
+      m_sketch.m_nodes.hide_snap_annos();
+      m_sketch.update_faces_();
+      rec.commit();
+    }
+  };
+
+  move_sketch_pt_(screen_coords, check_node);
+}
+
+void Sketch_tools::move_add_node_pt_(const ScreenCoords& screen_coords)
+{
+  if (!m_tmp_edges.empty())
+    move_line_string_pt_(screen_coords);
+  else
+    move_sketch_pt_(screen_coords, [](const std::optional<size_t>&, const gp_Pnt2d&) {});
+}
+
+// Arc circle related
+void Sketch_tools::add_arc_circle_pt_(const ScreenCoords& screen_coords)
+{
+  std::optional<size_t> node_idx = m_sketch.m_nodes.get_node(screen_coords);
+  if (!node_idx)
+    return;
+
+  if (!m_start_arc_circle_node_idx)
+  {
+    EZY_ASSERT(m_tmp_node_idxs.empty());
+    m_start_arc_circle_node_idx = m_sketch.m_nodes.size();
+  }
+
+  if (contains(m_tmp_node_idxs, node_idx))
+    // Arc points must be unique.
+    return;
+
+  m_tmp_node_idxs.push_back(*node_idx);
+
+  if (m_tmp_node_idxs.size() == 3)
+  {
+    Sketch_op_recorder rec(m_sketch.m_view, m_sketch);
+    {
+      const gp_Pnt2d& pt_a = m_sketch.m_nodes[m_tmp_node_idxs[0]];
+      const gp_Pnt2d& pt_c = m_sketch.m_nodes[m_tmp_node_idxs[1]];
+      const gp_Pnt2d& pt_b = m_sketch.m_nodes[m_tmp_node_idxs[2]];
+      m_sketch.add_arc_circle_(pt_a, pt_b, pt_c, rec);
+      m_tmp_node_idxs.clear();
+      m_sketch.update_faces_();
+      rec.commit();
+    }
+  }
+}
+
+void Sketch_tools::move_arc_circle_pt_(const ScreenCoords& screen_coords)
+{
+  std::optional<gp_Pnt2d> pt = m_sketch.m_nodes.snap(screen_coords);
+  if (!pt)
+    // View plane and sketch plane must be perpendicular.
+    return;
+
+  if (m_tmp_node_idxs.size() != 2)
+    return;
+
+  gp_Pnt a = m_sketch.to_3d_(m_tmp_node_idxs[0]);
+  gp_Pnt b = to_3d(m_sketch.m_pln, *pt);
+  gp_Pnt c = m_sketch.to_3d_(m_tmp_node_idxs[1]);
+
+  Handle(Geom_TrimmedCurve) arc_circle = GC_MakeArcOfCircle(a, b, c);
+  if (!arc_circle)
+  {
+    m_sketch.m_view.remove(m_tmp_shp);
+    m_tmp_shp = nullptr;
+    return;
+  }
+
+  TopoDS_Edge edge = BRepBuilderAPI_MakeEdge(arc_circle);
+  show(m_sketch.m_ctx, m_tmp_shp, edge);
+}
+
+void Sketch_tools::move_square_pt_(const ScreenCoords& screen_coords)
+{
+  move_line_string_pt_(screen_coords);
+
+  auto l = [&](Sketch_edge& e, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+  {
+    TopoDS_Wire square = make_square_wire(m_sketch.m_pln, pt_a, *m_last_pt);
+    show(m_sketch.m_ctx, m_tmp_shp, square);
+  };
+
+  if_edge_pt_valid_(l);
+}
+
+void Sketch_tools::finalize_square_(Sketch_op_recorder& rec)
+{
+  auto l = [this, &rec](Sketch_edge& e, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+  {
+    std::array<gp_Pnt2d, 4> corners = square_corners(pt_a, pt_b);
+    m_sketch.add_edge_(corners[0], corners[1], rec);
+    m_sketch.add_edge_(corners[1], corners[2], rec);
+    m_sketch.add_edge_(corners[2], corners[3], rec);
+    m_sketch.add_edge_(corners[3], corners[0], rec);
+    clear_tmps();
+    m_sketch.update_faces_();
+  };
+
+  if_edge_pt_valid_(l);
+}
+
+void Sketch_tools::move_rectangle_pt_(const ScreenCoords& screen_coords)
+{
+  move_line_string_pt_(screen_coords);
+
+  auto l = [&](Sketch_edge& e, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+  {
+    EZY_ASSERT(m_tmp_edges.size());
+
+    if (std::abs(pt_a.X() - pt_b.X()) > Precision::Confusion() && std::abs(pt_a.Y() - pt_b.Y()) > Precision::Confusion())
+    {
+      TopoDS_Wire rectangle = make_rectangle_wire(m_sketch.m_pln, pt_a, pt_b);
+      show(m_sketch.m_ctx, m_tmp_shp, rectangle);
+    }
+    else
+    {
+      m_sketch.m_ctx.Remove(m_tmp_shp, true);
+      m_tmp_shp.Nullify();
+    }
+  };
+
+  if_edge_pt_valid_(l);
+}
+
+void Sketch_tools::finalize_rectangle_(Sketch_op_recorder& rec)
+{
+  auto l = [this, &rec](Sketch_edge& e, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+  {
+    if (std::abs(pt_a.X() - pt_b.X()) > Precision::Confusion() && std::abs(pt_a.Y() - pt_b.Y()) > Precision::Confusion())
+    {
+      std::array<gp_Pnt2d, 4> corners = rectangle_corners(pt_a, pt_b);
+      m_sketch.add_edge_(corners[0], corners[1], rec);
+      m_sketch.add_edge_(corners[1], corners[2], rec);
+      m_sketch.add_edge_(corners[2], corners[3], rec);
+      m_sketch.add_edge_(corners[3], corners[0], rec);
+      clear_tmps();
+      m_sketch.update_faces_();
+    }
+    else
+    {
+      // Start a new edge
+      EZY_ASSERT(e.node_idx_b.has_value());
+      m_tmp_edges.push_back({*e.node_idx_b});
+    }
+  };
+
+  if_edge_pt_valid_(l);
+}
+
+void Sketch_tools::move_circle_pt_(const ScreenCoords& screen_coords)
+{
+  move_line_string_pt_(screen_coords);
+  auto l = [&](Sketch_edge& e, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+  {
+    TopoDS_Wire circle = make_circle_wire(m_sketch.m_pln, pt_a, *m_last_pt);
+    show(m_sketch.m_ctx, m_tmp_shp, circle);
+  };
+  if_edge_pt_valid_(l);
+}
+
+void Sketch_tools::finalize_circle_(Sketch_op_recorder& rec)
+{
+  auto l = [this, &rec](Sketch_edge& e, const gp_Pnt2d& center, const gp_Pnt2d& edge_pt)
+  {
+    std::array<gp_Pnt2d, 4> points = xy_stencil_pnts(center, edge_pt);
+    m_sketch.add_arc_circle_(points[0], points[2], points[1], rec);
+    m_sketch.add_arc_circle_(points[0], points[3], points[1], rec);
+    clear_tmps();
+    m_sketch.update_faces_();
+  };
+  if_edge_pt_valid_(l);
+}
+
+// Slot related
+void Sketch_tools::move_slot_pt_(const ScreenCoords& screen_coords)
+{
+  move_line_string_pt_(screen_coords);
+  auto l = [&](Sketch_edge& e, const gp_Pnt2d& pt_b, const gp_Pnt2d& pt_c)
+  {
+    if (m_tmp_edges.size() != 2)
+      return;
+
+    const gp_Pnt2d& pt_a = m_sketch.m_nodes[m_tmp_edges.front().node_idx_a];
+    if (unique(pt_a, pt_b, pt_c))
+      show(m_sketch.m_ctx, m_tmp_shp, make_slot_wire(m_sketch.m_pln, pt_a, pt_b, pt_c));
+  };
+  if_edge_pt_valid_(l);
+}
+
+void Sketch_tools::finalize_slot_(Sketch_op_recorder& rec)
+{
+  EZY_ASSERT(m_tmp_edges.size() == 2);
+  EZY_ASSERT(m_tmp_edges[1].node_idx_b.has_value());
+
+  Slot_pnts pnts = get_slot_points(m_sketch.m_nodes[m_tmp_edges[0].node_idx_a], m_sketch.m_nodes[m_tmp_edges[1].node_idx_a],
+                                   m_sketch.m_nodes[m_tmp_edges[1].node_idx_b]);
+
+  m_sketch.add_edge_(pnts.a_top_2d, pnts.b_top_2d, rec);
+  m_sketch.add_edge_(pnts.a_bottom_2d, pnts.b_bottom_2d, rec);
+  m_sketch.add_arc_circle_(pnts.a_bottom_2d, pnts.a_mid_2d, pnts.a_top_2d, rec);
+  m_sketch.add_arc_circle_(pnts.b_bottom_2d, pnts.b_mid_2d, pnts.b_top_2d, rec);
+  clear_tmps();
+  m_sketch.update_faces_();
+}
+
+// Operation axis related
+void Sketch_tools::add_operation_axis_pt_(const ScreenCoords& screen_coords)
+{
+  // Axis definition only happens when !has_operation_axis() (guarded at the call site in GUI).
+  // To redefine, the caller must first clear via the Options "Clear axis" button.
+  add_line_string_pt_(screen_coords, Sketch_tools::Linestring_type::Single);
+}
+
+void Sketch_tools::finalize_operation_axis_(Sketch_op_recorder& rec)
+{
+  m_sketch.m_operation_axis = std::move(m_tmp_edges.back());
+  if (m_sketch.m_operation_axis->node_idx_b.has_value())
+    rec.note_curr_operation_axis(m_sketch.m_nodes[m_sketch.m_operation_axis->node_idx_a],
+                                 m_sketch.m_nodes[*m_sketch.m_operation_axis->node_idx_b]);
+
+  m_sketch.cancel_elm(); // Reset state, we have the operation axis
+  m_sketch.sync_operation_axis_display_();
+  m_sketch.m_node_marks.sync();
+  m_sketch.m_nodes.hide_snap_annos();
+}
+
+bool Sketch_tools::clear_tmps()
+{
+  m_sketch.m_view.remove(m_tmp_shp);
+  for (Sketch_edge& e : m_tmp_edges)
+    m_sketch.m_view.remove(e.shp);
+
+  if (m_tmp_shp)
+  {
+    m_sketch.m_ctx.Remove(m_tmp_shp, true);
+    m_tmp_shp = nullptr;
+  }
+
+  const bool operation_canceled = !m_tmp_edges.empty();
+  clear_all(m_tmp_node_idxs, m_tmp_shp, m_tmp_edges);
+  m_sketch.m_dims.on_clear_tmps();
+
+  return operation_canceled;
+}
+
+// General sketch point related
+template <typename Callback>
+void Sketch_tools::add_sketch_pt_(const ScreenCoords& screen_coords, size_t required_num_pts, Callback&& callback)
+{
+  auto l = [&](const std::optional<size_t>& node_idx, const gp_Pnt2d& pt)
+  {
+    if (node_idx)
+      m_tmp_node_idxs.push_back(*node_idx);
+    else
+      m_tmp_node_idxs.push_back(m_sketch.m_nodes.add_new_node(pt));
+
+    if (m_tmp_node_idxs.size() >= required_num_pts)
+      callback(m_tmp_node_idxs.back());
+  };
+  move_sketch_pt_(screen_coords, l);
+}
+
+template <typename Callback> void Sketch_tools::move_sketch_pt_(const ScreenCoords& screen_coords, Callback&& callback)
+{
+  m_last_pt = m_sketch.m_view.pt_on_plane(screen_coords, m_sketch.m_pln);
+  if (!m_last_pt)
+    // View plane and sketch plane must be perpendicular.
+    return;
+
+  std::optional<size_t> node_idx = m_sketch.m_nodes.try_get_node_idx_snap(*m_last_pt);
+
+  callback(node_idx, *m_last_pt);
+}
+
+/// Invokes callback(e, pt_a, pt_b) with the last tmp edge only when it exists and is non-degenerate.
+template <typename Callback> void Sketch_tools::if_edge_pt_valid_(Callback&& callback)
+{
+  if (m_tmp_edges.empty())
+    return;
+
+  Sketch_edge&    e    = m_tmp_edges.back();
+  const gp_Pnt2d& pt_a = m_sketch.m_nodes[e.node_idx_a];
+  if (m_last_pt.has_value())
+    if (unique(pt_a, *m_last_pt))
+      callback(e, pt_a, *m_last_pt);
+}
+
+void Sketch_tools::finalize_add_node_elm_cleanup_()
+{
+  if (!m_tmp_edges.empty() && !m_tmp_edges.back().node_idx_b.has_value())
+  {
+    m_sketch.m_ctx.Remove(m_tmp_edges.back().shp, false);
+    m_tmp_edges.pop_back();
+  }
+
+  m_sketch.m_nodes.hide_snap_annos();
+  m_sketch.update_faces_();
+}

--- a/src/sketch_tools.h
+++ b/src/sketch_tools.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <gp_Pnt2d.hxx>
+#include <optional>
+#include <vector>
+
+#include "sketch_edge.h"
+#include "utl_types.h"
+
+class Sketch;
+class Sketch_op_recorder;
+
+/// Interactive sketch drawing session: tmp edges/nodes, previews, finalize/cancel.
+class Sketch_tools
+{
+public:
+  enum class Linestring_type
+  {
+    Single,
+    Two,
+    Multiple
+  };
+
+  explicit Sketch_tools(Sketch& sketch);
+
+  void on_click(const ScreenCoords& screen_coords);
+  void on_move(const ScreenCoords& screen_coords);
+  void on_enter();
+  void finalize();
+  bool cancel();
+
+  [[nodiscard]] bool edge_from_center_active() const;
+
+  /// Session state used while drawing (e.g. typed dimension input).
+  [[nodiscard]] std::vector<Sketch_edge>&       tmp_edges() { return m_tmp_edges; }
+  [[nodiscard]] const std::vector<Sketch_edge>& tmp_edges() const { return m_tmp_edges; }
+  [[nodiscard]] std::optional<gp_Pnt2d>&        last_pt() { return m_last_pt; }
+  [[nodiscard]] bool                            clear_tmps();
+
+  void clear_tmp_node_idxs() { m_tmp_node_idxs.clear(); }
+
+  [[nodiscard]] size_t tmp_node_count() const { return m_tmp_node_idxs.size(); }
+  [[nodiscard]] size_t tmp_edge_count() const { return m_tmp_edges.size(); }
+
+private:
+  friend class Sketch_dims;
+
+  bool complete_edge_from_center_(const ScreenCoords& screen_coords);
+
+  void add_line_string_pt_(const ScreenCoords& screen_coords, Linestring_type linestring_type);
+  void move_line_string_pt_(const ScreenCoords& screen_coords);
+  void finalize_edges_(Sketch_op_recorder& rec);
+
+  void add_node_pt_(const ScreenCoords& screen_coords);
+  void move_add_node_pt_(const ScreenCoords& screen_coords);
+
+  void add_arc_circle_pt_(const ScreenCoords& screen_coords);
+  void move_arc_circle_pt_(const ScreenCoords& screen_coords);
+
+  void move_square_pt_(const ScreenCoords& screen_coords);
+  void finalize_square_(Sketch_op_recorder& rec);
+
+  void move_circle_pt_(const ScreenCoords& screen_coords);
+  void finalize_circle_(Sketch_op_recorder& rec);
+
+  void move_rectangle_pt_(const ScreenCoords& screen_coords);
+  void finalize_rectangle_(Sketch_op_recorder& rec);
+
+  void move_slot_pt_(const ScreenCoords& screen_coords);
+  void finalize_slot_(Sketch_op_recorder& rec);
+
+  void add_operation_axis_pt_(const ScreenCoords& screen_coords);
+  void finalize_operation_axis_(Sketch_op_recorder& rec);
+
+  template <typename Callback>
+  void add_sketch_pt_(const ScreenCoords& screen_coords, size_t required_num_pts, Callback&& callback);
+  template <typename Callback> void move_sketch_pt_(const ScreenCoords& screen_coords, Callback&& callback);
+  template <typename Callback> void if_edge_pt_valid_(Callback&& callback);
+
+  void finalize_add_node_elm_cleanup_();
+
+  Sketch&                  m_sketch;
+  std::optional<size_t>    m_start_arc_circle_node_idx;
+  std::optional<gp_Pnt2d>  m_last_pt;
+  std::vector<size_t>      m_tmp_node_idxs;
+  std::vector<Sketch_edge> m_tmp_edges;
+  AIS_Shape_ptr            m_tmp_shp;
+};

--- a/src/sketch_topo.cpp
+++ b/src/sketch_topo.cpp
@@ -1,0 +1,759 @@
+#include "sketch_topo.h"
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepTools.hxx>
+#include <GC_MakeArcOfCircle.hxx>
+#include <Graphic3d_AspectFillArea3d.hxx>
+#include <Precision.hxx>
+#include <Quantity_Color.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Wire.hxx>
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <glm/glm.hpp>
+
+#include "occt_view.h"
+#include "sketch.h"
+#include "sketch_delta.h"
+#include "utl.h"
+#include "utl_geom.h"
+
+using namespace glm;
+
+struct Sketch_topo::Face_edge
+{
+  const Sketch::Edge& edge;
+  bool                reversed;
+
+  size_t start_nd_idx() const;
+  size_t end_nd_idx() const;
+};
+
+Sketch_topo::Sketch_topo(Sketch& sketch)
+    : m_sketch(sketch)
+{
+}
+
+void Sketch_topo::remove_displayed_faces()
+{
+  for (AIS_Shape_ptr& f : m_faces)
+    m_sketch.m_ctx.Remove(f, false);
+
+  m_faces.clear();
+  m_dim_classifier_faces.clear();
+}
+
+double Sketch_topo::plane_pick_snap_radius_world() const
+{
+  const double px = Sketch_nodes::get_snap_dist();
+  if (m_sketch.m_view.is_headless())
+    return std::max(px, Precision::Confusion() * 1e9);
+
+  const gp_Pnt2d          ref2(0.0, 0.0);
+  const ScreenCoords      s0   = m_sketch.m_view.get_screen_coords(to_3d(m_sketch.m_pln, ref2));
+  const dvec2             base = s0.unsafe_get();
+  std::optional<gp_Pnt2d> p1   = m_sketch.m_view.pt_on_plane(ScreenCoords(dvec2(base.x + px, base.y)), m_sketch.m_pln);
+  if (!p1)
+    return std::max(px, Precision::Confusion() * 1e9);
+
+  return ref2.Distance(*p1);
+}
+
+void Sketch_topo::snap_placed_node_to_closest_linear_edge_interior_(size_t node_idx)
+{
+  EZY_ASSERT(node_idx < m_sketch.m_nodes.size());
+
+  const gp_Pnt2d p(m_sketch.m_nodes[node_idx].X(), m_sketch.m_nodes[node_idx].Y());
+  const double   max_d = plane_pick_snap_radius_world();
+
+  double                  best_err = std::numeric_limits<double>::infinity();
+  std::optional<gp_Pnt2d> best_proj;
+
+  for (const auto& e : m_sketch.m_edges)
+  {
+    if (e.circle_arc)
+      continue;
+
+    if (e.node_idx_arc.has_value())
+      continue;
+
+    if (!e.node_idx_b.has_value())
+      continue;
+
+    const size_t    a  = e.node_idx_a;
+    const size_t    b  = *e.node_idx_b;
+    const gp_Pnt2d& pa = m_sketch.m_nodes[a];
+    const gp_Pnt2d& pb = m_sketch.m_nodes[b];
+    if (node_idx == a || node_idx == b)
+      continue;
+
+    std::optional<gp_Pnt2d> proj = snap_foot_to_open_segment_interior_if_close(p, pa, pb, max_d);
+    if (!proj)
+      continue;
+
+    const double err = p.Distance(*proj);
+    if (err < best_err)
+    {
+      best_err  = err;
+      best_proj = proj;
+    }
+  }
+
+  if (best_proj)
+  {
+    Sketch_nodes::Node& n = m_sketch.m_nodes[node_idx];
+    n.SetX(best_proj->X());
+    n.SetY(best_proj->Y());
+    n.midpoint = false;
+  }
+}
+
+void Sketch_topo::split_linear_edges_at_node_if_interior(size_t node_idx)
+{
+  split_linear_edges_at_node_if_interior(node_idx, static_cast<Sketch_op_recorder*>(nullptr));
+}
+
+void Sketch_topo::split_linear_edges_at_node_if_interior(size_t node_idx, Sketch_op_recorder& rec)
+{
+  split_linear_edges_at_node_if_interior(node_idx, &rec);
+}
+
+void Sketch_topo::split_linear_edges_at_node_if_interior(size_t node_idx, Sketch_op_recorder* rec)
+{
+  EZY_ASSERT(node_idx < m_sketch.m_nodes.size());
+  snap_placed_node_to_closest_linear_edge_interior_(node_idx);
+  const gp_Pnt2d& p = m_sketch.m_nodes[node_idx];
+
+  bool progress = true;
+  while (progress)
+  {
+    progress = false;
+    for (auto itr = m_sketch.m_edges.begin(); itr != m_sketch.m_edges.end(); ++itr)
+    {
+      if (itr->circle_arc)
+        continue;
+
+      if (itr->node_idx_arc.has_value())
+        continue;
+
+      if (!itr->node_idx_b.has_value())
+        continue;
+
+      const size_t    a  = itr->node_idx_a;
+      const size_t    b  = *itr->node_idx_b;
+      const gp_Pnt2d& pa = m_sketch.m_nodes[a];
+      const gp_Pnt2d& pb = m_sketch.m_nodes[b];
+
+      if (node_idx == a || node_idx == b)
+        continue;
+
+      if (!point_on_open_segment_2d(p, pa, pb))
+        continue;
+
+      Sketch::Edge edge_a{a};
+      m_sketch.update_edge_end_pt_(edge_a, node_idx);
+      Sketch::Edge edge_b{node_idx};
+      m_sketch.update_edge_end_pt_(edge_b, b);
+
+      if (rec)
+        rec->note_prev_linear_edge(itr->node_idx_a, *itr->node_idx_b, itr->node_idx_mid, itr->name);
+
+      m_sketch.m_ctx.Remove(itr->shp, false);
+      m_sketch.m_edges.erase(itr);
+      m_sketch.m_nodes[node_idx].midpoint = false;
+      m_sketch.m_edges.push_back(std::move(edge_a));
+      m_sketch.m_edges.push_back(std::move(edge_b));
+
+      progress = true;
+      break;
+    }
+  }
+}
+
+// Function to extract faces from the planar graph
+void Sketch_topo::update_faces()
+{
+  m_sketch.m_nodes.finalize();
+
+  m_sketch.m_view.remove(m_faces);
+  m_faces.clear();
+  m_dim_classifier_faces.clear();
+
+  // Used to cleanup dangling nodes;
+  std::vector<bool> used_nodes(m_sketch.m_nodes.size());
+
+  // Build adjacency list
+  std::unordered_map<size_t, std::vector<std::pair<size_t, const Sketch::Edge*>>> adj_list;
+
+  for (const auto& edge : m_sketch.m_edges)
+  {
+    EZY_ASSERT(edge.node_idx_b.has_value());
+
+    size_t a = edge.node_idx_a;
+    size_t b = edge.node_idx_b.value();
+    adj_list[a].push_back({b, &edge});
+    adj_list[b].push_back({a, &edge});
+
+    // Keep track of used nodes.
+    used_nodes[a] = true;
+    used_nodes[b] = true;
+    if (edge.node_idx_mid.has_value())
+      used_nodes[*edge.node_idx_mid] = true;
+
+    if (edge.node_idx_arc.has_value())
+      used_nodes[*edge.node_idx_arc] = true;
+  }
+
+  if (m_sketch.m_operation_axis.has_value())
+  {
+    used_nodes[m_sketch.m_operation_axis->node_idx_a] = true;
+    if (m_sketch.m_operation_axis->node_idx_b.has_value())
+      used_nodes[*m_sketch.m_operation_axis->node_idx_b] = true;
+  }
+
+  // Remove dangling edges (edges with degree-1 endpoints) iteratively.
+  // These edges cannot form closed faces, so we exclude them from face detection.
+  std::unordered_set<const Sketch::Edge*> excluded_edges;
+
+  // Treat edges attached to the virtual mid-node of an arc as dangling for face detection.
+  // Circle arcs are represented using a virtual node in the middle of the arc (`node_idx_arc`).
+  // Any non-arc edge that uses this virtual node as an endpoint should not participate in faces.
+  {
+    std::unordered_set<size_t> arc_mid_nodes;
+    for (const auto& edge : m_sketch.m_edges)
+      if (edge.node_idx_arc.has_value())
+        arc_mid_nodes.insert(*edge.node_idx_arc);
+
+    for (const auto& edge : m_sketch.m_edges)
+    {
+      // Only consider non-arc edges (straight segments etc.).
+      if (edge.circle_arc)
+        continue;
+
+      if (!edge.node_idx_b.has_value())
+        continue;
+
+      const size_t a = edge.node_idx_a;
+      const size_t b = *edge.node_idx_b;
+
+      if (arc_mid_nodes.count(a) || arc_mid_nodes.count(b))
+        excluded_edges.insert(&edge);
+    }
+  }
+
+  bool changed = true;
+  while (changed)
+  {
+    changed = false;
+    std::unordered_set<const Sketch::Edge*> to_exclude;
+
+    // Find edges where at least one endpoint has degree 1 (considering only non-excluded edges)
+    for (const auto& edge : m_sketch.m_edges)
+    {
+      if (excluded_edges.count(&edge))
+        continue;
+
+      EZY_ASSERT(edge.node_idx_b.has_value());
+      size_t a = edge.node_idx_a;
+      size_t b = edge.node_idx_b.value();
+
+      // Count degree for each endpoint (excluding already excluded edges)
+      int degree_a = 0;
+      int degree_b = 0;
+      for (const auto& [neighbor, e] : adj_list[a])
+        if (!excluded_edges.count(e))
+          ++degree_a;
+
+      for (const auto& [neighbor, e] : adj_list[b])
+        if (!excluded_edges.count(e))
+          ++degree_b;
+
+      // If either endpoint has degree 1, this edge is dangling
+      if (degree_a == 1 || degree_b == 1)
+      {
+        to_exclude.insert(&edge);
+        changed = true;
+      }
+    }
+
+    excluded_edges.insert(to_exclude.begin(), to_exclude.end());
+  }
+  // Bridge edge removal logic (active). Excludes edges that purely connect separate cycles
+  // (both ends degree >=3 and no alternate path) from the adjacency used by the face walker.
+  // This is required for sketches like bridge.ezy that contain a "bridge" touching an inner
+  // triangular loop so that we obtain exactly two faces, one of which has the triangle as a
+  // hole. Dangling removal alone is not sufficient. The logic was previously disabled because
+  // an earlier version produced bad results on some nested rect holes; current state + other
+  // fixes (cw break, split rules, etc.) are being validated with the new regression test.
+  // Remove bridge edges that connect two separate cycles.
+  // A bridge edge connects two cycles and has both endpoints with degree >= 3.
+  // We detect this by checking if the edge is the only connection between two cycles.
+  std::unordered_set<const Sketch::Edge*> bridge_edges;
+  for (const auto& edge : m_sketch.m_edges)
+  {
+    if (excluded_edges.count(&edge))
+      continue;
+
+    EZY_ASSERT(edge.node_idx_b.has_value());
+    size_t a = edge.node_idx_a;
+    size_t b = edge.node_idx_b.value();
+
+    // Count degree for each endpoint (excluding already excluded edges)
+    int degree_a = 0;
+    int degree_b = 0;
+    for (const auto& [neighbor, e] : adj_list[a])
+      if (!excluded_edges.count(e))
+        ++degree_a;
+
+    for (const auto& [neighbor, e] : adj_list[b])
+      if (!excluded_edges.count(e))
+        ++degree_b;
+
+    // Bridge edges have both endpoints with degree >= 3
+    // They connect two separate cycles. We detect this by checking if removing the edge
+    // creates two disconnected components, each containing a cycle.
+    if (degree_a >= 3 && degree_b >= 3)
+    {
+      // Check if removing this edge disconnects the graph
+      // by seeing if we can reach 'b' from 'a' without using this edge
+      std::unordered_set<size_t> visited;
+      std::vector<size_t>        queue;
+      queue.push_back(a);
+      visited.insert(a);
+      bool can_reach_b = false;
+
+      for (size_t i = 0; i < queue.size() && !can_reach_b; ++i)
+      {
+        size_t curr = queue[i];
+        for (const auto& [neighbor, e] : adj_list[curr])
+        {
+          if (excluded_edges.count(e) || e == &edge)
+            continue;
+
+          if (neighbor == b)
+          {
+            can_reach_b = true;
+            break;
+          }
+
+          if (!visited.count(neighbor))
+          {
+            visited.insert(neighbor);
+            queue.push_back(neighbor);
+          }
+        }
+      }
+
+      // If we can't reach b from a without this edge, it's a bridge
+      // But we also need to verify both sides have cycles
+      if (!can_reach_b)
+      {
+        // Check if component containing 'a' has a cycle
+        auto has_cycle_in_component = [&](size_t start, const Sketch::Edge* exclude_edge) -> bool
+        {
+          std::unordered_set<size_t>          comp_visited;
+          std::function<bool(size_t, size_t)> dfs = [&](size_t curr, size_t parent) -> bool
+          {
+            comp_visited.insert(curr);
+            for (const auto& [neighbor, e] : adj_list[curr])
+            {
+              if (excluded_edges.count(e) || e == exclude_edge)
+                continue;
+
+              if (neighbor == parent)
+                continue;
+
+              if (comp_visited.count(neighbor))
+                // Found a back edge = cycle
+                return true;
+
+              if (dfs(neighbor, curr))
+                return true;
+            }
+            return false;
+          };
+
+          // Try starting from each neighbor
+          for (const auto& [neighbor, e] : adj_list[start])
+          {
+            if (excluded_edges.count(e) || e == exclude_edge)
+              continue;
+
+            comp_visited.clear();
+            comp_visited.insert(start);
+            if (dfs(neighbor, start))
+              return true;
+          }
+          return false;
+        };
+
+        bool a_has_cycle = has_cycle_in_component(a, &edge);
+        bool b_has_cycle = has_cycle_in_component(b, &edge);
+
+        // If both components have cycles, this edge is a bridge
+        if (a_has_cycle && b_has_cycle)
+          bridge_edges.insert(&edge);
+      }
+    }
+  }
+
+  // Add bridge edges to excluded set
+  excluded_edges.insert(bridge_edges.begin(), bridge_edges.end());
+
+  // Rebuild adjacency list excluding dangling and bridge edges
+  adj_list.clear();
+  for (const auto& edge : m_sketch.m_edges)
+  {
+    if (excluded_edges.count(&edge))
+      continue;
+
+    EZY_ASSERT(edge.node_idx_b.has_value());
+    size_t a = edge.node_idx_a;
+    size_t b = edge.node_idx_b.value();
+    adj_list[a].push_back({b, &edge});
+    adj_list[b].push_back({a, &edge});
+  }
+
+  std::unordered_set<std::pair<size_t, size_t>, Pair_hash> seen_edges;
+
+  const auto edge_outgoing_dir = [this](size_t idx_a, size_t idx_b) -> gp_Vec2d
+  {
+    gp_Vec2d ret(m_sketch.m_nodes[idx_a], m_sketch.m_nodes[idx_b]);
+    ret.Normalize();
+    return ret;
+  };
+
+  for (auto& [a_idx, edges] : adj_list)
+    for (auto& [b_idx, start_edge] : edges)
+    {
+      if (seen_edges.count(std::make_pair(a_idx, b_idx)))
+        continue;
+
+      size_t              start_idx = a_idx;
+      size_t              prev_idx  = a_idx;
+      size_t              curr_idx  = b_idx;
+      const Sketch::Edge* curr_edge = start_edge;
+      Face_edges          face;
+
+      for (;;)
+      {
+        face.push_back({*curr_edge, curr_edge->reversed(prev_idx, curr_idx)});
+
+        // Base case
+        if (curr_idx == start_idx)
+        {
+          EZY_ASSERT(face.size() > 2);
+
+          // Deliberately accept the cycle only if the left-most walker produced a traversal
+          // whose shoelace is positive under our is_face_clockwise_ convention. If not, break
+          // (skip pushing a face for this seed). This is not an error -- other seeds may still
+          // discover the same geometric cycle (or its sibling faces) in the matching orientation.
+          // The early break makes the set of accepted faces and their order in m_faces depend on
+          // m_edges list order (affected by appends and push_backs during splits) and on individual
+          // Edge node_idx_a/b values (set from pa/pb at creation time, i.e. draw direction for
+          // edges added via the GUI line tool). This dependency has been observed to be required
+          // for correct results in the GUI for cases such as "square then mid vertical splitter
+          // added lower-to-top vs. top-to-bottom" (the break version yields the expected rects
+          // on the sides the user sees; a force-to-cw normalization for every collected cycle
+          // re-introduces the direction asymmetry or malformed faces in that flow).
+          // The hole test (and bridge/dangling face tests) still pass because their edge addition
+          // order + walker seeds happen to produce matching orientations for both outer and inner
+          // boundaries.
+          if (!is_face_clockwise_(face))
+            break;
+
+          for (const Face_edge& e : face)
+          {
+            // Mark edge in both directions to avoid processing the same face twice
+            // when starting from different nodes
+            size_t start = e.start_nd_idx();
+            size_t end   = e.end_nd_idx();
+            seen_edges.insert(std::make_pair(start, end));
+            seen_edges.insert(std::make_pair(end, start));
+          }
+
+          auto f = create_face_shape_(face);
+          f->SetColor(Quantity_NOC_GRAY7);       // Base color
+          f->SetTransparency(0.5);               // 0.5 = 50% transparent (0.0 = opaque, 1.0 = invisible)
+          f->SetMaterial(Graphic3d_NOM_PLASTIC); // Optional: material for shading
+
+          m_sketch.m_ctx.Display(f, AIS_Shaded, AIS_Shape::SelectionMode(TopAbs_FACE), true);
+          m_sketch.m_ctx.Activate(f, AIS_Shape::SelectionMode(TopAbs_FACE));
+          // m_ctx.UpdateCurrentViewer();
+          m_faces.push_back(f);
+          break;
+        }
+
+        size_t              left_most_idx;
+        double              min_angle      = std::numeric_limits<double>::max();
+        const Sketch::Edge* left_most_edge = nullptr;
+        gp_Vec2d            edge_a         = edge_outgoing_dir(prev_idx, curr_idx);
+
+        for (auto& [next_idx, next_edge] : adj_list[curr_idx])
+        {
+          if (next_idx == prev_idx)
+            continue;
+
+          gp_Vec2d edge_b = edge_outgoing_dir(curr_idx, next_idx);
+          double   angle  = std::atan2(edge_b.Crossed(edge_a), edge_b.Dot(edge_a));
+          if (angle < min_angle)
+          {
+            min_angle      = angle;
+            left_most_idx  = next_idx;
+            left_most_edge = next_edge;
+          }
+        }
+        if (!left_most_edge)
+          // Invalid topology, probably a dangling edge
+          break;
+
+        prev_idx  = curr_idx;
+        curr_idx  = left_most_idx;
+        curr_edge = left_most_edge;
+      }
+    }
+
+  // Mark unused nodes as deleted so they're excluded from snapping operations.
+  // Nodes become unused when all edges that reference them are removed.
+  // Permanent add-node points are never auto-tombstoned when unused; user delete sets `deleted` and it stays.
+  for (size_t idx = 0, num = m_sketch.m_nodes.size(); idx < num; ++idx)
+    if (!m_sketch.m_nodes[idx].permanent)
+      m_sketch.m_nodes[idx].deleted = !used_nodes[idx];
+
+  // Book keeping
+  struct Face_meta
+  {
+    Sketch_face_shp_ptr           shp;
+    double                        area;
+    int                           parent_idx;
+    std::vector<const Face_meta*> holes;
+  };
+
+  std::vector<Face_meta> face_metas;
+  face_metas.reserve(m_faces.size());
+  for (Sketch_face_shp_ptr& face : m_faces)
+    face_metas.push_back({face, compute_face_area(face), -1});
+
+  // Sort faces by area (descending) to check larger faces first
+  std::sort(face_metas.begin(), face_metas.end(),
+            [](const Face_meta& a, const Face_meta& b)
+            {
+              return a.area > b.area; // Descending by area
+            });
+
+  // Classify faces
+  for (size_t face_i = 0, num = face_metas.size(); face_i < num; ++face_i)
+  {
+    Face_meta& face_a = face_metas[face_i];
+    for (size_t face_j = face_i + 1; face_j < num; ++face_j)
+    {
+      Face_meta& face_b = face_metas[face_j];
+      if (is_face_contained(face_b.shp->Shape(), face_a.shp->Shape()))
+        // Check if face_a is better (smaller) parent than the current one
+        if (face_b.parent_idx == -1 || face_a.area < face_metas[face_a.parent_idx].area)
+          face_b.parent_idx = static_cast<int>(face_i);
+    }
+  }
+
+  // Assign holes
+  for (const Face_meta& face : face_metas)
+    if (face.parent_idx != -1)
+      face_metas[face.parent_idx].holes.push_back(&face);
+
+  // Rebuild face shapes with their holes
+  for (Face_meta& face : face_metas)
+    if (face.holes.size())
+    {
+      EZY_ASSERT(face.shp->Shape().ShapeType() == TopAbs_FACE);
+      BRepBuilderAPI_MakeFace face_maker(TopoDS::Face(face.shp->Shape()));
+      for (const Face_meta* hole : face.holes)
+      {
+        EZY_ASSERT(hole->shp->Shape().ShapeType() == TopAbs_FACE);
+        TopoDS_Wire hole_wire = BRepTools::OuterWire(TopoDS::Face(hole->shp->Shape()));
+        // Winding order is important
+        hole_wire.Reverse();
+        face_maker.Add(hole_wire);
+      }
+      EZY_ASSERT(face_maker.IsDone());
+      // auto dbg_face = to_boost(face_maker.Face(), m_pln);
+      face.shp->SetShape(face_maker.Face());
+    }
+
+  // Use the nesting depth of the faces to define the face selection sensitivity
+  for (const Face_meta& face : face_metas)
+  {
+    int              nesting_depth = 0;
+    const Face_meta* curr_face     = &face;
+    for (; curr_face->parent_idx != -1; ++nesting_depth)
+      curr_face = &face_metas[curr_face->parent_idx];
+
+    m_sketch.m_ctx.SetSelectionSensitivity(face.shp, 0, nesting_depth + 1);
+  }
+
+  rebuild_dim_classifier_face_cache_();
+  m_sketch.purge_stale_length_dimensions_();
+  m_sketch.sync_permanent_node_annos_();
+  m_sketch.refresh_all_length_dimensions_();
+
+  if (m_sketch.is_current())
+    m_sketch.m_view.refresh_active_sketch_grid();
+}
+
+void Sketch_topo::rebuild_dim_classifier_face_cache_()
+{
+  m_dim_classifier_faces.clear();
+  m_dim_classifier_faces.reserve(m_faces.size());
+  for (const Sketch_face_shp_ptr& fp : m_faces)
+    m_dim_classifier_faces.push_back(TopoDS::Face(fp->Shape()));
+}
+
+size_t Sketch_topo::Face_edge::start_nd_idx() const
+{
+  if (!reversed)
+    return edge.node_idx_a;
+
+  EZY_ASSERT(edge.node_idx_b);
+  return *edge.node_idx_b;
+}
+
+size_t Sketch_topo::Face_edge::end_nd_idx() const
+{
+  if (reversed)
+    return edge.node_idx_a;
+
+  EZY_ASSERT(edge.node_idx_b);
+  return *edge.node_idx_b;
+}
+
+bool Sketch_topo::is_face_clockwise_(const Face_edges& face) const
+{
+  // Compute signed area using the shoelace formula
+  double signed_area = 0.0;
+  for (const Face_edge& e : face)
+  {
+    // `start_nd_idx` and `end_nd_idx` consider reversed edges
+    const gp_Pnt2d& p1 = m_sketch.m_nodes[e.start_nd_idx()];
+    const gp_Pnt2d& p2 = m_sketch.m_nodes[e.end_nd_idx()];
+    signed_area += (p1.X() * p2.Y()) - (p2.X() * p1.Y());
+  }
+  // signed_area *= 0.5;  // Divide by 2 for actual area
+
+  return signed_area > 0;
+}
+
+Sketch_face_shp_ptr Sketch_topo::create_face_shape_(const Face_edges& face)
+{
+  EZY_ASSERT(face.size() > 2);
+
+  // Create edges for the wire
+  BRepBuilderAPI_MakeWire wire_maker;
+
+  struct Circle_arc
+  {
+    std::optional<size_t> nd_idx_a;
+    std::optional<size_t> nd_idx_b;
+    std::optional<size_t> nd_idx_c;
+    std::optional<bool>   dbg_reversed;
+  };
+
+  std::map<Geom_TrimmedCurve*, Circle_arc> circle_arcs;
+  std::vector<gp_Pnt>                      node_verts;
+  std::optional<size_t>                    dbg_last_node_idx;
+
+  for (const Face_edge& e : face)
+  {
+    EZY_ASSERT(e.edge.node_idx_b);
+
+    auto add_node_vert_unique = [&](const gp_Pnt& pt)
+    {
+      if (node_verts.empty())
+        node_verts.push_back(pt);
+      else if (!node_verts.back().IsEqual(pt, Precision::Confusion()))
+        node_verts.push_back(pt);
+    };
+
+    if (e.edge.circle_arc.get())
+    {
+      Circle_arc& arc = circle_arcs[e.edge.circle_arc.get()];
+
+      auto try_arc_circle = [&](bool reversed)
+      {
+        if (!arc.dbg_reversed.has_value())
+          arc.dbg_reversed = reversed;
+        else
+          EZY_ASSERT(*arc.dbg_reversed == reversed);
+
+        if (arc.nd_idx_a && arc.nd_idx_b && arc.nd_idx_c)
+        {
+          gp_Pnt a = m_sketch.to_3d_(arc.nd_idx_a);
+          gp_Pnt b = m_sketch.to_3d_(arc.nd_idx_b);
+          gp_Pnt c = m_sketch.to_3d_(arc.nd_idx_c);
+
+          add_node_vert_unique(a);
+          add_node_vert_unique(b);
+          add_node_vert_unique(c);
+
+          Geom_TrimmedCurve_ptr arc_circle;
+          if (reversed)
+            arc_circle = GC_MakeArcOfCircle(c, b, a);
+          else
+            arc_circle = GC_MakeArcOfCircle(a, b, c);
+
+          BRepBuilderAPI_MakeEdge edge(arc_circle);
+          EZY_ASSERT(edge.IsDone());
+          wire_maker.Add(edge.Edge());
+        }
+      };
+
+      // Depending on the order of the node indexes in face,
+      // the first or second circle arc edge might come first.
+      if (e.edge.node_idx_arc)
+      {
+        // This is the first part of the circle arc.
+        EZY_ASSERT(e.edge.node_idx_arc);
+        EZY_ASSERT(*e.edge.node_idx_b == *e.edge.node_idx_arc);
+        arc.nd_idx_a = e.edge.node_idx_a;
+        arc.nd_idx_b = e.edge.node_idx_arc;
+        try_arc_circle(e.reversed);
+      }
+      else
+      {
+        // This is the second part of the circle arc.
+        arc.nd_idx_c = *e.edge.node_idx_b;
+        try_arc_circle(e.reversed);
+      }
+    }
+    else
+    {
+      gp_Pnt a = m_sketch.to_3d_(e.start_nd_idx());
+      gp_Pnt b = m_sketch.to_3d_(e.end_nd_idx());
+
+      add_node_vert_unique(a);
+      add_node_vert_unique(b);
+
+      BRepBuilderAPI_MakeEdge edge(a, b);
+      EZY_ASSERT(edge.IsDone());
+      wire_maker.Add(edge.Edge());
+    }
+  }
+
+  EZY_ASSERT(wire_maker.IsDone());
+  TopoDS_Wire wire = wire_maker.Wire();
+
+  // Create a face from the wire
+  BRepBuilderAPI_MakeFace face_maker(wire);
+  EZY_ASSERT(face_maker.IsDone());
+
+  // auto dbg_face = to_boost(face_maker.Face(), m_pln);
+
+  Sketch_face_shp* ret = new Sketch_face_shp(m_sketch, face_maker.Face());
+  std::swap(node_verts, ret->verts_3d);
+  return ret;
+}

--- a/src/sketch_topo.cpp
+++ b/src/sketch_topo.cpp
@@ -599,7 +599,7 @@ void Sketch_topo::update_faces()
 
   rebuild_dim_classifier_face_cache_();
   m_sketch.m_dims.purge_stale_length_dimensions();
-  m_sketch.sync_permanent_node_annos_();
+  m_sketch.m_node_marks.sync();
   m_sketch.m_dims.refresh_all_length_dimensions();
 
   if (m_sketch.is_current())

--- a/src/sketch_topo.cpp
+++ b/src/sketch_topo.cpp
@@ -76,7 +76,7 @@ void Sketch_topo::snap_placed_node_to_closest_linear_edge_interior_(size_t node_
   double                  best_err = std::numeric_limits<double>::infinity();
   std::optional<gp_Pnt2d> best_proj;
 
-  for (const auto& e : m_sketch.m_edges)
+  for (const auto& e : m_sketch.m_edges.edges())
   {
     if (e.circle_arc)
       continue;
@@ -135,7 +135,7 @@ void Sketch_topo::split_linear_edges_at_node_if_interior(size_t node_idx, Sketch
   while (progress)
   {
     progress = false;
-    for (auto itr = m_sketch.m_edges.begin(); itr != m_sketch.m_edges.end(); ++itr)
+    for (auto itr = m_sketch.m_edges.edges().begin(); itr != m_sketch.m_edges.edges().end(); ++itr)
     {
       if (itr->circle_arc)
         continue;
@@ -166,10 +166,10 @@ void Sketch_topo::split_linear_edges_at_node_if_interior(size_t node_idx, Sketch
         rec->note_prev_linear_edge(itr->node_idx_a, *itr->node_idx_b, itr->node_idx_mid, itr->name);
 
       m_sketch.m_ctx.Remove(itr->shp, false);
-      m_sketch.m_edges.erase(itr);
+      m_sketch.m_edges.edges().erase(itr);
       m_sketch.m_nodes[node_idx].midpoint = false;
-      m_sketch.m_edges.push_back(std::move(edge_a));
-      m_sketch.m_edges.push_back(std::move(edge_b));
+      m_sketch.m_edges.edges().push_back(std::move(edge_a));
+      m_sketch.m_edges.edges().push_back(std::move(edge_b));
 
       progress = true;
       break;
@@ -192,7 +192,7 @@ void Sketch_topo::update_faces()
   // Build adjacency list
   std::unordered_map<size_t, std::vector<std::pair<size_t, const Sketch::Edge*>>> adj_list;
 
-  for (const auto& edge : m_sketch.m_edges)
+  for (const auto& edge : m_sketch.m_edges.edges())
   {
     EZY_ASSERT(edge.node_idx_b.has_value());
 
@@ -227,11 +227,11 @@ void Sketch_topo::update_faces()
   // Any non-arc edge that uses this virtual node as an endpoint should not participate in faces.
   {
     std::unordered_set<size_t> arc_mid_nodes;
-    for (const auto& edge : m_sketch.m_edges)
+    for (const auto& edge : m_sketch.m_edges.edges())
       if (edge.node_idx_arc.has_value())
         arc_mid_nodes.insert(*edge.node_idx_arc);
 
-    for (const auto& edge : m_sketch.m_edges)
+    for (const auto& edge : m_sketch.m_edges.edges())
     {
       // Only consider non-arc edges (straight segments etc.).
       if (edge.circle_arc)
@@ -255,7 +255,7 @@ void Sketch_topo::update_faces()
     std::unordered_set<const Sketch::Edge*> to_exclude;
 
     // Find edges where at least one endpoint has degree 1 (considering only non-excluded edges)
-    for (const auto& edge : m_sketch.m_edges)
+    for (const auto& edge : m_sketch.m_edges.edges())
     {
       if (excluded_edges.count(&edge))
         continue;
@@ -296,7 +296,7 @@ void Sketch_topo::update_faces()
   // A bridge edge connects two cycles and has both endpoints with degree >= 3.
   // We detect this by checking if the edge is the only connection between two cycles.
   std::unordered_set<const Sketch::Edge*> bridge_edges;
-  for (const auto& edge : m_sketch.m_edges)
+  for (const auto& edge : m_sketch.m_edges.edges())
   {
     if (excluded_edges.count(&edge))
       continue;
@@ -409,7 +409,7 @@ void Sketch_topo::update_faces()
 
   // Rebuild adjacency list excluding dangling and bridge edges
   adj_list.clear();
-  for (const auto& edge : m_sketch.m_edges)
+  for (const auto& edge : m_sketch.m_edges.edges())
   {
     if (excluded_edges.count(&edge))
       continue;

--- a/src/sketch_topo.cpp
+++ b/src/sketch_topo.cpp
@@ -598,9 +598,9 @@ void Sketch_topo::update_faces()
   }
 
   rebuild_dim_classifier_face_cache_();
-  m_sketch.purge_stale_length_dimensions_();
+  m_sketch.m_dims.purge_stale_length_dimensions();
   m_sketch.sync_permanent_node_annos_();
-  m_sketch.refresh_all_length_dimensions_();
+  m_sketch.m_dims.refresh_all_length_dimensions();
 
   if (m_sketch.is_current())
     m_sketch.m_view.refresh_active_sketch_grid();

--- a/src/sketch_topo.h
+++ b/src/sketch_topo.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <TopoDS_Face.hxx>
+#include <vector>
+
+#include "utl_types.h"
+
+class Sketch;
+class Sketch_op_recorder;
+
+/// Planar-graph topology for a sketch: face extraction, edge splitting, and face caches.
+class Sketch_topo
+{
+public:
+  explicit Sketch_topo(Sketch& sketch);
+
+  void update_faces();
+  void split_linear_edges_at_node_if_interior(size_t node_idx);
+  void split_linear_edges_at_node_if_interior(size_t node_idx, Sketch_op_recorder& rec);
+  void split_linear_edges_at_node_if_interior(size_t node_idx, Sketch_op_recorder* rec);
+
+  [[nodiscard]] const std::vector<Sketch_face_shp_ptr>& faces() const { return m_faces; }
+  [[nodiscard]] std::vector<Sketch_face_shp_ptr>&       faces() { return m_faces; }
+
+  [[nodiscard]] const std::vector<TopoDS_Face>& dim_classifier_faces() const { return m_dim_classifier_faces; }
+
+  void remove_displayed_faces();
+
+  [[nodiscard]] double plane_pick_snap_radius_world() const;
+
+private:
+  struct Face_edge;
+  using Face_edges = std::vector<Face_edge>;
+
+  void                snap_placed_node_to_closest_linear_edge_interior_(size_t node_idx);
+  bool                is_face_clockwise_(const Face_edges& face) const;
+  Sketch_face_shp_ptr create_face_shape_(const Face_edges& face);
+  void                rebuild_dim_classifier_face_cache_();
+
+  Sketch&                          m_sketch;
+  std::vector<Sketch_face_shp_ptr> m_faces;
+  std::vector<TopoDS_Face>         m_dim_classifier_faces;
+};

--- a/src/utl_types.h
+++ b/src/utl_types.h
@@ -2,31 +2,15 @@
 
 #include <AIS_Shape.hxx>
 #include <Standard_Handle.hxx>
-#include <gp_Pnt.hxx>
 #include <glm/glm.hpp>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "sketch_ais.h"
+
 class TopoDS_Shape;
 class Sketch;
-struct Sketch_AIS_node_mark;
-
-struct Sketch_AIS_edge : public AIS_Shape
-{
-  Sketch_AIS_edge(Sketch& owner, const TopoDS_Shape& shp);
-  Sketch& owner_sketch;
-};
-
-struct Sketch_face_shp : public AIS_Shape
-{
-  Sketch_face_shp(Sketch& owner, const TopoDS_Shape& face);
-
-  Sketch&             owner_sketch;
-  std::vector<gp_Pnt> verts_3d; // Used for extruding the face
-  std::vector<size_t> vert_idxs;
-  std::string         name;
-};
 
 class AIS_InteractiveObject;
 class AIS_InteractiveContext;
@@ -42,7 +26,6 @@ class Geom_Surface;
 class PrsDim_LengthDimension;
 class Graphic3d_Camera;
 class StdSelect_BRepOwner;
-struct Sketch_AIS_node_mark;
 
 using AIS_InteractiveObject_ptr  = opencascade::handle<AIS_InteractiveObject>;
 using AIS_InteractiveContext_ptr = opencascade::handle<AIS_InteractiveContext>;

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -159,7 +159,7 @@ const std::vector<Sketch_face_shp_ptr>& Sketch_access::get_faces(const Sketch& s
 
 const std::list<Sketch::Edge>& Sketch_access::get_edges(const Sketch& sketch)
 {
-  return sketch.m_edges;
+  return sketch.m_edges.edges();
 }
 
 size_t Sketch_access::length_dimension_count(const Sketch& sketch)

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -113,6 +113,7 @@ class Sketch_access
   /// Exact replay of a saved linear edge (with its pre-existing midpoint node index).
   /// Used for regression tests of specific .ezy cases (e.g. bridge + hole topologies).
   static void sketch_json_add_linear_edge_(Sketch& sketch, size_t idx_a, size_t idx_b, std::optional<size_t> idx_mid = std::nullopt);
+  static void set_operation_axis_(Sketch& sketch, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b);
 };
 
 void Sketch_access::add_edge_(Sketch& sketch, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
@@ -231,6 +232,11 @@ inline void Sketch_access::get_originating_face_snp_pts_3d_(Sketch& sketch, std:
 void Sketch_access::sketch_json_add_linear_edge_(Sketch& sketch, size_t idx_a, size_t idx_b, std::optional<size_t> idx_mid)
 {
   sketch.sketch_json_add_linear_edge_(idx_a, idx_b, idx_mid);
+}
+
+void Sketch_access::set_operation_axis_(Sketch& sketch, const gp_Pnt2d& pt_a, const gp_Pnt2d& pt_b)
+{
+  sketch.sketch_json_set_operation_axis_(pt_a, pt_b);
 }
 
 class View_access
@@ -622,6 +628,123 @@ TEST_F(Sketch_test, Undo_two_crossing_edges_via_finalize)
   EXPECT_TRUE(view().undo());
   EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 0)
       << "Undo of the first edge should remove it";
+}
+
+TEST_F(Sketch_test, Undo_extrude_snapshot_keeps_single_sketch)
+{
+  Sketch::Sketch_ptr sk = view().curr_sketch_shared();
+  const size_t sk_id = sk->get_id();
+
+  {
+    Sketch_op_recorder rec(view(), *sk);
+    const std::array<gp_Pnt2d, 4> corners = square_corners(gp_Pnt2d(0.0, 0.0), gp_Pnt2d(10.0, 0.0));
+    Sketch_access::add_edge_(*sk, corners[0], corners[1], rec);
+    Sketch_access::add_edge_(*sk, corners[1], corners[2], rec);
+    Sketch_access::add_edge_(*sk, corners[2], corners[3], rec);
+    Sketch_access::add_edge_(*sk, corners[3], corners[0], rec);
+    rec.commit();
+  }
+
+  EXPECT_EQ(sk->edge_count(), 4u);
+  EXPECT_EQ(view().get_sketches().size(), 1u);
+
+  const nlohmann::json pre_extrude = nlohmann::json::parse(view().to_json());
+  ASSERT_EQ(pre_extrude["sketches"].size(), 1u);
+
+  view().push_undo_snapshot();
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_EQ(view().get_sketches().size(), 1u) << "JSON undo after extrude must not add a sketch";
+
+  Sketch::Sketch_ptr restored;
+  for (const Sketch::Sketch_ptr& s : view().get_sketches())
+    if (s->get_id() == sk_id)
+      restored = s;
+
+  ASSERT_TRUE(restored) << "Restored sketch should keep the same stable id";
+  EXPECT_EQ(restored->edge_count(), 4u);
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_EQ(restored->edge_count(), 0u) << "Second undo should remove the square from the same sketch";
+}
+
+TEST_F(Sketch_test, Undo_delta_resolves_by_sketch_id_when_names_duplicate)
+{
+  Sketch::Sketch_ptr sk1 = view().curr_sketch_shared();
+  Sketch::Sketch_ptr sk2 = std::make_shared<Sketch>("Other", view(), gp_Pln(gp::Origin(), gp::DX()));
+  view().get_sketches().push_back(sk2);
+  sk1->set_name("Dup");
+  sk2->set_name("Dup");
+
+  {
+    Sketch_op_recorder rec(view(), *sk2);
+    Sketch_access::add_edge_(*sk2, gp_Pnt2d(0.0, 0.0), gp_Pnt2d(5.0, 0.0), rec);
+    rec.commit();
+  }
+
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(*sk1), 0u);
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(*sk2), 1u);
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(*sk1), 0u);
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(*sk2), 0u)
+      << "Undo must target the sketch that was edited, not the first same-named sketch";
+}
+
+TEST_F(Sketch_test, Undo_circle_axis_then_revolve_snapshot_three_undos)
+{
+  Sketch::Sketch_ptr sk = view().curr_sketch_shared();
+  const size_t         sk_id = sk->get_id();
+
+  {
+    Sketch_op_recorder rec(view(), *sk);
+    const gp_Pnt2d                 center(0.0, 0.0);
+    const gp_Pnt2d                 edge_pt(5.0, 0.0);
+    const std::array<gp_Pnt2d, 4> points = xy_stencil_pnts(center, edge_pt);
+    Sketch_access::add_arc_circle_(*sk, points[0], points[2], points[1], rec);
+    Sketch_access::add_arc_circle_(*sk, points[0], points[3], points[1], rec);
+    rec.commit();
+  }
+
+  EXPECT_EQ(Sketch_access::get_arc_internal_edge_count(*sk), 4u);
+
+  {
+    Sketch_op_recorder rec(view(), *sk);
+    const gp_Pnt2d axis_a(0.0, -10.0);
+    const gp_Pnt2d axis_b(10.0, -10.0);
+    Sketch_access::set_operation_axis_(*sk, axis_a, axis_b);
+    rec.note_curr_operation_axis(axis_a, axis_b);
+    rec.commit();
+  }
+  EXPECT_TRUE(sk->has_operation_axis());
+
+  view().push_undo_snapshot();
+
+  auto find_sk = [&]() -> Sketch::Sketch_ptr
+  {
+    for (const Sketch::Sketch_ptr& s : view().get_sketches())
+      if (s->get_id() == sk_id)
+        return s;
+    return nullptr;
+  };
+
+  EXPECT_TRUE(view().undo());
+  sk = find_sk();
+  ASSERT_TRUE(sk);
+  EXPECT_EQ(view().get_sketches().size(), 1u);
+  EXPECT_TRUE(sk->has_operation_axis());
+  EXPECT_EQ(Sketch_access::get_arc_internal_edge_count(*sk), 4u);
+
+  EXPECT_TRUE(view().undo());
+  sk = find_sk();
+  ASSERT_TRUE(sk);
+  EXPECT_FALSE(sk->has_operation_axis());
+  EXPECT_EQ(Sketch_access::get_arc_internal_edge_count(*sk), 4u);
+
+  EXPECT_TRUE(view().undo());
+  sk = find_sk();
+  ASSERT_TRUE(sk);
+  EXPECT_EQ(Sketch_access::get_arc_internal_edge_count(*sk), 0u);
 }
 
 // Test T-junction case (one edge's endpoint touches the interior of another).

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -164,22 +164,22 @@ const std::list<Sketch::Edge>& Sketch_access::get_edges(const Sketch& sketch)
 
 size_t Sketch_access::length_dimension_count(const Sketch& sketch)
 {
-  return sketch.m_length_dimensions.size();
+  return sketch.m_dims.dimensions().size();
 }
 
 size_t Sketch_access::length_dimension_node_lo(const Sketch& sketch, size_t index)
 {
-  return sketch.m_length_dimensions[index].node_idx_lo;
+  return sketch.m_dims.dimensions()[index].node_idx_lo;
 }
 
 size_t Sketch_access::length_dimension_node_hi(const Sketch& sketch, size_t index)
 {
-  return sketch.m_length_dimensions[index].node_idx_hi;
+  return sketch.m_dims.dimensions()[index].node_idx_hi;
 }
 
 void Sketch_access::set_entered_edge_len(Sketch& sketch, const gp_Dir2d& dir, double len)
 {
-  sketch.m_entered_edge_len = Sketch::Edge_len{dir, len};
+  sketch.m_dims.entered_edge_len() = Sketch_dims::Edge_len{dir, len};
 }
 
 void Sketch_access::update_faces_(Sketch& sketch)

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -102,8 +102,13 @@ class Sketch_access
   static void get_originating_face_snp_pts_3d_(Sketch& sketch, std::vector<gp_Pnt>& out);
 
   static const std::vector<Sketch_face_shp_ptr>& get_faces(const Sketch& sketch);
+  static const std::list<Sketch::Edge>&        get_edges(const Sketch& sketch);
   static size_t                                 get_linear_edge_count(const Sketch& sketch);
   static size_t                                 get_arc_internal_edge_count(const Sketch& sketch);
+  static size_t                                 length_dimension_count(const Sketch& sketch);
+  static size_t                                 length_dimension_node_lo(const Sketch& sketch, size_t index);
+  static size_t                                 length_dimension_node_hi(const Sketch& sketch, size_t index);
+  static void                                   set_entered_edge_len(Sketch& sketch, const gp_Dir2d& dir, double len);
 
   /// Exact replay of a saved linear edge (with its pre-existing midpoint node index).
   /// Used for regression tests of specific .ezy cases (e.g. bridge + hole topologies).
@@ -128,7 +133,7 @@ void Sketch_access::add_edge_raw_(Sketch& sketch, const gp_Pnt2d& pt_a, const gp
 size_t Sketch_access::get_linear_edge_count(const Sketch& sketch)
 {
   size_t count = 0;
-  for (const auto& edge : sketch.m_edges)
+  for (const auto& edge : Sketch_access::get_edges(sketch))
   {
     if (edge.node_idx_b.has_value() && !edge.circle_arc)
       ++count;
@@ -139,7 +144,7 @@ size_t Sketch_access::get_linear_edge_count(const Sketch& sketch)
 size_t Sketch_access::get_arc_internal_edge_count(const Sketch& sketch)
 {
   size_t count = 0;
-  for (const auto& edge : sketch.m_edges)
+  for (const auto& edge : Sketch_access::get_edges(sketch))
   {
     if (edge.circle_arc)
       ++count;
@@ -150,6 +155,31 @@ size_t Sketch_access::get_arc_internal_edge_count(const Sketch& sketch)
 const std::vector<Sketch_face_shp_ptr>& Sketch_access::get_faces(const Sketch& sketch)
 {
   return sketch.m_faces;
+}
+
+const std::list<Sketch::Edge>& Sketch_access::get_edges(const Sketch& sketch)
+{
+  return sketch.m_edges;
+}
+
+size_t Sketch_access::length_dimension_count(const Sketch& sketch)
+{
+  return sketch.m_length_dimensions.size();
+}
+
+size_t Sketch_access::length_dimension_node_lo(const Sketch& sketch, size_t index)
+{
+  return sketch.m_length_dimensions[index].node_idx_lo;
+}
+
+size_t Sketch_access::length_dimension_node_hi(const Sketch& sketch, size_t index)
+{
+  return sketch.m_length_dimensions[index].node_idx_hi;
+}
+
+void Sketch_access::set_entered_edge_len(Sketch& sketch, const gp_Dir2d& dir, double len)
+{
+  sketch.m_entered_edge_len = Sketch::Edge_len{dir, len};
 }
 
 void Sketch_access::update_faces_(Sketch& sketch)
@@ -329,7 +359,7 @@ TEST_F(Sketch_test, AddLinearEdge_MidpointOption)
 
   // Check the (only) edge has no mid
   bool has_mid = false;
-  for (const auto& e : sketch.m_edges) {
+  for (const auto& e : Sketch_access::get_edges(sketch)) {
     if (e.node_idx_mid.has_value()) has_mid = true;
   }
   EXPECT_FALSE(has_mid);
@@ -346,7 +376,7 @@ TEST_F(Sketch_test, AddLinearEdge_MidpointOption)
   EXPECT_EQ(sketch.get_nodes().size(), nodes_after_first + 3);
 
   // Find the second edge and verify it has a mid
-  auto it = sketch.m_edges.begin();
+  auto it = Sketch_access::get_edges(sketch).begin();
   std::advance(it, 1);  // second edge
   EXPECT_TRUE(it->node_idx_mid.has_value());
   const gp_Pnt2d& mid = sketch.get_nodes()[*it->node_idx_mid];
@@ -417,7 +447,7 @@ TEST_F(Sketch_test, AddEdgeFromCenter_SecondClickFullSpan)
   EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 1);
 
   bool found = false;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
   {
     if (!e.node_idx_b.has_value() || e.circle_arc)
       continue;
@@ -450,13 +480,13 @@ TEST_F(Sketch_test, AddEdgeFromCenter_DimensionUsesFullLength)
   sketch.add_sketch_pt(ScreenCoords(dvec2(0.0, 0.0)));
   sketch.sketch_pt_move(ScreenCoords(dvec2(1.0, 0.0)));
 
-  sketch.m_entered_edge_len = Sketch::Edge_len{gp_Dir2d(1.0, 0.0), 10.0};
+  Sketch_access::set_entered_edge_len(sketch, gp_Dir2d(1.0, 0.0), 10.0);
   sketch.on_enter();
 
   EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 1);
 
   bool found = false;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
   {
     if (!e.node_idx_b.has_value() || e.circle_arc)
       continue;
@@ -1345,7 +1375,7 @@ TEST_F(Sketch_test, UpdateFaces_DanglingEdgesArcMidNode)
   // The dangling edges (especially the vertical one attached to arc_mid) should still exist
   // in the sketch, but they must not affect face detection.
   size_t total_edges = 0;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
     if (e.node_idx_b.has_value())
       ++total_edges;
 
@@ -1590,9 +1620,7 @@ TEST_F(Sketch_test, JsonSerializationDeserialization)
 
   // Add edges to create a rectangle-like shape
   for (size_t i = 0; i < points.size() - 1; i += 2)
-  {
     Sketch_access::add_edge_(sketch, points[i], points[i + 1]);
-  }
 
   // Serialize to JSON
   nlohmann::json json_data = Sketch_json::to_json(sketch, view().asset_store());
@@ -1612,6 +1640,7 @@ TEST_F(Sketch_test, JsonSerializationDeserialization)
   for (size_t i = 0; i < sketch.get_nodes().size(); ++i)
     if (!sketch.get_nodes()[i].deleted)
       ++live_nodes;
+
   EXPECT_EQ(json_data["nodes"].size(), live_nodes);
   EXPECT_EQ(json_data["edges"].size(), 3);      // Should have 3 edges
   EXPECT_EQ(json_data["arc_edges"].size(), 0);  // No arc edges
@@ -1625,11 +1654,10 @@ TEST_F(Sketch_test, JsonSerializationDeserialization)
 
   // Count edges in deserialized sketch
   size_t edge_count = 0;
-  for (const auto& edge : deserialized_sketch->m_edges)
-  {
+  for (const auto& edge : Sketch_access::get_edges(*deserialized_sketch))
     if (edge.node_idx_b.has_value())
       edge_count++;
-  }
+  
   EXPECT_EQ(edge_count, 3);  // Should have 3 edges
 }
 
@@ -1687,14 +1715,14 @@ TEST_F(Sketch_test, JsonSerializationDifferentEdgeCounts)
   std::shared_ptr<Sketch> deserialized2 = Sketch_json::from_json(view(), json2);
 
   size_t edge_count1 = 0;
-  for (const auto& edge : deserialized1->m_edges)
+  for (const auto& edge : Sketch_access::get_edges(*deserialized1))
   {
     if (edge.node_idx_b.has_value())
       edge_count1++;
   }
 
   size_t edge_count2 = 0;
-  for (const auto& edge : deserialized2->m_edges)
+  for (const auto& edge : Sketch_access::get_edges(*deserialized2))
   {
     if (edge.node_idx_b.has_value())
       edge_count2++;
@@ -1725,9 +1753,9 @@ TEST_F(Sketch_test, JsonSerializationWithDimensions)
 
   std::shared_ptr<Sketch> deserialized_sketch = Sketch_json::from_json(view(), json_data);
 
-  ASSERT_EQ(deserialized_sketch->m_length_dimensions.size(), 1u);
-  EXPECT_EQ(deserialized_sketch->m_length_dimensions[0].node_idx_lo, 0u);
-  EXPECT_EQ(deserialized_sketch->m_length_dimensions[0].node_idx_hi, 1u);
+  ASSERT_EQ(Sketch_access::length_dimension_count(*deserialized_sketch), 1u);
+  EXPECT_EQ(Sketch_access::length_dimension_node_lo(*deserialized_sketch, 0), 0u);
+  EXPECT_EQ(Sketch_access::length_dimension_node_hi(*deserialized_sketch, 0), 1u);
 }
 
 // Legacy indexed edges used a 4th boolean "dim" field; migrate to length_dimensions (node pair).
@@ -1742,9 +1770,9 @@ TEST_F(Sketch_test, JsonLegacyIndexedEdgeDimFlagMigratesToLengthDimensions)
   j.erase("length_dimensions");
 
   std::shared_ptr<Sketch> loaded = Sketch_json::from_json(view(), j);
-  ASSERT_EQ(loaded->m_length_dimensions.size(), 1u);
-  EXPECT_EQ(loaded->m_length_dimensions[0].node_idx_lo, 0u);
-  EXPECT_EQ(loaded->m_length_dimensions[0].node_idx_hi, 1u);
+  ASSERT_EQ(Sketch_access::length_dimension_count(*loaded), 1u);
+  EXPECT_EQ(Sketch_access::length_dimension_node_lo(*loaded, 0), 0u);
+  EXPECT_EQ(Sketch_access::length_dimension_node_hi(*loaded, 0), 1u);
 }
 
 TEST_F(Sketch_test, EzyDocumentJsonIncludesFormatVersion)
@@ -1877,7 +1905,7 @@ TEST_F(Sketch_test, UpdateFaces_BridgeEdgeRemoval)
 
   // Verify all edges still exist in the sketch (bridge edge is excluded from face detection but still exists)
   size_t total_edges = 0;
-  for (const auto& edge : sketch.m_edges)
+  for (const auto& edge : Sketch_access::get_edges(sketch))
   {
     if (edge.node_idx_b.has_value())
       total_edges++;
@@ -1886,7 +1914,7 @@ TEST_F(Sketch_test, UpdateFaces_BridgeEdgeRemoval)
 
   // Verify the bridge edge exists in the sketch
   bool found_bridge_edge = false;
-  for (const auto& edge : sketch.m_edges)
+  for (const auto& edge : Sketch_access::get_edges(sketch))
   {
     if (!edge.node_idx_b.has_value())
       continue;
@@ -2144,7 +2172,7 @@ TEST_F(Sketch_test, UpdateFaces_DanglingEdgesRemoval)
   // Verify all edges are still in the sketch (they're just excluded from face detection)
   // The edges should still exist in m_edges, but not participate in face formation
   size_t total_edges = 0;
-  for (const auto& edge : sketch.m_edges)
+  for (const auto& edge : Sketch_access::get_edges(sketch))
   {
     if (edge.node_idx_b.has_value())
       total_edges++;
@@ -2247,7 +2275,7 @@ TEST_F(Sketch_test, MirrorSelectedEdges_SimpleStraightEdge)
 
   // Find the shp of the edge we just added (last one with b node)
   AIS_Shape_ptr edge_to_mirror;
-  for (auto rit = sketch.m_edges.rbegin(); rit != sketch.m_edges.rend(); ++rit)
+  for (auto rit = Sketch_access::get_edges(sketch).rbegin(); rit != Sketch_access::get_edges(sketch).rend(); ++rit)
   {
     if (rit->node_idx_b.has_value())
     {
@@ -2265,7 +2293,7 @@ TEST_F(Sketch_test, MirrorSelectedEdges_SimpleStraightEdge)
   // Count drawable edges before
   auto count_drawable_edges = [&](const Sketch& s) -> size_t {
     size_t n = 0;
-    for (const auto& e : s.m_edges)
+    for (const auto& e : Sketch_access::get_edges(s))
       if (e.node_idx_b.has_value()) ++n;
     return n;
   };
@@ -2280,7 +2308,7 @@ TEST_F(Sketch_test, MirrorSelectedEdges_SimpleStraightEdge)
 
   // Verify a mirrored edge now exists at y = -2 with matching x coords
   bool found_mirrored = false;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
   {
     if (!e.node_idx_b.has_value()) continue;
     const gp_Pnt2d& na = sketch.get_nodes()[e.node_idx_a];
@@ -2316,7 +2344,7 @@ TEST_F(Sketch_test, MirrorSelectedEdges_VerticalAxis)
 
   // Select it
   AIS_Shape_ptr shp;
-  for (auto rit = sketch.m_edges.rbegin(); rit != sketch.m_edges.rend(); ++rit)
+  for (auto rit = Sketch_access::get_edges(sketch).rbegin(); rit != Sketch_access::get_edges(sketch).rend(); ++rit)
   {
     if (rit->node_idx_b.has_value()) { shp = rit->shp; break; }
   }
@@ -2327,17 +2355,17 @@ TEST_F(Sketch_test, MirrorSelectedEdges_VerticalAxis)
   cctx.AddOrRemoveSelected(shp, true);
 
   size_t before = 0;
-  for (const auto& e : sketch.m_edges) if (e.node_idx_b.has_value()) ++before;
+  for (const auto& e : Sketch_access::get_edges(sketch)) if (e.node_idx_b.has_value()) ++before;
 
   sketch.mirror_selected_edges();
 
   size_t after = 0;
-  for (const auto& e : sketch.m_edges) if (e.node_idx_b.has_value()) ++after;
+  for (const auto& e : Sketch_access::get_edges(sketch)) if (e.node_idx_b.has_value()) ++after;
   EXPECT_EQ(after, before + 1);
 
   // Expect mirrored edge at x=-2
   bool found = false;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
   {
     if (!e.node_idx_b.has_value()) continue;
     const gp_Pnt2d& na = sketch.get_nodes()[e.node_idx_a];
@@ -2375,7 +2403,7 @@ TEST_F(Sketch_test, MirrorSelectedEdges_Arc)
 
   // For arcs, the shp is shared; select the shp of one of the arc edges
   AIS_Shape_ptr arc_shp;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
   {
     if (e.circle_arc)
     {
@@ -2390,19 +2418,19 @@ TEST_F(Sketch_test, MirrorSelectedEdges_Arc)
   cctx.AddOrRemoveSelected(arc_shp, true);
 
   size_t before = 0;
-  for (const auto& e : sketch.m_edges) if (e.node_idx_b.has_value()) ++before;
+  for (const auto& e : Sketch_access::get_edges(sketch)) if (e.node_idx_b.has_value()) ++before;
 
   sketch.mirror_selected_edges();
 
   // Mirroring an arc pair should add another arc pair below
   size_t after = 0;
-  for (const auto& e : sketch.m_edges) if (e.node_idx_b.has_value()) ++after;
+  for (const auto& e : Sketch_access::get_edges(sketch)) if (e.node_idx_b.has_value()) ++after;
   // Expect +2 edges for the mirrored arc (the pair)
   EXPECT_EQ(after, before + 2) << "Mirroring an arc should add two new arc edges";
 
   // Spot-check that a mirrored point exists below the axis (e.g. around y=-1 or so)
   bool found_symmetric = false;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
   {
     if (!e.node_idx_b.has_value() || !e.circle_arc) continue;
     const gp_Pnt2d& pa = sketch.get_nodes()[e.node_idx_a];
@@ -2461,7 +2489,7 @@ TEST_F(Sketch_test, RevolveSelected_SimpleEdgeProfile)
 
   // Select the edge shp (same mechanism used by mirror tests and the real UI selection)
   AIS_Shape_ptr edge_shp;
-  for (auto rit = sketch.m_edges.rbegin(); rit != sketch.m_edges.rend(); ++rit)
+  for (auto rit = Sketch_access::get_edges(sketch).rbegin(); rit != Sketch_access::get_edges(sketch).rend(); ++rit)
   {
     if (rit->node_idx_b.has_value())
     {
@@ -2565,7 +2593,7 @@ TEST_F(Sketch_test, RevolveSelected_ClosedEdgeProfile)
   cctx.ClearSelected(true);
 
   size_t selected_count = 0;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
   {
     if (e.node_idx_b.has_value())
     {
@@ -2595,7 +2623,7 @@ TEST_F(Sketch_test, RevolveSelected_ClosedEdgeProfile)
   bld.MakeCompound(profile);
 
   // Collect exactly the profile edges we added for this test
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
   {
     if (e.node_idx_b.has_value())
     {
@@ -2668,7 +2696,7 @@ TEST_F(Sketch_test, SplitEdge_HasMidpoints)
   // Count initial nodes and edges
   size_t initial_node_count = sketch.get_nodes().size();
   size_t initial_edge_count = 0;
-  for (const auto& edge : sketch.m_edges)
+  for (const auto& edge : Sketch_access::get_edges(sketch))
     if (edge.node_idx_b.has_value())
       initial_edge_count++;
 
@@ -2677,7 +2705,7 @@ TEST_F(Sketch_test, SplitEdge_HasMidpoints)
 
   // Find the midpoint of the initial edge
   std::optional<size_t> initial_midpoint_idx;
-  for (const auto& edge : sketch.m_edges)
+  for (const auto& edge : Sketch_access::get_edges(sketch))
   {
     if (edge.node_idx_b.has_value() && edge.node_idx_mid.has_value())
     {
@@ -2711,7 +2739,7 @@ TEST_F(Sketch_test, SplitEdge_HasMidpoints)
 
   // Count edges after splitting
   size_t final_edge_count = 0;
-  for (const auto& edge : sketch.m_edges)
+  for (const auto& edge : Sketch_access::get_edges(sketch))
     if (edge.node_idx_b.has_value())
       final_edge_count++;
 
@@ -2720,7 +2748,7 @@ TEST_F(Sketch_test, SplitEdge_HasMidpoints)
 
   // Verify that both split edges have midpoints
   std::vector<std::optional<size_t>> split_edge_midpoints;
-  for (const auto& edge : sketch.m_edges)
+  for (const auto& edge : Sketch_access::get_edges(sketch))
   {
     if (!edge.node_idx_b.has_value())
       continue;
@@ -2788,7 +2816,7 @@ TEST_F(Sketch_test, AddNode_splits_linear_edge_interior)
 
   auto count_real_edges = [](const Sketch& s) {
     size_t n = 0;
-    for (const auto& e : s.m_edges)
+    for (const auto& e : Sketch_access::get_edges(s))
       if (e.node_idx_b.has_value())
         ++n;
     return n;
@@ -2807,7 +2835,7 @@ TEST_F(Sketch_test, AddNode_splits_linear_edge_interior)
 
   bool found_0_7 = false;
   bool found_7_20 = false;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
   {
     if (!e.node_idx_b.has_value() || e.circle_arc)
       continue;
@@ -2857,7 +2885,7 @@ TEST_F(Sketch_test, AddNode_off_edge_adds_node_only)
   sketch.add_sketch_pt(away);
 
   size_t edge_count = 0;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
     if (e.node_idx_b.has_value())
       ++edge_count;
   EXPECT_EQ(edge_count, 1u);
@@ -2891,7 +2919,7 @@ TEST_F(Sketch_test, AddNode_near_edge_snaps_onto_segment_and_splits)
   sketch.add_sketch_pt(near_edge);
 
   size_t edge_count = 0;
-  for (const auto& e : sketch.m_edges)
+  for (const auto& e : Sketch_access::get_edges(sketch))
     if (e.node_idx_b.has_value())
       ++edge_count;
   EXPECT_EQ(edge_count, 2u) << "Near-miss pick should snap to segment and replace one edge with two";

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -154,7 +154,7 @@ size_t Sketch_access::get_arc_internal_edge_count(const Sketch& sketch)
 
 const std::vector<Sketch_face_shp_ptr>& Sketch_access::get_faces(const Sketch& sketch)
 {
-  return sketch.m_faces;
+  return sketch.m_topo.faces();
 }
 
 const std::list<Sketch::Edge>& Sketch_access::get_edges(const Sketch& sketch)


### PR DESCRIPTION
## Summary

- Split `sketch.cpp` (~3000 lines) into focused modules: `Sketch_edges`, `Sketch_topo`, `Sketch_dims`, `Sketch_tools`, `Sketch_node_marks`, and `sketch_ais`.
- `Sketch` now owns sub-objects and delegates: interactive drawing to `Sketch_tools`, face/split logic to `Sketch_topo`, persistent edges to `Sketch_edges`, dimensions to `Sketch_dims`.
- Added read-only edge visitors (`for_each_linear` / `for_each_arc`) for JSON and delta paths.
- Moved AIS sketch types into `sketch_ais.h`.
- Light polish: display and operations moved to `sketch_display.cpp` and `sketch_operations.cpp` (no new wrapper classes; state stays on `Sketch`). `sketch.cpp` is ~400 lines.
- No intended user-visible behavior change; structural cleanup after `Sketch_underlay` (#161).

Closes #163.

## Files changed

- `src/sketch.cpp`, `src/sketch.h` - slim coordinator (~400 lines)
- `src/sketch_edge.*`, `src/sketch_edges.*` - edge type and persistent list
- `src/sketch_topo.*` - face extraction and interior splits
- `src/sketch_dims.*` - length dimensions and typed input
- `src/sketch_tools.*` - interactive draw session
- `src/sketch_node_marks.*`, `src/sketch_ais.*` - node marks and AIS helpers
- `src/sketch_display.cpp` - visibility, edge style, sketch switching, list hover
- `src/sketch_operations.cpp` - operation axis, mirror, revolve
- `src/sketch_json.cpp`, `src/sketch_delta.cpp`, `src/utl_types.h`
- `tests/sketch_tests.cpp`

## Test plan

- [x] Build `EzyCad_lib` and `EzyCad_tests` (Release).
- [x] Run `EzyCad_tests --gtest_filter=Sketch_test.*` - 53/53 passed.
- [x] Manual smoke: add line, square, circle, arc; undo/redo; mirror/revolve with operation axis.
- [x] No user-doc updates required (internal refactor).

## Notes

- `Sketch_tools::finalize_edges_` stays in tools (session commit), not `Sketch_topo` (graph primitives).
- Display/operations split uses dedicated `.cpp` files only (lighter than wrapper classes).
- Follow-up: deduplicate batch edge commit with `Sketch_edges::add_edge_impl_`.
