### PR TITLE
Fix sketch face walk arrival tangent on arcs (circle + chord)

### DIFF
--- a/agents/drafts/issues/active/gh-184-sketch-face-walk-incoming-arc-tangent.md
+++ b/agents/drafts/issues/active/gh-184-sketch-face-walk-incoming-arc-tangent.md
@@ -1,0 +1,66 @@
+# Sketch face walk uses start-of-arc tangent as arrival direction
+
+---
+github_issue: 184
+status: active
+paired_draft: ../../prs/active/gh-185-sketch-face-walk-incoming-arc-tangent.md
+---
+
+**Suggested labels:** `bug`, `sketch`, `topology`
+
+**Opened on GitHub:** https://github.com/trailcode/EzyCad/issues/184
+
+## Title (GitHub)
+
+Sketch face walk uses start-of-arc tangent as arrival direction (circle + chord drops faces)
+
+## Body (GitHub)
+
+### Summary
+
+Face extraction in `Sketch_topo::update_faces_` treated `sketch_edge_outgoing_dir_2d` (tangent at the **start** of the traversed edge) as the arrival direction at the current node. On arcs those tangents differ, so the leftmost-turn rule can pick the wrong next edge and drop faces. Reproduced with a full circle split into arcs plus a chord (e.g. `project.ezy`: circle + chord `4->3`).
+
+### Problem
+
+- At chord endpoints the walker arrives on an arc; start and end tangents are not the same.
+- Using the start tangent as `incoming_dir` mis-ranks candidate outgoing edges.
+- Expected: two faces (small circular segment + large remainder). Wrong tangent can yield missing/incorrect faces.
+- Straight edges were unaffected (chord direction is constant).
+
+### Implemented scope
+
+**Code changes:**
+
+- `src/sketch_edge.h` / `src/sketch_edge.cpp` — add `sketch_edge_incoming_dir_2d`
+- `src/sketch_topo.cpp` — use incoming dir for face-walk turn selection
+- `tests/sketch_tests.cpp` — `UpdateFaces_CircleWithChord_IncomingArcTangent` (+ Geometry Watch debug vars)
+- `tools/ezycad_graphical_debugging.xml`, `utl_geom*` — `to_boost_ls`, Ring registration for polygons
+
+**Documentation:**
+
+- `src/doc/sketch.md`, `src/doc/utility.md` — API / helper notes
+
+### Acceptance criteria
+
+- [x] Face walk uses arrival tangent at the current node for arcs (`sketch_edge_incoming_dir_2d`).
+- [x] Regression test: circle of four arcs + chord produces two faces with correct areas.
+- [x] `EzyCad_tests` filter `Sketch_test.UpdateFaces_CircleWithChord_IncomingArcTangent` passes.
+
+### Files touched
+
+- `src/sketch_edge.cpp`, `src/sketch_edge.h`, `src/sketch_topo.cpp`
+- `src/utl_geom.cpp`, `src/utl_geom.h`, `src/utl_geom_boost.inl`
+- `src/doc/sketch.md`, `src/doc/utility.md`
+- `tests/sketch_tests.cpp`
+- `tools/ezycad_graphical_debugging.xml`
+- `agents/drafts/issues/active/gh-184-sketch-face-walk-incoming-arc-tangent.md` (this draft)
+
+### Related
+
+- PR: https://github.com/trailcode/EzyCad/pull/185
+- Follow-up to #166; distinct from #165
+
+### Test plan
+
+- [x] `EzyCad_tests --gtest_filter=Sketch_test.UpdateFaces_CircleWithChord_IncomingArcTangent`
+- [ ] Manual: circle + chord sketch shows both faces

