### PR TITLE
Collapse repeated Log window messages with repeat count

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2669,18 +2669,49 @@ void GUI::message_status_window_()
 }
 
 // Log window implementation
+namespace
+{
+
+std::string format_log_line(const std::string& base, size_t repeat_count)
+{
+  if (repeat_count <= 1)
+    return base;
+  return base + " #" + std::to_string(repeat_count);
+}
+
+void append_log_line(std::vector<char>& buffer, const std::string& line)
+{
+  if (buffer.size() > 1)
+  {
+    buffer.pop_back(); // trailing '\0'
+    buffer.push_back('\n');
+  }
+  else if (!buffer.empty())
+    buffer.pop_back();
+
+  buffer.insert(buffer.end(), line.begin(), line.end());
+  buffer.push_back('\0');
+}
+
+} // namespace
+
 void GUI::log_message(const std::string& message)
 {
-  if (m_log_buffer.size() > 1)
+  if (!m_log_last_line_base.empty() && message == m_log_last_line_base)
   {
-    m_log_buffer.pop_back(); // trailing '\0'
-    m_log_buffer.push_back('\n');
+    ++m_log_repeat_count;
+    const std::string line = format_log_line(m_log_last_line_base, m_log_repeat_count);
+    m_log_buffer.resize(m_log_last_line_start);
+    m_log_buffer.insert(m_log_buffer.end(), line.begin(), line.end());
+    m_log_buffer.push_back('\0');
+    m_log_scroll_to_bottom = true;
+    return;
   }
-  else if (!m_log_buffer.empty())
-    m_log_buffer.pop_back();
 
-  m_log_buffer.insert(m_log_buffer.end(), message.begin(), message.end());
-  m_log_buffer.push_back('\0');
+  append_log_line(m_log_buffer, message);
+  m_log_last_line_base   = message;
+  m_log_last_line_start  = m_log_buffer.size() - message.size() - 1;
+  m_log_repeat_count     = 1;
   m_log_scroll_to_bottom = true;
 }
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -492,6 +492,9 @@ private:
   std::vector<char> m_log_buffer{'\0'};
   bool              m_log_scroll_to_bottom = false; // Auto-scroll log to bottom on new lines (like Lua console)
   bool              m_log_window_visible   = true;  // Control log window visibility
+  std::string       m_log_last_line_base;           // Dedup: base text of the trailing log line
+  size_t            m_log_last_line_start = 0;      // Dedup: buffer offset where trailing line begins
+  size_t            m_log_repeat_count   = 0;       // Dedup: consecutive repeats of m_log_last_line_base
 
   // Stream redirection
   std::streambuf* m_original_cout_buf = nullptr; // Original stdout buffer


### PR DESCRIPTION
## Summary
- When the same log line is emitted repeatedly (e.g. `Settings: saved.` during pane toggles), update the trailing Log window line with a repeat counter (`#2`, `#3`, ...) instead of appending duplicate lines.
- Applies to all `GUI::log_message` traffic, including settings callbacks and stdout/stderr routed through `Log_strm`.

## Test plan
- [x] Build EzyCad (Debug or RelWithDebInfo).
- [x] Open View > Log.
- [x] Toggle UI options that trigger repeated settings saves; confirm one line updates as `Settings: saved. #n`.
- [x] Perform a different logged action; confirm a new line appears and repeat counting resets.
- [x] Confirm Lua/Python console output and one-off startup messages still log normally.