--- a/agents/drafts/prs/active/gh-185-sketch-face-walk-incoming-arc-tangent.md
+++ b/agents/drafts/prs/active/gh-185-sketch-face-walk-incoming-arc-tangent.md
@@ -1,0 +1,47 @@
+# PR - Fix sketch face walk arrival tangent on arcs
+
+---
+github_pr: 185
+status: active
+paired_draft: ../../issues/active/gh-184-sketch-face-walk-incoming-arc-tangent.md
+---
+
+**Opened on GitHub:** https://github.com/trailcode/EzyCad/pull/185
+
+## Title
+
+Fix sketch face walk arrival tangent on arcs (circle + chord)
+
+## Summary
+
+- Face walk used `sketch_edge_outgoing_dir_2d` (tangent at edge **start**) as the arrival direction at the current node. On arcs that is wrong; leftmost-turn selection can drop faces (circle + chord).
+- Add `sketch_edge_incoming_dir_2d` and use it for `incoming_dir` in `Sketch_topo::update_faces_`.
+- Regression test `UpdateFaces_CircleWithChord_IncomingArcTangent`.
+- Graphical Debugging: `to_boost_ls`, `segment_2d` / `ring_2d` as Ring, `tools/ezycad_graphical_debugging.xml` (https://github.com/awulkiew/graphical-debugging).
+
+## Files Changed
+
+- `src/sketch_edge.cpp`, `src/sketch_edge.h`, `src/sketch_topo.cpp`
+- `src/utl_geom.cpp`, `src/utl_geom.h`, `src/utl_geom_boost.inl`
+- `src/doc/sketch.md`, `src/doc/utility.md`
+- `tests/sketch_tests.cpp`
+- `tools/ezycad_graphical_debugging.xml`
+- `agents/drafts/issues/active/gh-184-sketch-face-walk-incoming-arc-tangent.md`
+- `agents/drafts/prs/active/gh-185-sketch-face-walk-incoming-arc-tangent.md`
+
+## Related
+
+- Issue: https://github.com/trailcode/EzyCad/issues/184
+- Follow-up to #166; does not address #165
+
+## Test Plan
+
+- [x] Build `EzyCad_tests` (Debug)
+- [x] `EzyCad_tests --gtest_filter=Sketch_test.UpdateFaces_CircleWithChord_IncomingArcTangent`
+- [ ] Manual: circle + chord sketch confirms both faces
+- [ ] Optional: Geometry Watch with `tools/ezycad_graphical_debugging.xml`
+
+## Post-merge
+
+- [ ] Archive issue/PR drafts
+- [ ] Consider `CHANGELOG.md` `[Unreleased]` entry if not already present

--- a/src/doc/sketch.md
+++ b/src/doc/sketch.md
@@ -197,7 +197,7 @@ Prefer these visitors in JSON/delta/topo code over iterating `std::list<Sketch_e
 | File | Responsibility |
 | --- | --- |
 | `sketch.h` / `sketch.cpp` | Coordinator: input routing, edge shape updates, snap aggregation, inspector labels, static options |
-| `sketch_edge.h` | `Sketch_edge` struct; `sketch_edge_is_linear` / `sketch_edge_is_arc` |
+| `sketch_edge.h` | `Sketch_edge` struct; `sketch_edge_is_linear` / `sketch_edge_is_arc`; `sketch_edge_outgoing_dir_2d` / `sketch_edge_incoming_dir_2d` |
 | `sketch_edges.h` | Persistent `std::list<Sketch_edge>`; add linear/arc edges; split at intersections; pick and selection |
 | `sketch_topo.h` | Planar face extraction from edge graph; automatic splitting at interior nodes and arc crossings |
 | `sketch_nodes.h` | Node storage, snap, snap guides, outside-sketch snap points |

--- a/src/doc/utility.md
+++ b/src/doc/utility.md
@@ -64,8 +64,8 @@ Large module; grouped by concern:
 | Plane / 2D | `to_2d`, `to_3d`, `xy_plane`, `sketch_reference_plane`, `Plane_side` |
 | Profile wires | `make_square_wire`, `make_circle_wire`, `make_slot_wire`, `create_wire_box` |
 | Sketch dimensions | `Length_dimension_style`, `create_distance_annotation`, `apply_length_dimension_style` |
-| Analysis | `to_boost` (polygon), `get_shape_bbox_center`, `plane_from_face`, `side_of_plane` |
-| Tests / debug | `to_wkt_string`, `ezy_geom::area`, `is_valid` |
+| Analysis | `to_boost` (polygon), `to_boost_ls` (edge linestring), `get_shape_bbox_center`, `plane_from_face`, `side_of_plane` |
+| Tests / debug | `to_wkt_string` (ring / polygon), `ezy_geom::area`, `is_valid` |
 
 Includes [`utl_geom_boost.inl`](../utl_geom_boost.inl) for Boost.Geometry polygon types used in tests and face validation.
 

--- a/src/sketch_edge.cpp
+++ b/src/sketch_edge.cpp
@@ -102,3 +102,9 @@ gp_Vec2d sketch_edge_outgoing_dir_2d(const Sketch_edge& e, const gp_Pnt2d& from_
 
   return normalize_or_axis_(gp_Vec2d(from_pt, to_pt));
 }
+
+gp_Vec2d sketch_edge_incoming_dir_2d(const Sketch_edge& e, const gp_Pnt2d& from_pt, const gp_Pnt2d& to_pt, const gp_Pln& pln)
+{
+  // Tangent at to_pt in the travel direction == opposite of outgoing back toward from_pt.
+  return -sketch_edge_outgoing_dir_2d(e, to_pt, from_pt, pln);
+}

--- a/src/sketch_edge.h
+++ b/src/sketch_edge.h
@@ -25,8 +25,12 @@ struct Sketch_edge
 [[nodiscard]] bool sketch_edge_is_linear(const Sketch_edge& e);
 [[nodiscard]] bool sketch_edge_is_arc(const Sketch_edge& e);
 
-/// Unit direction from \a from_pt toward \a to_pt along \a e (chord for lines, curve tangent for arcs).
+/// Unit direction at \a from_pt toward \a to_pt along \a e (chord for lines, curve tangent for arcs).
 [[nodiscard]] gp_Vec2d sketch_edge_outgoing_dir_2d(const Sketch_edge& e, const gp_Pnt2d& from_pt, const gp_Pnt2d& to_pt,
+                                                   const gp_Pln& pln);
+
+/// Unit arrival direction at \a to_pt when traveling from \a from_pt along \a e.
+[[nodiscard]] gp_Vec2d sketch_edge_incoming_dir_2d(const Sketch_edge& e, const gp_Pnt2d& from_pt, const gp_Pnt2d& to_pt,
                                                    const gp_Pln& pln);
 
 /// Read-only linear edge (node indices only).

--- a/src/sketch_topo.cpp
+++ b/src/sketch_topo.cpp
@@ -475,6 +475,7 @@ void Sketch_topo::update_faces()
     for (auto& [b_idx, start_edge] : edges)
     {
       const Half_edge seed{start_edge, start_edge->reversed(a_idx, b_idx)};
+
       if (visited.count(seed))
         continue;
 
@@ -494,7 +495,7 @@ void Sketch_topo::update_faces()
         // possible relative to the direction we arrived from (smallest signed
         // angle). This keeps the face interior on our left for the whole walk.
         const gp_Vec2d incoming_dir =
-            sketch_edge_outgoing_dir_2d(*curr_edge, m_sketch.m_nodes[prev_idx], m_sketch.m_nodes[curr_idx], m_sketch.m_pln);
+            sketch_edge_incoming_dir_2d(*curr_edge, m_sketch.m_nodes[prev_idx], m_sketch.m_nodes[curr_idx], m_sketch.m_pln);
 
         double              min_angle = std::numeric_limits<double>::max();
         size_t              next_idx  = 0;

--- a/src/utl_geom.cpp
+++ b/src/utl_geom.cpp
@@ -970,6 +970,56 @@ ezy_geom::point_2d to_boost(const gp_Pln& plane, const gp_Pnt& point_3d)
 
 ezy_geom::point_2d to_boost(const gp_Pnt2d& pt) { return {pt.X(), pt.Y()}; }
 
+ezy_geom::ring_2d to_boost_ls(const TopoDS_Shape& shape, const gp_Pln& pln)
+{
+  EZY_ASSERT_MSG(shape.ShapeType() == TopAbs_EDGE, "Shape must be an edge");
+
+  const TopoDS_Edge& edge  = TopoDS::Edge(shape);
+  BRepAdaptor_Curve  curve(edge);
+  ezy_geom::ring_2d  line;
+
+  auto append_pt = [&](const gp_Pnt2d& pt)
+  {
+    if (!line.empty())
+    {
+      const auto& last = line.back();
+      if (gp_Pnt2d(last.x(), last.y()).IsEqual(pt, Precision::Confusion()))
+        return;
+    }
+    line.push_back({pt.X(), pt.Y()});
+  };
+
+  switch (curve.GetType())
+  {
+  case GeomAbs_Line:
+    append_pt(to_2d(pln, curve.Value(curve.FirstParameter())));
+    append_pt(to_2d(pln, curve.Value(curve.LastParameter())));
+    break;
+
+  case GeomAbs_Circle:
+  {
+    const double u_start = curve.FirstParameter();
+    const double u_end   = curve.LastParameter();
+    const double span    = std::abs(u_end - u_start);
+
+    constexpr size_t k_min_pts    = 8;
+    constexpr size_t k_max_pts    = 32;
+    constexpr double k_rad_per_pt = to_radians(15.0);
+    const size_t     num_pts    = std::clamp(static_cast<size_t>(std::ceil(span / k_rad_per_pt)) + 1, k_min_pts, k_max_pts);
+
+    const double step = (u_end - u_start) / static_cast<double>(num_pts - 1);
+    for (size_t i = 0; i < num_pts; ++i)
+      append_pt(to_2d(pln, curve.Value(u_start + static_cast<double>(i) * step)));
+    break;
+  }
+
+  default:
+    EZY_ASSERT_MSG(false, "Unsupported edge curve type for to_boost_ls");
+  }
+
+  return line;
+}
+
 // Convert a TopoDS_Shape to a ezy_geom::polygon_2d (pure C++ version)
 ezy_geom::polygon_2d to_boost(const TopoDS_Shape& shape, const gp_Pln& pln2)
 {
@@ -1253,21 +1303,41 @@ double ezy_geom::area(const polygon_2d& poly)
   return std::abs(a);
 }
 
+namespace
+{
+std::string wkt_fmt_num(double v)
+{
+  if (std::abs(v - std::round(v)) < 1e-9)
+    return std::to_string(static_cast<long long>(std::round(v)));
+
+  std::ostringstream os;
+  os << std::fixed << std::setprecision(6) << v;
+  return os.str();
+}
+
+void wkt_write_ring_coords(std::ostringstream& ss, const ezy_geom::ring_2d& r)
+{
+  for (size_t i = 0; i < r.size(); ++i)
+  {
+    if (i > 0)
+      ss << ",";
+
+    ss << wkt_fmt_num(r[i].x()) << " " << wkt_fmt_num(r[i].y());
+  }
+}
+} // namespace
+
+std::string to_wkt_string(const ezy_geom::ring_2d& ring)
+{
+  std::ostringstream ss;
+  ss << "LINESTRING(";
+  wkt_write_ring_coords(ss, ring);
+  ss << ")";
+  return ss.str();
+}
+
 std::string to_wkt_string(const ezy_geom::polygon_2d& poly)
 {
-  auto fmt_num = [](double v) -> std::string
-  {
-    if (std::abs(v - std::round(v)) < 1e-9)
-    {
-      // whole number
-      return std::to_string(static_cast<long long>(std::round(v)));
-    }
-
-    std::ostringstream os;
-    os << std::fixed << std::setprecision(6) << v;
-    return os.str();
-  };
-
   std::ostringstream ss;
 
   auto write_ring = [&](const ezy_geom::ring_2d& r, bool first_ring)
@@ -1276,13 +1346,7 @@ std::string to_wkt_string(const ezy_geom::polygon_2d& poly)
       ss << ",";
 
     ss << "(";
-    for (size_t i = 0; i < r.size(); ++i)
-    {
-      if (i > 0)
-        ss << ",";
-
-      ss << fmt_num(r[i].x()) << " " << fmt_num(r[i].y());
-    }
+    wkt_write_ring_coords(ss, r);
     ss << ")";
   };
 

--- a/src/utl_geom.h
+++ b/src/utl_geom.h
@@ -28,9 +28,11 @@ gp_Pnt2d             to_pnt2d(const ezy_geom::point_2d& pt);
 ezy_geom::point_2d   to_boost(const gp_Pln& plane, const gp_Pnt& point_3d);
 ezy_geom::point_2d   to_boost(const gp_Pnt2d& point);
 ezy_geom::polygon_2d to_boost(const TopoDS_Shape& shape, const gp_Pln& pln2);
+ezy_geom::ring_2d    to_boost_ls(const TopoDS_Shape& shape, const gp_Pln& pln);
 bool                 is_clockwise(const ezy_geom::ring_2d& ring);
 
-// Simple WKT writer for our polygon type (used by tests).
+// Simple WKT writers (used by tests and Graphical Debugging log output).
+std::string to_wkt_string(const ezy_geom::ring_2d& ring);
 std::string to_wkt_string(const ezy_geom::polygon_2d& poly);
 
 // Function to project a 3D point onto a plane and get its 2D (u, v) coordinates
@@ -176,6 +178,9 @@ ezy_geom::point_2d to_boost(const gp_Pnt2d& point);
 
 // Convert a TopoDS_Shape to a ezy_geom::polygon_2d
 ezy_geom::polygon_2d to_boost(const TopoDS_Shape& shape, const gp_Pln& pln2);
+
+/// Edge as an open 2D polyline on \a pln (arc edges are densified).
+ezy_geom::ring_2d to_boost_ls(const TopoDS_Shape& shape, const gp_Pln& pln);
 
 gp_Pnt get_shape_bbox_center(const TopoDS_Shape& shp);
 

--- a/src/utl_geom.h
+++ b/src/utl_geom.h
@@ -31,7 +31,7 @@ ezy_geom::polygon_2d to_boost(const TopoDS_Shape& shape, const gp_Pln& pln2);
 ezy_geom::ring_2d    to_boost_ls(const TopoDS_Shape& shape, const gp_Pln& pln);
 bool                 is_clockwise(const ezy_geom::ring_2d& ring);
 
-// Simple WKT writers (used by tests and Graphical Debugging log output).
+// Simple WKT writers (used by tests).
 std::string to_wkt_string(const ezy_geom::ring_2d& ring);
 std::string to_wkt_string(const ezy_geom::polygon_2d& poly);
 

--- a/src/utl_geom_boost.inl
+++ b/src/utl_geom_boost.inl
@@ -16,13 +16,16 @@ struct point_2d
   }
 };
 
-/// Open polyline or closed ring vertex sequence (inherits vector for Graphical Debugging).
+/// Open polyline or closed ring vertex sequence (inherits vector for Graphical Debugging:
+/// https://github.com/awulkiew/graphical-debugging , tools/ezycad_graphical_debugging.xml).
+/// Registered as Ring in that XML so polygon_2d ExteriorRing resolves.
 struct ring_2d : std::vector<point_2d>
 {
   using std::vector<point_2d>::vector;
 };
 
-/// Two endpoints (Graphical Debugging segment visualizer).
+/// Two endpoints (Graphical Debugging segment visualizer:
+/// https://github.com/awulkiew/graphical-debugging , tools/ezycad_graphical_debugging.xml).
 struct segment_2d
 {
   point_2d from;

--- a/src/utl_geom_boost.inl
+++ b/src/utl_geom_boost.inl
@@ -16,7 +16,18 @@ struct point_2d
   }
 };
 
-using ring_2d = std::vector<point_2d>;
+/// Open polyline or closed ring vertex sequence (inherits vector for Graphical Debugging).
+struct ring_2d : std::vector<point_2d>
+{
+  using std::vector<point_2d>::vector;
+};
+
+/// Two endpoints (Graphical Debugging segment visualizer).
+struct segment_2d
+{
+  point_2d from;
+  point_2d to;
+};
 
 struct polygon_2d
 {

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -1661,6 +1661,52 @@ TEST_F(Sketch_test, UpdateFaces_SemicircleTangentWalker)
   EXPECT_EQ(face->Shape().ShapeType(), TopAbs_FACE);
 }
 
+// Circle split into four arcs plus a chord (project.ezy topology). At the chord
+// endpoints the walker arrives on an arc whose start and end tangents differ; using
+// the start tangent as the arrival direction picks the wrong next edge and drops faces.
+TEST_F(Sketch_test, UpdateFaces_CircleWithChord_IncomingArcTangent)
+{
+  gp_Pln default_plane(gp::Origin(), gp::DZ());
+  Sketch sketch("circle_chord", view(), default_plane);
+
+  constexpr double r = 10.0;
+  const gp_Pnt2d   right(r, 0.0);
+  const gp_Pnt2d   left(-r, 0.0);
+  const gp_Pnt2d   chord_r(r * 0.5, r * std::sqrt(3.0) * 0.5);   // 60 deg
+  const gp_Pnt2d   chord_l(-r * 0.5, r * std::sqrt(3.0) * 0.5);  // 120 deg
+
+  Sketch_access::add_arc_circle_(sketch, left, gp_Pnt2d(0.0, -r), right);                                      // bottom
+  Sketch_access::add_arc_circle_(sketch, chord_r, gp_Pnt2d(r * std::sqrt(3.0) * 0.5, r * 0.5), right);         // right
+  Sketch_access::add_arc_circle_(sketch, left, gp_Pnt2d(-r * std::sqrt(3.0) * 0.5, r * 0.5), chord_l);         // left
+  Sketch_access::add_arc_circle_(sketch, chord_l, gp_Pnt2d(0.0, r), chord_r);                                  // top
+  Sketch_access::add_edge_(sketch, chord_l, chord_r);
+
+  Sketch_access::update_faces_(sketch);
+
+  const auto& faces = Sketch_access::get_faces(sketch);
+  ASSERT_EQ(faces.size(), 2u) << "Circle + chord must produce the small segment and the large remainder";
+
+  double areas[2] = {};
+  for (size_t i = 0; i < faces.size(); ++i)
+  {
+    EXPECT_EQ(faces[i]->Shape().ShapeType(), TopAbs_FACE);
+    GProp_GProps props;
+    BRepGProp::SurfaceProperties(faces[i]->Shape(), props);
+    areas[i] = props.Mass();
+  }
+
+  const double circle_area = r * r * std::numbers::pi;
+  // Smaller circular segment for central angle pi/3: (R^2/2)*(theta - sin theta).
+  constexpr double theta        = std::numbers::pi / 3.0;
+  const double     segment_area = 0.5 * r * r * (theta - std::sin(theta));
+
+  const double small = std::min(areas[0], areas[1]);
+  const double large = std::max(areas[0], areas[1]);
+  EXPECT_NEAR(small, segment_area, 0.5);
+  EXPECT_NEAR(large, circle_area - segment_area, 0.5);
+  EXPECT_NEAR(small + large, circle_area, 0.5);
+}
+
 TEST_F(Sketch_test, ArcSplit_LineCrossingArcInterior)
 {
   gp_Pln default_plane(gp::Origin(), gp::DZ());

--- a/tests/sketch_tests.cpp
+++ b/tests/sketch_tests.cpp
@@ -3,10 +3,13 @@
 #include <TopoDS.hxx>
 #include <TopoDS_Wire.hxx>
 #include <BRepPrimAPI_MakeRevol.hxx>
+#include <BRepTools.hxx>
+#include <BRepTools_WireExplorer.hxx>
 #include <GProp_GProps.hxx>
 #include <BRepGProp.hxx>
 #include <Bnd_Box.hxx>
 #include <BRepBndLib.hxx>
+#include <algorithm>
 #include <iostream>
 #include <numbers>
 #include <set>
@@ -1681,10 +1684,51 @@ TEST_F(Sketch_test, UpdateFaces_CircleWithChord_IncomingArcTangent)
   Sketch_access::add_arc_circle_(sketch, chord_l, gp_Pnt2d(0.0, r), chord_r);                                  // top
   Sketch_access::add_edge_(sketch, chord_l, chord_r);
 
+  // Graphical Debugging v0.56+ (Geometry Watch): dbg_edges
+  // https://github.com/awulkiew/graphical-debugging
+  std::vector<ezy_geom::ring_2d> dbg_edges;
+  for (const auto& e : Sketch_access::get_edges(sketch))
+  {
+    if (e.shp.IsNull())
+      continue;
+    dbg_edges.push_back(to_boost_ls(e.shp->Shape(), default_plane));
+  }
+  (void)dbg_edges;
+
   Sketch_access::update_faces_(sketch);
 
   const auto& faces = Sketch_access::get_faces(sketch);
   ASSERT_EQ(faces.size(), 2u) << "Circle + chord must produce the small segment and the large remainder";
+
+  // Graphical Debugging v0.56+ (Geometry Watch): dbg_faces
+  // https://github.com/awulkiew/graphical-debugging
+  // Built from outer-wire edge samples (to_boost can assert on arc face closure).
+  std::vector<ezy_geom::polygon_2d> dbg_faces;
+  dbg_faces.reserve(faces.size());
+  for (const auto& f : faces)
+  {
+    ezy_geom::ring_2d   outer;
+    const TopoDS_Wire   wire = BRepTools::OuterWire(TopoDS::Face(f->Shape()));
+    for (BRepTools_WireExplorer wex(wire); wex.More(); wex.Next())
+    {
+      ezy_geom::ring_2d ls = to_boost_ls(wex.Current(), default_plane);
+      if (wex.Orientation() == TopAbs_REVERSED)
+        std::reverse(ls.begin(), ls.end());
+      for (size_t i = 0; i < ls.size(); ++i)
+      {
+        if (!outer.empty() && i == 0)
+          continue;
+        outer.push_back(ls[i]);
+      }
+    }
+    if (!outer.empty())
+      outer.push_back(outer.front());
+
+    ezy_geom::polygon_2d poly;
+    poly.outer() = std::move(outer);
+    dbg_faces.push_back(std::move(poly));
+  }
+  (void)dbg_faces;
 
   double areas[2] = {};
   for (size_t i = 0; i < faces.size(); ++i)

--- a/tools/ezycad_graphical_debugging.xml
+++ b/tools/ezycad_graphical_debugging.xml
@@ -3,15 +3,19 @@
 
   <!--
   Graphical Debugging v0.56+ type definitions for EzyCad.
+  Extension: https://github.com/awulkiew/graphical-debugging
 
   ring_2d must be a struct inheriting std::vector (not a typedef). MSVC unrolls
   typedefs to std::vector<...>, which the extension renders as MultiPoint (dots).
-  See MyLinestring4 in the extension examples/cpp.xml.
+  See MyLinestring4 / MyRing in the extension examples/cpp.xml.
+
+  ring_2d is registered as Ring (not Linestring) so polygon_2d ExteriorRing can
+  resolve it. Open polylines may show a closing segment in Geometry Watch.
 
   Setup:
     1. Tools -> Options -> Graphical Debugging -> General -> set this file path
     2. Restart Visual Studio
-    3. Geometry Watch: seed_seg (segment) or seed_ring (linestring)
+    3. Geometry Watch: ring_2d / segment_2d / polygon_2d (and containers of them)
   -->
 
   <Point Type="ezy_geom::point_2d" Id="ezy_geom::point_2d">
@@ -30,14 +34,15 @@
     </Coordinates>
   </Segment>
 
-  <Linestring Type="ezy_geom::ring_2d" Id="ezy_geom::ring_2d">
+  <!-- Ring (not Linestring): required so Polygon ExteriorRing/InteriorRings resolve. -->
+  <Ring Type="ezy_geom::ring_2d" Id="ezy_geom::ring_2d">
     <Points>
       <Array>
         <Pointer>_Mypair._Myval2._Myfirst</Pointer>
         <Size>_Mypair._Myval2._Mylast - _Mypair._Myval2._Myfirst</Size>
       </Array>
     </Points>
-  </Linestring>
+  </Ring>
 
   <Polygon Type="ezy_geom::polygon_2d" Id="ezy_geom::polygon_2d">
     <ExteriorRing>

--- a/tools/ezycad_graphical_debugging.xml
+++ b/tools/ezycad_graphical_debugging.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GraphicalDebugging>
+
+  <!--
+  Graphical Debugging v0.56+ type definitions for EzyCad.
+
+  ring_2d must be a struct inheriting std::vector (not a typedef). MSVC unrolls
+  typedefs to std::vector<...>, which the extension renders as MultiPoint (dots).
+  See MyLinestring4 in the extension examples/cpp.xml.
+
+  Setup:
+    1. Tools -> Options -> Graphical Debugging -> General -> set this file path
+    2. Restart Visual Studio
+    3. Geometry Watch: seed_seg (segment) or seed_ring (linestring)
+  -->
+
+  <Point Type="ezy_geom::point_2d" Id="ezy_geom::point_2d">
+    <Coordinates>
+      <X>x_</X>
+      <Y>y_</Y>
+    </Coordinates>
+  </Point>
+
+  <Segment Type="ezy_geom::segment_2d" Id="ezy_geom::segment_2d">
+    <Coordinates>
+      <FirstX>from.x_</FirstX>
+      <FirstY>from.y_</FirstY>
+      <SecondX>to.x_</SecondX>
+      <SecondY>to.y_</SecondY>
+    </Coordinates>
+  </Segment>
+
+  <Linestring Type="ezy_geom::ring_2d" Id="ezy_geom::ring_2d">
+    <Points>
+      <Array>
+        <Pointer>_Mypair._Myval2._Myfirst</Pointer>
+        <Size>_Mypair._Myval2._Mylast - _Mypair._Myval2._Myfirst</Size>
+      </Array>
+    </Points>
+  </Linestring>
+
+  <Polygon Type="ezy_geom::polygon_2d" Id="ezy_geom::polygon_2d">
+    <ExteriorRing>
+      <Name>outer_</Name>
+    </ExteriorRing>
+    <InteriorRings>
+      <Container>
+        <Name>inners_</Name>
+      </Container>
+    </InteriorRings>
+  </Polygon>
+
+</GraphicalDebugging>


### PR DESCRIPTION
## Summary

- Face walk used `sketch_edge_outgoing_dir_2d` (tangent at edge **start**) as the arrival direction at the current node. On arcs that is wrong; leftmost-turn selection can drop faces (circle + chord).
- Add `sketch_edge_incoming_dir_2d` and use it for `incoming_dir` in `Sketch_topo::update_faces_`.
- Regression test `UpdateFaces_CircleWithChord_IncomingArcTangent` (four arcs + chord; two faces / segment areas).
- Graphical Debugging support: `to_boost_ls`, `segment_2d` / `ring_2d` as Ring, `tools/ezycad_graphical_debugging.xml` ([extension](https://github.com/awulkiew/graphical-debugging)).

## Related

- Closes #184
- Follow-up to #166 (arc topology / tangent walker); does not address #165

## Test plan

- [x] Build `EzyCad_tests` (Debug)
- [x] `EzyCad_tests --gtest_filter=Sketch_test.UpdateFaces_CircleWithChord_IncomingArcTangent`
- [x] Manual: open a circle + chord sketch (e.g. project.ezy topology) and confirm both faces appear
- [x] Optional: Geometry Watch `dbg_edges` / `dbg_faces` in that test with `tools/ezycad_graphical_debugging.xml` configured

Made with [Cursor](https://cursor.com)