### PR TITLE
Align Markdown tables and document preferred formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ EzyCad is maintained by a small team and we would love more contributors. If you
 
 The **`third_party/`** folder holds other libraries **shipped inside the EzyCad repository** (typically committed as a vendored snapshot, not fetched by CMake except where noted):
 
-| Component | Location | Role |
-| --- | --- | --- |
-| **Dear ImGui** | `third_party/imgui/` | Immediate-mode UI used by the application. This tree includes **project-specific changes** for font rendering; see [imgui#7519 (comment)](https://github.com/ocornut/imgui/issues/7519#issuecomment-2629628233). |
-| **nlohmann/json** | `third_party/json/` (headers under `include/`) | JSON used by the project; CMake adds `third_party/json/include`. |
-| **tinyfiledialogs** | `third_party/tinyfiledialogs/` | Small C helper for native file dialogs on desktop. |
-| **ImGuiColorTextEdit** | `third_party/ImGuiColorTextEdit/` | Syntax-highlighted editor widget for the **Lua** and **Python** script consoles ([upstream](https://github.com/BalazsJako/ImGuiColorTextEdit)). |
+| Component              | Location                                       | Role                                                                                                                                                                                                             |
+| ---------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Dear ImGui**         | `third_party/imgui/`                           | Immediate-mode UI used by the application. This tree includes **project-specific changes** for font rendering; see [imgui#7519 (comment)](https://github.com/ocornut/imgui/issues/7519#issuecomment-2629628233). |
+| **nlohmann/json**      | `third_party/json/` (headers under `include/`) | JSON used by the project; CMake adds `third_party/json/include`.                                                                                                                                                 |
+| **tinyfiledialogs**    | `third_party/tinyfiledialogs/`                 | Small C helper for native file dialogs on desktop.                                                                                                                                                               |
+| **ImGuiColorTextEdit** | `third_party/ImGuiColorTextEdit/`              | Syntax-highlighted editor widget for the **Lua** and **Python** script consoles ([upstream](https://github.com/BalazsJako/ImGuiColorTextEdit)).                                                                  |
 
 **ImGuiColorTextEdit:** Prefer a full checkout under `third_party/ImGuiColorTextEdit/` (see `third_party/README.md`). If that folder is missing, CMake **FetchContent** downloads upstream at a **fixed commit** (`ca2f9f1462e3b60e56351bc466acda448c5ea50d`) because the upstream repo has **no release tags**. To upgrade the editor, bump that SHA in `CMakeLists.txt` and refresh any vendored copy.
 

--- a/agents.md
+++ b/agents.md
@@ -12,6 +12,7 @@ Pointer for AI coding assistants. Details live in [agents/README.md](agents/READ
 ## When needed
 
 - UI/settings/docs changes: [agents/conventions/user-docs-sync.md](agents/conventions/user-docs-sync.md)
+- Markdown tables (align for source + preview): [agents/conventions/markdown-tables.md](agents/conventions/markdown-tables.md)
 - Sketch subsystem: [src/doc/sketch.md](src/doc/sketch.md) (read; update when API or architecture changes)
 - Shape module: [src/doc/shape.md](src/doc/shape.md) (read; update when API or operation patterns change)
 - GUI module: [src/doc/gui.md](src/doc/gui.md) (read; update when input routing, modes, or settings change)

--- a/agents/README.md
+++ b/agents/README.md
@@ -6,20 +6,21 @@ Root markers: [AGENTS.md](../AGENTS.md) / [agents.md](../agents.md).
 
 ## Quick index
 
-| Need | File |
-| --- | --- |
-| ASCII / `src/` edits | [conventions/ascii-source.md](conventions/ascii-source.md) |
-| C++ style (full) | [docs/ezycad_code_style.md](../docs/ezycad_code_style.md) |
-| User docs when UI changes | [conventions/user-docs-sync.md](conventions/user-docs-sync.md) |
-| Sketch module (dev doc) | [src/doc/sketch.md](../src/doc/sketch.md) — read when editing sketch code; update if API/architecture changes |
-| Shape module (dev doc) | [src/doc/shape.md](../src/doc/shape.md) — read when editing `shp_*` code; update if API/operations change |
-| GUI module (dev doc) | [src/doc/gui.md](../src/doc/gui.md) — read when editing `gui_*` / viewer shell; update if routing or settings change |
-| Script module (dev doc) | [src/doc/script.md](../src/doc/script.md) — read when editing `scr_*`; update if bindings change |
-| Utility module (dev doc) | [src/doc/utility.md](../src/doc/utility.md) — read when editing `utl_*`; update if shared helpers or I/O change |
-| Build / test / wasm | [workflows/local-dev.md](workflows/local-dev.md) |
-| Release | [workflows/release.md](workflows/release.md) |
-| Issue/PR drafts | [drafts/](drafts/) — [github-drafts.md](conventions/github-drafts.md) |
-| Token-saving rules | [conventions/token-lean.md](conventions/token-lean.md) |
-| Outreach (optional) | [outreach/discoverability.md](outreach/discoverability.md) |
+| Need                      | File                                                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| ASCII / `src/` edits      | [conventions/ascii-source.md](conventions/ascii-source.md)                                                           |
+| C++ style (full)          | [docs/ezycad_code_style.md](../docs/ezycad_code_style.md)                                                            |
+| User docs when UI changes | [conventions/user-docs-sync.md](conventions/user-docs-sync.md)                                                       |
+| Sketch module (dev doc)   | [src/doc/sketch.md](../src/doc/sketch.md) — read when editing sketch code; update if API/architecture changes        |
+| Shape module (dev doc)    | [src/doc/shape.md](../src/doc/shape.md) — read when editing `shp_*` code; update if API/operations change            |
+| GUI module (dev doc)      | [src/doc/gui.md](../src/doc/gui.md) — read when editing `gui_*` / viewer shell; update if routing or settings change |
+| Script module (dev doc)   | [src/doc/script.md](../src/doc/script.md) — read when editing `scr_*`; update if bindings change                     |
+| Utility module (dev doc)  | [src/doc/utility.md](../src/doc/utility.md) — read when editing `utl_*`; update if shared helpers or I/O change      |
+| Build / test / wasm       | [workflows/local-dev.md](workflows/local-dev.md)                                                                     |
+| Release                   | [workflows/release.md](workflows/release.md)                                                                         |
+| Issue/PR drafts           | [drafts/](drafts/) — [github-drafts.md](conventions/github-drafts.md)                                                |
+| Token-saving rules        | [conventions/token-lean.md](conventions/token-lean.md)                                                               |
+| Markdown tables           | [conventions/markdown-tables.md](conventions/markdown-tables.md) — align GFM pipes for source + preview              |
+| Outreach (optional)       | [outreach/discoverability.md](outreach/discoverability.md)                                                           |
 
 Full user-doc style: [docs/ezycad_doc_style.md](../docs/ezycad_doc_style.md). OCCT build: [docs/building-occt.md](../docs/building-occt.md).

--- a/agents/conventions/github-drafts.md
+++ b/agents/conventions/github-drafts.md
@@ -22,11 +22,11 @@ agents/drafts/
 
 ## Naming (GitHub-first)
 
-| Situation | Filename pattern | Example |
-| --- | --- | --- |
-| Issue filed on GitHub | `gh-NNN-short-slug.md` | `gh-134-linear-edge-automatic-splitting.md` |
-| PR filed on GitHub | `gh-NNN-short-slug.md` (use **PR** number in `prs/`) | `gh-145-sketch-delta-undo-redo.md` |
-| Not yet filed | `draft-short-slug.md` | `draft-src-prefix-refactor-sketch-recorder.md` |
+| Situation             | Filename pattern                                     | Example                                        |
+| --------------------- | ---------------------------------------------------- | ---------------------------------------------- |
+| Issue filed on GitHub | `gh-NNN-short-slug.md`                               | `gh-134-linear-edge-automatic-splitting.md`    |
+| PR filed on GitHub    | `gh-NNN-short-slug.md` (use **PR** number in `prs/`) | `gh-145-sketch-delta-undo-redo.md`             |
+| Not yet filed         | `draft-short-slug.md`                                | `draft-src-prefix-refactor-sketch-recorder.md` |
 
 Use lowercase kebab-case slugs. Keep slugs short but recognizable.
 

--- a/agents/conventions/markdown-tables.md
+++ b/agents/conventions/markdown-tables.md
@@ -20,6 +20,28 @@ Rules:
 - Leave a blank line before and after the table; do not indent table rows (indentation can turn them into a code block).
 - Skip tables inside fenced code blocks (examples stay as authored).
 
+## Wide tables and editor word wrap
+
+Aligned pipe rows are **one long line per row**. Pretty/preview mode reflows cells; source/"code" mode does not. If the editor **word-wraps**, column `|` alignment looks broken even though the Markdown is fine.
+
+**Preferred fix (editor):** turn word wrap **off** for Markdown so wide tables scroll horizontally and stay aligned. In Cursor/VS Code user `settings.json`:
+
+```json
+"[markdown]": {
+  "editor.wordWrap": "off"
+}
+```
+
+Toggle for the current file: View → Word Wrap (or the equivalent command).
+
+**Content mitigations** (when a table is still painful even with wrap off):
+
+- Prefer **2–3 columns**; split a wide reference into two tables or a short table + bullets.
+- Keep cells short; move long prose **under** the table.
+- Do **not** rely on multiline pipe cells — GFM does not wrap cell text across source lines cleanly.
+
+Padding/alignment can make rows slightly longer; that is intentional for source readability when wrap is off. Do not un-align tables just to fight wrap.
+
 ## Re-align helper
 
 ```bash

--- a/agents/conventions/markdown-tables.md
+++ b/agents/conventions/markdown-tables.md
@@ -1,0 +1,35 @@
+# Markdown tables (preferred)
+
+Prefer **aligned GFM pipe tables** in all repo `.md` files so tables stay readable in editor/source ("code") view and render correctly in Markdown preview / GitHub / Read the Docs ("pretty") view.
+
+## Preferred form
+
+```markdown
+| Helper                           | Requirement                                     |
+| -------------------------------- | ----------------------------------------------- |
+| `ensure_operation_shps_()`       | One or more selected `Shp` objects              |
+| `ensure_operation_multi_shps_()` | Two or more selected shapes (fuse, cut, common) |
+```
+
+Rules:
+
+- Use GFM pipes (`| ... |`), not HTML `<table>`.
+- Pad cells with spaces so column `|` characters line up in the source.
+- Include a separator row (`| --- | --- |`); pad dashes to the column width.
+- Keep each cell on one line; put long notes in a list under the table instead of multiline cells.
+- Leave a blank line before and after the table; do not indent table rows (indentation can turn them into a code block).
+- Skip tables inside fenced code blocks (examples stay as authored).
+
+## Re-align helper
+
+```bash
+python scripts/align_md_tables.py
+python scripts/align_md_tables.py --check
+```
+
+Skips `third_party/`, local `build*` trees, `_deps`, and similar vendor/output dirs.
+
+## Related
+
+- User-facing docs style: [docs/ezycad_doc_style.md](../../docs/ezycad_doc_style.md) (Tables)
+- Issue/PR drafts: [github-drafts.md](github-drafts.md)

--- a/agents/conventions/token-lean.md
+++ b/agents/conventions/token-lean.md
@@ -12,19 +12,20 @@ Goal: give assistants **only what they need** for the task at hand. Full style g
 
 ## Load on demand
 
-| Task | Read |
-| --- | --- |
-| Build / test | [workflows/local-dev.md](../workflows/local-dev.md) — or root [README.md](../../README.md#building-instructions) |
-| User-visible UI/settings | [user-docs-sync.md](user-docs-sync.md) + target `docs/usage-*.md` only |
+| Task                                                                                                 | Read                                                                                                                                |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Build / test                                                                                         | [workflows/local-dev.md](../workflows/local-dev.md) — or root [README.md](../../README.md#building-instructions)                    |
+| User-visible UI/settings                                                                             | [user-docs-sync.md](user-docs-sync.md) + target `docs/usage-*.md` only                                                              |
 | Sketch subsystem (`src/sketch*`, `tests/sketch_*_tests.cpp`, sketch behavior in `occt_view` / `gui`) | [src/doc/sketch.md](../../src/doc/sketch.md) — read before editing; update when API, invariants, module layout, or workflows change |
-| Shape module (`src/shp*`, shape ops in `occt_view` / `gui`) | [src/doc/shape.md](../../src/doc/shape.md) — read before editing; update when API, operation patterns, or registration/undo change |
-| GUI / viewer shell (`src/gui*`, input routing, settings panes) | [src/doc/gui.md](../../src/doc/gui.md) — read before editing; update when modes, Options, hotkeys, or settings keys change |
-| Script consoles (`src/scr*`, bindings) | [src/doc/script.md](../../src/doc/script.md) — read before editing; update when `ezy`/`view` API or console UI changes |
-| Utilities (`src/utl*`, results, I/O, geometry) | [src/doc/utility.md](../../src/doc/utility.md) — read before editing; update when shared helper contracts change |
-| Docs build | [workflows/docs-build.md](../workflows/docs-build.md) |
-| Release | [workflows/release.md](../workflows/release.md) |
-| Specific issue/PR | One file under `drafts/issues/active/` or `drafts/prs/active/` |
-| Forum posts | [outreach/discoverability.md](../outreach/discoverability.md) |
+| Shape module (`src/shp*`, shape ops in `occt_view` / `gui`)                                          | [src/doc/shape.md](../../src/doc/shape.md) — read before editing; update when API, operation patterns, or registration/undo change  |
+| GUI / viewer shell (`src/gui*`, input routing, settings panes)                                       | [src/doc/gui.md](../../src/doc/gui.md) — read before editing; update when modes, Options, hotkeys, or settings keys change          |
+| Script consoles (`src/scr*`, bindings)                                                               | [src/doc/script.md](../../src/doc/script.md) — read before editing; update when `ezy`/`view` API or console UI changes              |
+| Utilities (`src/utl*`, results, I/O, geometry)                                                       | [src/doc/utility.md](../../src/doc/utility.md) — read before editing; update when shared helper contracts change                    |
+| Docs build                                                                                           | [workflows/docs-build.md](../workflows/docs-build.md)                                                                               |
+| Editing Markdown tables                                                                              | [markdown-tables.md](markdown-tables.md) — align GFM pipes; `python scripts/align_md_tables.py`                                     |
+| Release                                                                                              | [workflows/release.md](../workflows/release.md)                                                                                     |
+| Specific issue/PR                                                                                    | One file under `drafts/issues/active/` or `drafts/prs/active/`                                                                      |
+| Forum posts                                                                                          | [outreach/discoverability.md](../outreach/discoverability.md)                                                                       |
 
 ## Draft hygiene (saves tokens long-term)
 
@@ -37,13 +38,13 @@ Goal: give assistants **only what they need** for the task at hand. Full style g
 
 Module notes live under `src/doc/` (IDE folder `src\doc`; see root `CMakeLists.txt`). They are **not** user guides — do not duplicate `docs/usage-*.md`.
 
-| Module doc | When |
-| --- | --- |
-| [src/doc/sketch.md](../../src/doc/sketch.md) | Editing `src/sketch*`, `tests/sketch_*_tests.cpp`, or sketch-facing behavior in `occt_view` / `gui` / `mode` |
-| [src/doc/shape.md](../../src/doc/shape.md) | Editing `src/shp*`, shape operations in `occt_view` / `gui`, or 3D solid behavior |
-| [src/doc/gui.md](../../src/doc/gui.md) | Editing `src/gui*`, `Occt_view` in `gui_occt_view*`, input routing, Options/Settings UI |
-| [src/doc/script.md](../../src/doc/script.md) | Editing `src/scr*`, Lua/Python bindings, console behavior |
-| [src/doc/utility.md](../../src/doc/utility.md) | Editing `src/utl*`, `Status`/`Result`, `.ezy` I/O, geometry/settings helpers |
+| Module doc                                     | When                                                                                                         |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [src/doc/sketch.md](../../src/doc/sketch.md)   | Editing `src/sketch*`, `tests/sketch_*_tests.cpp`, or sketch-facing behavior in `occt_view` / `gui` / `mode` |
+| [src/doc/shape.md](../../src/doc/shape.md)     | Editing `src/shp*`, shape operations in `occt_view` / `gui`, or 3D solid behavior                            |
+| [src/doc/gui.md](../../src/doc/gui.md)         | Editing `src/gui*`, `Occt_view` in `gui_occt_view*`, input routing, Options/Settings UI                      |
+| [src/doc/script.md](../../src/doc/script.md)   | Editing `src/scr*`, Lua/Python bindings, console behavior                                                    |
+| [src/doc/utility.md](../../src/doc/utility.md) | Editing `src/utl*`, `Status`/`Result`, `.ezy` I/O, geometry/settings helpers                                 |
 
 **On sketch changes:** read `sketch.md` first for context. Update it in the same branch when you change public `Sketch` API, coordinator/sub-module boundaries, invariants (IDs, undo, transient vs committed state), or developer usage patterns. Skip updates for internal-only refactors with no doc impact.
 

--- a/agents/conventions/user-docs-sync.md
+++ b/agents/conventions/user-docs-sync.md
@@ -18,15 +18,15 @@ Skip user-guide updates for internal-only refactors (PIMPL, naming, line endings
 
 ## Files to check
 
-| Change type | Primary docs |
-| --- | --- |
+| Change type                             | Primary docs                                                                               |
+| --------------------------------------- | ------------------------------------------------------------------------------------------ |
 | New/changed **Settings** or **Options** | `docs/usage-settings.md` (pane list, Options section, **`gui` / `occt_view` JSON tables**) |
-| Sketch tools, snap, dimensions | `docs/usage-sketch.md`; cross-links from `usage-settings.md` |
-| 3D view, grid, navigation | `docs/usage-occt-view.md`, `docs/usage.md` (view sections) |
-| General UI, lists, modes | `docs/usage.md` |
-| Lua / Python / settings JSON API | `docs/scripting.md` |
-| Build / OCCT / wasm | `docs/building-occt.md` |
-| Notable user-facing fix or feature | `CHANGELOG.md` under `[Unreleased]` |
+| Sketch tools, snap, dimensions          | `docs/usage-sketch.md`; cross-links from `usage-settings.md`                               |
+| 3D view, grid, navigation               | `docs/usage-occt-view.md`, `docs/usage.md` (view sections)                                 |
+| General UI, lists, modes                | `docs/usage.md`                                                                            |
+| Lua / Python / settings JSON API        | `docs/scripting.md`                                                                        |
+| Build / OCCT / wasm                     | `docs/building-occt.md`                                                                    |
+| Notable user-facing fix or feature      | `CHANGELOG.md` under `[Unreleased]`                                                        |
 
 ## Minimum checklist (settings / preferences)
 

--- a/agents/drafts/issues/active/draft-src-prefix-refactor-sketch-recorder.md
+++ b/agents/drafts/issues/active/draft-src-prefix-refactor-sketch-recorder.md
@@ -29,17 +29,17 @@ No user-visible behavior change is intended; this is structural cleanup on top o
 
 **File renames (prefix convention):**
 
-| Old | New | Prefix |
-| --- | --- | --- |
-| `dbg.h` | `utl_dbg.h` | `utl_` utilities |
-| `geom.cpp/h/inl` | `utl_geom.cpp/h/inl` | `utl_` |
-| `log.cpp/h` | `utl_log.cpp/h` | `utl_` |
-| `ply_io.cpp/h` | `utl_ply_io.cpp/h` | `utl_` |
-| `settings.cpp/h` | `utl_settings.cpp/h` | `utl_` |
-| `types.h/inl` | `utl_types.h/inl` | `utl_` |
-| `modes.cpp/h` | `gui_modes.cpp/h` | `gui_` |
-| `lua_console.cpp/h` | `scr_lua_console.cpp/h` | `scr_` (scripting) |
-| `python_console.cpp/h` | `scr_python_console.cpp/h` | `scr_` |
+| Old                    | New                        | Prefix             |
+| ---------------------- | -------------------------- | ------------------ |
+| `dbg.h`                | `utl_dbg.h`                | `utl_` utilities   |
+| `geom.cpp/h/inl`       | `utl_geom.cpp/h/inl`       | `utl_`             |
+| `log.cpp/h`            | `utl_log.cpp/h`            | `utl_`             |
+| `ply_io.cpp/h`         | `utl_ply_io.cpp/h`         | `utl_`             |
+| `settings.cpp/h`       | `utl_settings.cpp/h`       | `utl_`             |
+| `types.h/inl`          | `utl_types.h/inl`          | `utl_`             |
+| `modes.cpp/h`          | `gui_modes.cpp/h`          | `gui_`             |
+| `lua_console.cpp/h`    | `scr_lua_console.cpp/h`    | `scr_` (scripting) |
+| `python_console.cpp/h` | `scr_python_console.cpp/h` | `scr_`             |
 
 Existing prefixes unchanged: `shp_*`, `sketch*`, `gui*`, `occt_*`, `utl_*` (json/occt helpers), `delta*`.
 

--- a/agents/drafts/issues/active/gh-163-sketch-module-refactor.md
+++ b/agents/drafts/issues/active/gh-163-sketch-module-refactor.md
@@ -36,17 +36,17 @@ No user-visible behavior change is intended; this is structural cleanup followin
 
 **New modules / translation units:**
 
-| Module / file | Responsibility |
-| --- | --- |
-| `sketch_edge` | `Sketch_edge` type and `sketch_edge_is_linear()` |
-| `Sketch_edges` | Persistent edge list; add/split/remove; JSON linear edges; read-only `for_each_linear` / `for_each_arc` visitors |
-| `Sketch_topo` | Face extraction, `split_linear_edges_at_node_if_interior`, face caches |
-| `Sketch_dims` | Length dimensions, typed input, pick state, tmp dimension preview |
-| `Sketch_node_marks` | Permanent node '+' markers (`sync`, `remove_at`, etc.) |
-| `sketch_ais` | `Sketch_AIS_edge`, `Sketch_AIS_node_mark`, `Sketch_face_shp`, mark removal helper |
-| `Sketch_tools` | Interactive drawing session: tmp edges/nodes, mode-specific tools, finalize/cancel |
-| `sketch_display.cpp` | Viewer display: visibility, edge styling, sketch switching, list hover (state on `Sketch`) |
-| `sketch_operations.cpp` | Operation axis, mirror, revolve (state on `Sketch`) |
+| Module / file           | Responsibility                                                                                                   |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `sketch_edge`           | `Sketch_edge` type and `sketch_edge_is_linear()`                                                                 |
+| `Sketch_edges`          | Persistent edge list; add/split/remove; JSON linear edges; read-only `for_each_linear` / `for_each_arc` visitors |
+| `Sketch_topo`           | Face extraction, `split_linear_edges_at_node_if_interior`, face caches                                           |
+| `Sketch_dims`           | Length dimensions, typed input, pick state, tmp dimension preview                                                |
+| `Sketch_node_marks`     | Permanent node '+' markers (`sync`, `remove_at`, etc.)                                                           |
+| `sketch_ais`            | `Sketch_AIS_edge`, `Sketch_AIS_node_mark`, `Sketch_face_shp`, mark removal helper                                |
+| `Sketch_tools`          | Interactive drawing session: tmp edges/nodes, mode-specific tools, finalize/cancel                               |
+| `sketch_display.cpp`    | Viewer display: visibility, edge styling, sketch switching, list hover (state on `Sketch`)                       |
+| `sketch_operations.cpp` | Operation axis, mirror, revolve (state on `Sketch`)                                                              |
 
 **`Sketch` layout after refactor:**
 

--- a/agents/drafts/issues/active/gh-192-align-markdown-tables.md
+++ b/agents/drafts/issues/active/gh-192-align-markdown-tables.md
@@ -1,0 +1,64 @@
+---
+github_issue: 192
+github_pr: 193
+status: active
+paired_draft: ../prs/active/gh-193-align-markdown-tables.md
+---
+
+# Align Markdown tables for source + preview readability
+
+**Suggested labels:** `documentation`, `enhancement`
+
+---
+
+## Title (GitHub)
+
+Align Markdown tables for source + preview readability
+
+## Body (GitHub)
+
+### Summary
+
+Prefer aligned GFM pipe tables across repo Markdown so tables stay readable in editor/source view and still render correctly in preview / GitHub / Read the Docs. Add an agent convention and a small re-align helper script.
+
+### Problem
+
+- Many `.md` tables used compact `| --- |` separators without column padding, so source/"code" view was hard to scan.
+- There was no documented preference for agents/contributors on table formatting, or guidance for wide tables vs editor word wrap.
+
+### Implemented scope
+
+**Tooling:**
+
+- `scripts/align_md_tables.py` — aligns GFM pipe tables (skips fenced code blocks and build/vendor trees); supports `--check`.
+
+**Documentation / agent notes:**
+
+- `agents/conventions/markdown-tables.md` — preferred form, wide-table/word-wrap notes, helper usage
+- Pointers from `AGENTS.md` / `agents.md`, `agents/README.md`, `token-lean.md`, `local-dev.md`, `docs/ezycad_doc_style.md`
+- Existing tables realigned in `docs/`, `src/doc/`, `agents/`, and root `README.md`
+
+### Acceptance criteria
+
+- [x] GFM tables in tracked `.md` files are column-aligned (helper `--check` clean)
+- [x] Agent convention documents preferred form and word-wrap guidance
+- [x] Helper script documented in local-dev / agent index
+- [ ] CI green on the linked PR
+
+### Files touched
+
+- `scripts/align_md_tables.py`
+- `agents/conventions/markdown-tables.md`
+- `agents.md` / `AGENTS.md`, `agents/README.md`, `agents/conventions/token-lean.md`, `agents/workflows/local-dev.md`
+- `docs/ezycad_doc_style.md` and realigned tables under `docs/`, `src/doc/`, `agents/`, `README.md`
+- `agents/drafts/issues/active/gh-192-align-markdown-tables.md` (this draft)
+
+### Related
+
+- PR: https://github.com/trailcode/EzyCad/pull/193
+
+### Test plan
+
+- [x] `python scripts/align_md_tables.py --check`
+- [ ] Spot-check a few pages in Markdown preview (e.g. `src/doc/shape.md`, `docs/usage-sketch.md`)
+- [ ] Optional: `sphinx-build -b html -W docs docs/_build` if docs CI does not already cover it

--- a/agents/drafts/prs/active/gh-193-align-markdown-tables.md
+++ b/agents/drafts/prs/active/gh-193-align-markdown-tables.md
@@ -1,0 +1,44 @@
+---
+github_pr: 193
+github_issue: 192
+status: active
+paired_draft: ../issues/active/gh-192-align-markdown-tables.md
+---
+
+# PR - Align Markdown tables and document preferred formatting
+
+## Title
+
+Align Markdown tables and document preferred formatting
+
+## Summary
+
+- Align GFM pipe tables across repo Markdown (`docs/`, `src/doc/`, `agents/`, `README.md`) so columns read cleanly in editor/source view and still render in preview.
+- Add preferred convention `agents/conventions/markdown-tables.md` (including wide-table / word-wrap guidance) and wire it into agent indexes and `docs/ezycad_doc_style.md`.
+- Add `scripts/align_md_tables.py` (with `--check`) to re-align tables; listed in `agents/workflows/local-dev.md`.
+
+## Files Changed
+
+- `scripts/align_md_tables.py`
+- `agents/conventions/markdown-tables.md`
+- `agents.md`, `agents/README.md`, `agents/conventions/token-lean.md`, `agents/workflows/local-dev.md`
+- `docs/ezycad_doc_style.md`
+- Realigned tables in `docs/*`, `src/doc/*`, `agents/*`, `README.md`
+- `agents/drafts/issues/active/gh-192-align-markdown-tables.md`
+- `agents/drafts/prs/active/gh-193-align-markdown-tables.md`
+
+## Related
+
+- Issue: https://github.com/trailcode/EzyCad/issues/192
+- Branch: `Trailcode/doc-table-format`
+
+## Test Plan
+
+- [x] `python scripts/align_md_tables.py --check`
+- [ ] Spot-check Markdown preview on a wide table (e.g. `src/doc/shape.md`, `docs/usage-settings.md`)
+- [ ] Confirm docs CI / `sphinx-build` if required by existing workflows
+
+## Post-merge
+
+- [ ] Archive issue/PR drafts
+- [ ] Close #192 if fully addressed

--- a/agents/outreach/discoverability.md
+++ b/agents/outreach/discoverability.md
@@ -4,13 +4,13 @@ Copy-paste templates for posts that link back to the project. Update URLs or scr
 
 **Canonical links**
 
-| Resource | URL |
-| --- | --- |
-| GitHub | https://github.com/trailcode/EzyCad |
-| Documentation | https://ezycad.readthedocs.io/ |
-| Landing page | https://trailcode.github.io/EzyCad/ |
+| Resource                     | URL                                            |
+| ---------------------------- | ---------------------------------------------- |
+| GitHub                       | https://github.com/trailcode/EzyCad            |
+| Documentation                | https://ezycad.readthedocs.io/                 |
+| Landing page                 | https://trailcode.github.io/EzyCad/            |
 | Run in browser (WebAssembly) | https://trailcode.github.io/EzyCad/EzyCad.html |
-| Releases | https://github.com/trailcode/EzyCad/releases |
+| Releases                     | https://github.com/trailcode/EzyCad/releases   |
 
 **Search tip for others:** `trailcode EzyCad` or `site:github.com EzyCad trailcode`
 

--- a/agents/workflows/local-dev.md
+++ b/agents/workflows/local-dev.md
@@ -103,6 +103,7 @@ See `scripts/build-occt-793-wasm.ps1`, `scripts/build-occt-v8-wasm.ps1`, and sha
 
 ## Other scripts
 
+- `scripts/align_md_tables.py` — Align GFM pipe tables in `.md` files for source + preview readability (see [conventions/markdown-tables.md](../conventions/markdown-tables.md)).
 - `scripts/sync-github-pages-html.ps1` — Sync `web/` changes (EzyCad.html etc.) to the GitHub Pages wasm demo site.
 - `scripts/pbf-to-png.ps1` / `.py` — Icon / asset conversion helpers.
 - `scripts/pimpl_gen.py` — PIMPL stub generator.

--- a/docs/building-occt.md
+++ b/docs/building-occt.md
@@ -12,10 +12,10 @@ EzyCad does **not** vendor OCCT; builds live **outside** the tree. Point CMake a
 
 ## Version matrix (EzyCad)
 
-| Target | Documented / tested | CMake variables |
-| --- | --- | --- |
-| **Windows desktop** | OCCT **8.0.0** prebuilt | `OpenCASCADE_DIR`, `OCCT_3RD_PARTY_DIR` |
-| **WebAssembly** | OCCT **7.9.3** (`V7_9_3`) recommended; **8.0.0.p1** (`V8_0_0_p1`) has regressions | `OpenCASCADE_DIR` only (static install) |
+| Target              | Documented / tested                                                               | CMake variables                         |
+| ------------------- | --------------------------------------------------------------------------------- | --------------------------------------- |
+| **Windows desktop** | OCCT **8.0.0** prebuilt                                                           | `OpenCASCADE_DIR`, `OCCT_3RD_PARTY_DIR` |
+| **WebAssembly**     | OCCT **7.9.3** (`V7_9_3`) recommended; **8.0.0.p1** (`V8_0_0_p1`) has regressions | `OpenCASCADE_DIR` only (static install) |
 
 ---
 
@@ -75,10 +75,10 @@ EzyCad’s wasm target links **`TKOpenGles`** (not `TKOpenGl`), static OCCT, and
 
 EzyCad links **`TKOpenGles`** (not `TKOpenGl`), static OCCT, and **`-fexceptions`** (see `CMakeLists.txt` Emscripten block).
 
-| Script | OCCT tag | Default tree root |
-| --- | --- | --- |
-| `scripts/build-occt-793-wasm.ps1` (`.cmd`) | **V7_9_3** (recommended) | `%USERPROFILE%\occt-wasm-build\V7_9_3` |
-| `scripts/build-occt-v8-wasm.ps1` (`.cmd`) | V8_0_0_p1 | `%USERPROFILE%\occt-wasm-build\V8_0_0_p1` |
+| Script                                     | OCCT tag                 | Default tree root                         |
+| ------------------------------------------ | ------------------------ | ----------------------------------------- |
+| `scripts/build-occt-793-wasm.ps1` (`.cmd`) | **V7_9_3** (recommended) | `%USERPROFILE%\occt-wasm-build\V7_9_3`    |
+| `scripts/build-occt-v8-wasm.ps1` (`.cmd`)  | V8_0_0_p1                | `%USERPROFILE%\occt-wasm-build\V8_0_0_p1` |
 
 Both wrap the shared implementation `scripts/build-occt-wasm.ps1`. Each version gets its own `src/`, `build/`, and `install/` under the versioned root (flat layout).
 
@@ -117,30 +117,30 @@ Serve: `python -m http.server 8000` from the build output directory (the `.html`
 
 Used by `build-occt-wasm.ps1` — keep in sync if editing the script:
 
-| Variable | Value | Why |
-| --- | --- | --- |
-| `BUILD_LIBRARY_TYPE` | `Static` | `.a` archives linked into EzyCad.wasm |
-| `BUILD_MODULE_Draw` | `OFF` | No Tcl/Tk harness |
-| `USE_OPENGL` | `OFF` | Desktop GL driver |
-| `USE_GLES2` | `ON` | `TKOpenGles` for WebGL2 |
-| `USE_VTK` | `OFF` | Default in 8.0; avoids GLES VTK issues |
-| `USE_FREETYPE` | `ON` | Dimension / text rendering |
-| `USE_TBB`, `USE_FFMPEG`, `USE_FREEIMAGE`, `USE_OPENVR`, `USE_TK` | `OFF` | Reduce deps and build time |
-| `CMAKE_*_FLAGS` | `-fexceptions` | Match EzyCad emscripten link flags |
+| Variable                                                         | Value          | Why                                    |
+| ---------------------------------------------------------------- | -------------- | -------------------------------------- |
+| `BUILD_LIBRARY_TYPE`                                             | `Static`       | `.a` archives linked into EzyCad.wasm  |
+| `BUILD_MODULE_Draw`                                              | `OFF`          | No Tcl/Tk harness                      |
+| `USE_OPENGL`                                                     | `OFF`          | Desktop GL driver                      |
+| `USE_GLES2`                                                      | `ON`           | `TKOpenGles` for WebGL2                |
+| `USE_VTK`                                                        | `OFF`          | Default in 8.0; avoids GLES VTK issues |
+| `USE_FREETYPE`                                                   | `ON`           | Dimension / text rendering             |
+| `USE_TBB`, `USE_FFMPEG`, `USE_FREEIMAGE`, `USE_OPENVR`, `USE_TK` | `OFF`          | Reduce deps and build time             |
+| `CMAKE_*_FLAGS`                                                  | `-fexceptions` | Match EzyCad emscripten link flags     |
 
 FreeType wasm configure also disables optional zlib/png/harfbuzz finds to simplify the emscripten build.
 
 ### Wasm troubleshooting
 
-| Symptom | Fix |
-| --- | --- |
-| `running scripts is disabled` | `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned` **or** use `build-occt-793-wasm.cmd` / `build-occt-v8-wasm.cmd` **or** `powershell -ExecutionPolicy Bypass -File ...` |
-| `Can't initialize filter; xz` | Script uses `.tar.gz` for FreeType; delete stale `*.tar.xz` under `src/` and re-run |
-| `source directory .../build/freetype does not contain CMakeLists.txt` | Fixed: do not name a PowerShell function parameter `$Args` (shadows automatic `$Args`) |
-| `emcc` not found | Run `emsdk_env.bat` / `emsdk_env.ps1` in the same shell |
-| EzyCad configure hangs on `find_package(OpenCASCADE)` | `emcmake cmake ... --debug-output`; verify `OpenCASCADE_DIR` path |
-| OCCT 8 + ghosted dimension labels | Retest `gui.edge_dim_text_render_mode` (Z-layer Topmost); grid compositing changed in 8.0 |
-| Shaded faces missing / wireframe-only solids (wasm, OCCT 8.x) | Use **7.9.3** (`build-occt-793-wasm.ps1`); see [bugs.md](bugs.md) |
+| Symptom                                                               | Fix                                                                                                                                                                         |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `running scripts is disabled`                                         | `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned` **or** use `build-occt-793-wasm.cmd` / `build-occt-v8-wasm.cmd` **or** `powershell -ExecutionPolicy Bypass -File ...` |
+| `Can't initialize filter; xz`                                         | Script uses `.tar.gz` for FreeType; delete stale `*.tar.xz` under `src/` and re-run                                                                                         |
+| `source directory .../build/freetype does not contain CMakeLists.txt` | Fixed: do not name a PowerShell function parameter `$Args` (shadows automatic `$Args`)                                                                                      |
+| `emcc` not found                                                      | Run `emsdk_env.bat` / `emsdk_env.ps1` in the same shell                                                                                                                     |
+| EzyCad configure hangs on `find_package(OpenCASCADE)`                 | `emcmake cmake ... --debug-output`; verify `OpenCASCADE_DIR` path                                                                                                           |
+| OCCT 8 + ghosted dimension labels                                     | Retest `gui.edge_dim_text_render_mode` (Z-layer Topmost); grid compositing changed in 8.0                                                                                   |
+| Shaded faces missing / wireframe-only solids (wasm, OCCT 8.x)         | Use **7.9.3** (`build-occt-793-wasm.ps1`); see [bugs.md](bugs.md)                                                                                                           |
 
 ---
 
@@ -204,25 +204,25 @@ OCCT 8 supports vcpkg (`USE_VTK=ON` only if needed). EzyCad’s `CMakeLists.txt`
 
 ## Maintaining OCCT version pins
 
-| File | What to update |
-| --- | --- |
-| `README.md` | Pin version, download URLs, example `OpenCASCADE_DIR` |
-| `CMakeLists.txt` | `OCCT_3RD_PARTY_DIR` paths (freetype/tbb/ffmpeg versions in `DLLS_COMMON`) |
+| File                                 | What to update                                                                           |
+| ------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `README.md`                          | Pin version, download URLs, example `OpenCASCADE_DIR`                                    |
+| `CMakeLists.txt`                     | `OCCT_3RD_PARTY_DIR` paths (freetype/tbb/ffmpeg versions in `DLLS_COMMON`)               |
 | `.github/workflows/windows-msvc.yml` | Prebuilt download URL, cache key, `OpenCASCADE_DIR`/`OCCT_3RD_PARTY_DIR` in CI configure |
-| `scripts/build-occt-wasm.ps1` | Shared wasm build; `$OcctTag`, `$FreeTypeVersion`, cmake flags |
-| `scripts/build-occt-793-wasm.ps1` | Wrapper defaulting to `V7_9_3` |
-| `scripts/build-occt-v8-wasm.ps1` | Wrapper defaulting to `V8_0_0_p1` |
-| `docs/building-occt.md` | This document |
-| `src/ply_io.cpp` | Comments if triangulation API changes |
+| `scripts/build-occt-wasm.ps1`        | Shared wasm build; `$OcctTag`, `$FreeTypeVersion`, cmake flags                           |
+| `scripts/build-occt-793-wasm.ps1`    | Wrapper defaulting to `V7_9_3`                                                           |
+| `scripts/build-occt-v8-wasm.ps1`     | Wrapper defaulting to `V8_0_0_p1`                                                        |
+| `docs/building-occt.md`              | This document                                                                            |
+| `src/ply_io.cpp`                     | Comments if triangulation API changes                                                    |
 
 ---
 
 ## Quick reference: EzyCad CMake variables
 
-| Variable | Platform | Purpose |
-| --- | --- | --- |
-| `OpenCASCADE_DIR` | All | Path to `OpenCASCADEConfig.cmake` directory |
-| `OCCT_3RD_PARTY_DIR` | Windows desktop | Root of 3rdparty bundle for runtime DLLs |
-| `CMAKE_BUILD_TYPE` | Native / wasm | `Release` recommended |
+| Variable             | Platform        | Purpose                                     |
+| -------------------- | --------------- | ------------------------------------------- |
+| `OpenCASCADE_DIR`    | All             | Path to `OpenCASCADEConfig.cmake` directory |
+| `OCCT_3RD_PARTY_DIR` | Windows desktop | Root of 3rdparty bundle for runtime DLLs    |
+| `CMAKE_BUILD_TYPE`   | Native / wasm   | `Release` recommended                       |
 
 EzyCad wasm also sets `TKOpenGles` in `OpenCASCADE_LIBS` when `CMAKE_CXX_COMPILER_ID` is `Emscripten`.

--- a/docs/ezycad_code_style.md
+++ b/docs/ezycad_code_style.md
@@ -113,9 +113,9 @@ Prefer **`CHK_RET(expr)`** when a callee returns `Status` or `Result<T>` and the
 
 ### Quick reference
 
-| Kind of problem | Mechanism |
-|-----------------|-----------|
-| Bug, contract violation, impossible branch | `EZY_ASSERT` / `EZY_ASSERT_MSG` |
+| Kind of problem                                   | Mechanism                                               |
+| ------------------------------------------------- | ------------------------------------------------------- |
+| Bug, contract violation, impossible branch        | `EZY_ASSERT` / `EZY_ASSERT_MSG`                         |
 | User error, I/O, OS, recoverable external failure | `Status`, `Result<T>`, `CHK_RET`, explicit error return |
 
 ## Comments

--- a/docs/ezycad_doc_style.md
+++ b/docs/ezycad_doc_style.md
@@ -8,35 +8,35 @@ Published HTML: **[https://ezycad.readthedocs.io/](https://ezycad.readthedocs.io
 
 All live together under the single `docs/` folder:
 
-| File | Purpose |
-|------|---------|
-| `usage.md` | Main usage guide |
-| `usage-sketch.md` | 2D sketching |
-| `usage-settings.md` | Settings pane and JSON |
-| `usage-occt-view.md` | 3D viewer (OCCT) |
-| `scripting.md` | Lua / Python consoles |
-| `building-occt.md` | Building Open CASCADE (desktop + WebAssembly) |
-| `bugs.md` | Known issues / sharp edges |
-| `ezycad_code_style.md` | C++ style (in `src/`) |
-| `ezycad_doc_style.md` | This file – Markdown / user docs style |
-| `README.md` (root) | Project overview |
-| `CHANGELOG.md` (root) | Release notes ([Keep a Changelog](https://keepachangelog.com/)) |
+| File                   | Purpose                                                         |
+| ---------------------- | --------------------------------------------------------------- |
+| `usage.md`             | Main usage guide                                                |
+| `usage-sketch.md`      | 2D sketching                                                    |
+| `usage-settings.md`    | Settings pane and JSON                                          |
+| `usage-occt-view.md`   | 3D viewer (OCCT)                                                |
+| `scripting.md`         | Lua / Python consoles                                           |
+| `building-occt.md`     | Building Open CASCADE (desktop + WebAssembly)                   |
+| `bugs.md`              | Known issues / sharp edges                                      |
+| `ezycad_code_style.md` | C++ style (in `src/`)                                           |
+| `ezycad_doc_style.md`  | This file – Markdown / user docs style                          |
+| `README.md` (root)     | Project overview                                                |
+| `CHANGELOG.md` (root)  | Release notes ([Keep a Changelog](https://keepachangelog.com/)) |
 
 ## Writing conventions
 
 - **Audience**: Machinists and hobby CAD users; prefer plain language and short steps.
 - **Headings**: Use `##` / `###` for sections Sphinx/MyST can index; keep a stable **Table of Contents** in `usage.md` when adding major sections.
 - **Keyboard shortcuts**: Use `<kbd>Tab</kbd>`, `<kbd>Ctrl</kbd>+<kbd>Z</kbd>`, etc. They render on Read the Docs via MyST.
-- **Tables**: GFM pipe tables are fine on Read the Docs.
+- **Tables**: Use **aligned** GFM pipe tables (pad columns so `|` lines up in the source). They render on Read the Docs / GitHub preview and stay readable in the editor. Preferred form and helper script: [agents/conventions/markdown-tables.md](../agents/conventions/markdown-tables.md).
 - **Cross-links**: Link other guides as `usage-sketch.md`, `usage-settings.md#view-menu`, or `#anchor` within the same file. Prefer anchors that match heading text (MyST slugifies headings for URLs).
 - **Encoding**: The **ASCII-only** rule in `ezycad_code_style.md` applies to `src/`, not to these guides; Unicode in user docs is acceptable when it helps clarity.
 
 ## Images
 
-| Kind | Path | Syntax |
-|------|------|--------|
-| Toolbar icons | `res/icons/Name.png` | `![alt](res/icons/Name.png)` |
-| Screenshots / diagrams | `images/name.png` | `![alt](images/name.png)` |
+| Kind                   | Path                 | Syntax                       |
+| ---------------------- | -------------------- | ---------------------------- |
+| Toolbar icons          | `res/icons/Name.png` | `![alt](res/icons/Name.png)` |
+| Screenshots / diagrams | `images/name.png`    | `![alt](images/name.png)`    |
 
 Rules:
 
@@ -55,11 +55,11 @@ Rules:
 
 Everything documentation-related now lives under the single `docs/` folder at the repository root. This is the only directory contributors need to care about for docs.
 
-| Item | Location |
-|------|----------|
-| Read the Docs config | [`.readthedocs.yaml`](.readthedocs.yaml) (at repo root) |
-| Sphinx config + content | `docs/conf.py`, `docs/index.rst`, all the `*.md` guides |
-| Python deps | `docs/requirements.txt` |
+| Item                        | Location                                                   |
+| --------------------------- | ---------------------------------------------------------- |
+| Read the Docs config        | [`.readthedocs.yaml`](.readthedocs.yaml) (at repo root)    |
+| Sphinx config + content     | `docs/conf.py`, `docs/index.rst`, all the `*.md` guides    |
+| Python deps                 | `docs/requirements.txt`                                    |
 | GitHub Actions verification | [`.github/workflows/docs.yml`](.github/workflows/docs.yml) |
 
 ```bash

--- a/docs/readthedocs.md
+++ b/docs/readthedocs.md
@@ -8,9 +8,9 @@ Published site: **https://ezycad.readthedocs.io/**
 
 ## Repository automation
 
-| Mechanism | What it does |
-| --- | --- |
-| [`.readthedocs.yaml`](../.readthedocs.yaml) | RTD build config (points at `docs/conf.py`). |
+| Mechanism                                                     | What it does                                                       |
+| ------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [`.readthedocs.yaml`](../.readthedocs.yaml)                   | RTD build config (points at `docs/conf.py`).                       |
 | [`.github/workflows/docs.yml`](../.github/workflows/docs.yml) | GitHub Actions verification build (runs on changes under `docs/`). |
 
 Screenshots and diagrams live in `docs/images/`. Icons come from `res/icons/`.

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -4,10 +4,10 @@ EzyCad can embed **Lua** and (on supported builds) **Python** consoles. They sha
 
 ## Availability
 
-| | Lua | Python |
-| --- | --- | --- |
+|                       | Lua                           | Python                                                                                                                                                                                                   |
+| --------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Desktop (Windows)** | Always (built-in Lua library) | Only if the app was **built with Python enabled** (`EZYCAD_HAVE_PYTHON` in CMake; needs Python development libraries). If the **View -> Python Console** item appears and works, your build includes it. |
-| **WebAssembly** | Yes | No (not shipped in the browser build). |
+| **WebAssembly**       | Yes                           | No (not shipped in the browser build).                                                                                                                                                                   |
 
 ## Opening the consoles
 
@@ -30,35 +30,35 @@ Use **`ezy.help()`** or **`help()`** in either console for the built-in reminder
 
 **`ezy`**
 
-| Method | Purpose |
-| --- | --- |
-| `ezy.log(msg)` | Print to the console and the main **Log** pane |
-| `ezy.msg(text)` | Show a status message (same style as GUI messages) |
-| `ezy.get_mode()` | Current application mode name (string) |
-| `ezy.set_mode(name)` | Switch mode by name |
-| `ezy.help()` | Print binding summary |
+| Method               | Purpose                                            |
+| -------------------- | -------------------------------------------------- |
+| `ezy.log(msg)`       | Print to the console and the main **Log** pane     |
+| `ezy.msg(text)`      | Show a status message (same style as GUI messages) |
+| `ezy.get_mode()`     | Current application mode name (string)             |
+| `ezy.set_mode(name)` | Switch mode by name                                |
+| `ezy.help()`         | Print binding summary                              |
 
 **`view`**
 
-| Method | Purpose |
-| --- | --- |
-| `view.sketch_count()` | Number of sketches |
-| `view.shape_count()` | Number of 3D shapes |
-| `view.curr_sketch_name()` | Name of the current sketch |
-| `view.add_box(ox, oy, oz, w, l, h)` / `view.add_sphere(ox, oy, oz, r)` | Add primitive shapes |
-| `view.get_shape(i)` | Shape by **1-based** index: Lua userdata or `nil`; Python `Shp` with `name`, `visible`, `set_visible`, etc. |
-| `view.get_camera()` | Camera vectors: `eye`, `center`, and `up` |
-| `view.set_camera(ex, ey, ez, cx, cy, cz, ux, uy, uz)` | Set camera vectors |
+| Method                                                                 | Purpose                                                                                                     |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `view.sketch_count()`                                                  | Number of sketches                                                                                          |
+| `view.shape_count()`                                                   | Number of 3D shapes                                                                                         |
+| `view.curr_sketch_name()`                                              | Name of the current sketch                                                                                  |
+| `view.add_box(ox, oy, oz, w, l, h)` / `view.add_sphere(ox, oy, oz, r)` | Add primitive shapes                                                                                        |
+| `view.get_shape(i)`                                                    | Shape by **1-based** index: Lua userdata or `nil`; Python `Shp` with `name`, `visible`, `set_visible`, etc. |
+| `view.get_camera()`                                                    | Camera vectors: `eye`, `center`, and `up`                                                                   |
+| `view.set_camera(ex, ey, ez, cx, cy, cz, ux, uy, uz)`                  | Set camera vectors                                                                                          |
 
 **Sketch inspection and creation** (Lua and Python; indices are **1-based** in Lua, **0-based** in Python):
 
-| Method | Purpose |
-| --- | --- |
-| `view.curr_sketch_node_count()` / `view.curr_sketch_node(i)` | Read nodes `(x, y)` on the current sketch plane |
-| `view.curr_sketch_dim_count()` / `view.curr_sketch_dim(i)` | Read length dimensions |
-| `view.add_sketch(plane, offset, base_name)` | New sketch on `XY`, `XZ`, or `YZ` (`offset` in display units; optional name) |
-| `view.add_edge(x1, y1, x2, y2)` | Add a linear edge to the current sketch |
-| `view.finish_sketch_edges()` | Rebuild closed-face topology after bulk edge import |
+| Method                                                       | Purpose                                                                      |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `view.curr_sketch_node_count()` / `view.curr_sketch_node(i)` | Read nodes `(x, y)` on the current sketch plane                              |
+| `view.curr_sketch_dim_count()` / `view.curr_sketch_dim(i)`   | Read length dimensions                                                       |
+| `view.add_sketch(plane, offset, base_name)`                  | New sketch on `XY`, `XZ`, or `YZ` (`offset` in display units; optional name) |
+| `view.add_edge(x1, y1, x2, y2)`                              | Add a linear edge to the current sketch                                      |
+| `view.finish_sketch_edges()`                                 | Rebuild closed-face topology after bulk edge import                          |
 
 **Lua only:** global **`print`** is routed to **`ezy.log`**.  
 **Python only:** **`print`** is similarly redirected to **`ezy.log`** after bootstrap.

--- a/docs/usage-settings.md
+++ b/docs/usage-settings.md
@@ -144,73 +144,73 @@ If saved layout text has no `[Docking]` section (older installs), a default dock
 
 ### `occt_view`
 
-| Key | Type | Meaning |
-| --- | --- | --- |
-| `bg_color1` | array of 3 numbers | Background gradient color 1 (float RGB, 0 to 1). |
-| `bg_color2` | array of 3 numbers | Background gradient color 2. |
-| `bg_gradient_method` | integer | Gradient mode: 0 horizontal, 1 vertical, 2 to 3 diagonals, 4 to 7 corners (same order as the Settings pane combo). |
-| `grid_color1` | array of 3 numbers | Fine (dense) grid lines (`Aspect_Grid` main color). |
-| `grid_color2` | array of 3 numbers | Major (sparse / every-tenth) grid lines (`Aspect_Grid` tenth-line color). |
-| `grid_visible` | boolean | When **true**, the OCCT reference grid is drawn in the 3D view (default **true**). |
-| `grid_step` | number | Grid line spacing in **model** units (default **10**). Legacy `grid_x_step` / `grid_y_step` load as this value (X preferred). |
-| `grid_padding` | number | Margin around active sketch content when sizing the grid, in **model** units (default **1000**; Settings shows display units). Legacy `grid_graphic_x_size` loads as padding if `grid_padding` is absent. |
-| `grid_graphic_z_offset` | number | Grid plane offset along Z in **model** units. |
+| Key                     | Type               | Meaning                                                                                                                                                                                                   |
+| ----------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bg_color1`             | array of 3 numbers | Background gradient color 1 (float RGB, 0 to 1).                                                                                                                                                          |
+| `bg_color2`             | array of 3 numbers | Background gradient color 2.                                                                                                                                                                              |
+| `bg_gradient_method`    | integer            | Gradient mode: 0 horizontal, 1 vertical, 2 to 3 diagonals, 4 to 7 corners (same order as the Settings pane combo).                                                                                        |
+| `grid_color1`           | array of 3 numbers | Fine (dense) grid lines (`Aspect_Grid` main color).                                                                                                                                                       |
+| `grid_color2`           | array of 3 numbers | Major (sparse / every-tenth) grid lines (`Aspect_Grid` tenth-line color).                                                                                                                                 |
+| `grid_visible`          | boolean            | When **true**, the OCCT reference grid is drawn in the 3D view (default **true**).                                                                                                                        |
+| `grid_step`             | number             | Grid line spacing in **model** units (default **10**). Legacy `grid_x_step` / `grid_y_step` load as this value (X preferred).                                                                             |
+| `grid_padding`          | number             | Margin around active sketch content when sizing the grid, in **model** units (default **1000**; Settings shows display units). Legacy `grid_graphic_x_size` loads as padding if `grid_padding` is absent. |
+| `grid_graphic_z_offset` | number             | Grid plane offset along Z in **model** units.                                                                                                                                                             |
 
 ### `gui`
 
-| Key | Type | Meaning |
-| --- | --- | --- |
-| `dark_mode` | boolean | Light/dark theme. |
-| `show_options` | boolean | Options panel visible. |
-| `show_sketch_list` | boolean | Sketch List pane visible. |
-| `show_shape_list` | boolean | Shape List pane visible. |
-| `log_window_visible` | boolean | Log window visible. |
-| `show_settings_dialog` | boolean | Whether the Settings pane was open when last saved (usually false). |
-| `show_lua_console` | boolean | Lua console pane visible. |
-| `show_python_console` | boolean | Python console pane visible (native builds with Python). |
-| `show_dbg` | boolean | Debug pane visible (debug builds only). |
-| `inspection_orthographic` | boolean | Non-sketch modes Options: orthographic camera when true (default false). Sketch modes always use orthographic. |
-| `edge_dim_label_h` | integer | Length dimension label placement: **0** near first point, **1** near second, **2** center, **3** automatic. |
-| `edge_dim_line_width` | number | Sketch length dimension line width (**0.5** to **8.0**). |
-| `edge_dim_arrow_size` | number | Arrow head length (**1.0** to **24.0**). |
-| `edge_dim_color` | array of 3 numbers | Dimension line, arrow, and text RGB (**0** to **1** per channel; default olive **0.54**, **0.54**, **0.21**). |
-| `edge_dim_text_scale` | number | Label height multiplier (**0.5** to **3.0**; default **1.0**). |
-| `edge_dim_text_render_mode` | integer | **0** opaque 2D, **1** SetCommonColor, **2** 2D screen, **3** 3D text, **4** Z Top, **5** Z Topmost (default). |
-| `edge_dim_arrow_style` | integer | **0** standard, **1** sharp, **2** wide, **3** 3D shaded. |
-| `edge_dim_arrow_orientation` | integer | **0** automatic, **1** internal, **2** external. |
-| `show_sketch_dimensions` | boolean | When false, hides length dimensions on all sketches. |
-| `permanent_node_anno_scale` | number | Scale for permanent **+** markers: the sketch **Origin** and user-placed Add node points ([Sketch origin](usage-sketch.md#sketch-origin); **0.25** to **3.0**; default **1.0**). |
-| `origin_marker_color` | array of 3 numbers | RGB color for the **active** sketch's Origin marker (+ with circle; **0** to **1** per channel; default cyan **0.0**, **0.75**, **1.0**). |
-| `snap_guide_color_node` | array of 3 numbers | RGB for snap guides when both axes lock to the same node (float **0** to **1**; default lavender **0.82**, **0.55**, **0.95**). Legacy `snap_guide_color` loads here when `snap_guide_color_node` is absent. |
-| `snap_guide_color_axis` | array of 3 numbers | RGB for snap guides when aligned on X or Y only (float **0** to **1**; default magenta **0.96**, **0.06**, **0.54**). Legacy `snap_guide_color` sets both node and axis colors. |
-| `snap_guide_mode` | integer | **0** *Traditional* (local markers), **1** *Fullscreen* (view-spanning axis lines), **2** *Both* (default **2**). |
-| `snap_guide_line_width` | number | Open CASCADE line width for snap guides (axis lines, markers, co-axial overlay; **0.5** to **8.0**; default **1.0**). |
-| `annotate_all_coaxial_nodes` | boolean | When true (default), show axis guides and markers for *all* co-axial nodes (current sketch plus other visible sketches). When false, only the closest node per active axis is annotated. Also in sketch **Options**. |
-| `imgui_style_dark` | object | ImGui layout for **dark mode** (see keys below). |
-| `imgui_style_light` | object | ImGui layout for **light mode** (same keys). |
-| `imgui_rounding_general` | number | **Legacy:** copied into both theme objects on load when `imgui_style_*` is absent. |
-| `imgui_rounding_scroll` | number | **Legacy:** same. |
-| `imgui_rounding_tabs` | number | **Legacy:** same. |
-| `underlay_highlight_color` | array of 3 numbers | Default underlay tint (float RGB **0** to **1** per channel; default **0.64**, **0.56**, **0.31**). |
-| `elm_list_hover_color` | array of 4 numbers | RGBA highlight for rows hovered in the **Shape List** or **Sketch List** dimensions table (float **0** to **1** per channel; default purple **0.40**, **0.10**, **0.47**, **1**). |
-| `view_roll_step_deg` | number | Degrees per **NumPad 8**/**2**/**4**/**6** orbit and **Shift+NumPad 4**/**6** roll (allowed range **0.1** to **180** in code; default **45**). |
-| `view_zoom_scroll_scale` | number | Multiplier for `UpdateZoom` scroll delta from wheel and keyboard zoom (allowed range **0.25** to **64** in code; default **4**). With **Shift** held, the effective step is multiplied by **0.1** (Blender-style finer zoom). |
-| `load_last_opened_on_startup` | boolean | Desktop: open the last `.ezy` on launch. **Legacy:** `load_last_saved_on_startup` is read as a fallback if the newer key is absent. |
-| `last_opened_project_path` | string | Path of the last opened project for the option above. **Legacy:** `last_saved_project_path` is accepted if the newer key is missing. |
+| Key                           | Type               | Meaning                                                                                                                                                                                                                       |
+| ----------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dark_mode`                   | boolean            | Light/dark theme.                                                                                                                                                                                                             |
+| `show_options`                | boolean            | Options panel visible.                                                                                                                                                                                                        |
+| `show_sketch_list`            | boolean            | Sketch List pane visible.                                                                                                                                                                                                     |
+| `show_shape_list`             | boolean            | Shape List pane visible.                                                                                                                                                                                                      |
+| `log_window_visible`          | boolean            | Log window visible.                                                                                                                                                                                                           |
+| `show_settings_dialog`        | boolean            | Whether the Settings pane was open when last saved (usually false).                                                                                                                                                           |
+| `show_lua_console`            | boolean            | Lua console pane visible.                                                                                                                                                                                                     |
+| `show_python_console`         | boolean            | Python console pane visible (native builds with Python).                                                                                                                                                                      |
+| `show_dbg`                    | boolean            | Debug pane visible (debug builds only).                                                                                                                                                                                       |
+| `inspection_orthographic`     | boolean            | Non-sketch modes Options: orthographic camera when true (default false). Sketch modes always use orthographic.                                                                                                                |
+| `edge_dim_label_h`            | integer            | Length dimension label placement: **0** near first point, **1** near second, **2** center, **3** automatic.                                                                                                                   |
+| `edge_dim_line_width`         | number             | Sketch length dimension line width (**0.5** to **8.0**).                                                                                                                                                                      |
+| `edge_dim_arrow_size`         | number             | Arrow head length (**1.0** to **24.0**).                                                                                                                                                                                      |
+| `edge_dim_color`              | array of 3 numbers | Dimension line, arrow, and text RGB (**0** to **1** per channel; default olive **0.54**, **0.54**, **0.21**).                                                                                                                 |
+| `edge_dim_text_scale`         | number             | Label height multiplier (**0.5** to **3.0**; default **1.0**).                                                                                                                                                                |
+| `edge_dim_text_render_mode`   | integer            | **0** opaque 2D, **1** SetCommonColor, **2** 2D screen, **3** 3D text, **4** Z Top, **5** Z Topmost (default).                                                                                                                |
+| `edge_dim_arrow_style`        | integer            | **0** standard, **1** sharp, **2** wide, **3** 3D shaded.                                                                                                                                                                     |
+| `edge_dim_arrow_orientation`  | integer            | **0** automatic, **1** internal, **2** external.                                                                                                                                                                              |
+| `show_sketch_dimensions`      | boolean            | When false, hides length dimensions on all sketches.                                                                                                                                                                          |
+| `permanent_node_anno_scale`   | number             | Scale for permanent **+** markers: the sketch **Origin** and user-placed Add node points ([Sketch origin](usage-sketch.md#sketch-origin); **0.25** to **3.0**; default **1.0**).                                              |
+| `origin_marker_color`         | array of 3 numbers | RGB color for the **active** sketch's Origin marker (+ with circle; **0** to **1** per channel; default cyan **0.0**, **0.75**, **1.0**).                                                                                     |
+| `snap_guide_color_node`       | array of 3 numbers | RGB for snap guides when both axes lock to the same node (float **0** to **1**; default lavender **0.82**, **0.55**, **0.95**). Legacy `snap_guide_color` loads here when `snap_guide_color_node` is absent.                  |
+| `snap_guide_color_axis`       | array of 3 numbers | RGB for snap guides when aligned on X or Y only (float **0** to **1**; default magenta **0.96**, **0.06**, **0.54**). Legacy `snap_guide_color` sets both node and axis colors.                                               |
+| `snap_guide_mode`             | integer            | **0** *Traditional* (local markers), **1** *Fullscreen* (view-spanning axis lines), **2** *Both* (default **2**).                                                                                                             |
+| `snap_guide_line_width`       | number             | Open CASCADE line width for snap guides (axis lines, markers, co-axial overlay; **0.5** to **8.0**; default **1.0**).                                                                                                         |
+| `annotate_all_coaxial_nodes`  | boolean            | When true (default), show axis guides and markers for *all* co-axial nodes (current sketch plus other visible sketches). When false, only the closest node per active axis is annotated. Also in sketch **Options**.          |
+| `imgui_style_dark`            | object             | ImGui layout for **dark mode** (see keys below).                                                                                                                                                                              |
+| `imgui_style_light`           | object             | ImGui layout for **light mode** (same keys).                                                                                                                                                                                  |
+| `imgui_rounding_general`      | number             | **Legacy:** copied into both theme objects on load when `imgui_style_*` is absent.                                                                                                                                            |
+| `imgui_rounding_scroll`       | number             | **Legacy:** same.                                                                                                                                                                                                             |
+| `imgui_rounding_tabs`         | number             | **Legacy:** same.                                                                                                                                                                                                             |
+| `underlay_highlight_color`    | array of 3 numbers | Default underlay tint (float RGB **0** to **1** per channel; default **0.64**, **0.56**, **0.31**).                                                                                                                           |
+| `elm_list_hover_color`        | array of 4 numbers | RGBA highlight for rows hovered in the **Shape List** or **Sketch List** dimensions table (float **0** to **1** per channel; default purple **0.40**, **0.10**, **0.47**, **1**).                                             |
+| `view_roll_step_deg`          | number             | Degrees per **NumPad 8**/**2**/**4**/**6** orbit and **Shift+NumPad 4**/**6** roll (allowed range **0.1** to **180** in code; default **45**).                                                                                |
+| `view_zoom_scroll_scale`      | number             | Multiplier for `UpdateZoom` scroll delta from wheel and keyboard zoom (allowed range **0.25** to **64** in code; default **4**). With **Shift** held, the effective step is multiplied by **0.1** (Blender-style finer zoom). |
+| `load_last_opened_on_startup` | boolean            | Desktop: open the last `.ezy` on launch. **Legacy:** `load_last_saved_on_startup` is read as a fallback if the newer key is absent.                                                                                           |
+| `last_opened_project_path`    | string             | Path of the last opened project for the option above. **Legacy:** `last_saved_project_path` is accepted if the newer key is missing.                                                                                          |
 
 Each **`imgui_style_dark`** / **`imgui_style_light`** object may contain:
 
-| Key | Type | Meaning |
-| --- | --- | --- |
-| `rounding_general` | number | Window/child/frame/popup rounding (**0** to **32** in JSON; Settings sliders **0** to **16**). |
-| `rounding_scroll` | number | Scrollbar and grab rounding. |
-| `rounding_tabs` | number | Tab rounding. |
-| `window_alpha` | number | Panel window background opacity (**0.1** to **1.0**). |
-| `window_border` | number | Window border thickness (**0** to **2**). |
-| `frame_border` | number | Widget frame border thickness (**0** to **2**). |
-| `window_padding_x`, `window_padding_y` | number | Inner padding of windows (**0** to **24**). |
-| `frame_padding_x`, `frame_padding_y` | number | Padding inside framed widgets (**0** to **24**). |
-| `item_spacing_x`, `item_spacing_y` | number | Spacing between widgets (**0** to **24**). |
+| Key                                    | Type   | Meaning                                                                                        |
+| -------------------------------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| `rounding_general`                     | number | Window/child/frame/popup rounding (**0** to **32** in JSON; Settings sliders **0** to **16**). |
+| `rounding_scroll`                      | number | Scrollbar and grab rounding.                                                                   |
+| `rounding_tabs`                        | number | Tab rounding.                                                                                  |
+| `window_alpha`                         | number | Panel window background opacity (**0.1** to **1.0**).                                          |
+| `window_border`                        | number | Window border thickness (**0** to **2**).                                                      |
+| `frame_border`                         | number | Widget frame border thickness (**0** to **2**).                                                |
+| `window_padding_x`, `window_padding_y` | number | Inner padding of windows (**0** to **24**).                                                    |
+| `frame_padding_x`, `frame_padding_y`   | number | Padding inside framed widgets (**0** to **24**).                                               |
+| `item_spacing_x`, `item_spacing_y`     | number | Spacing between widgets (**0** to **24**).                                                     |
 
 Scripting API **`ezy.occt_view_settings_json()`** returns a JSON string with **`occt_view`** plus selected **`gui`** keys (including dimension and snap keys above, **`gui.permanent_node_anno_scale`**, **`gui.inspection_orthographic`**, **`gui.view_roll_step_deg`**, **`gui.view_zoom_scroll_scale`** when saved). See [scripting.md](scripting.md).
 

--- a/docs/usage-sketch.md
+++ b/docs/usage-sketch.md
@@ -45,17 +45,17 @@ See [Sketch origin](#sketch-origin) — every sketch includes one permanent refe
 
 **Every sketch has exactly one Origin** — a fixed reference point on the sketch plane, shown as a **+ inside a circle** on the **active sketch only** (a **permanent node**, not placed with a tool) whenever that sketch is visible in sketch mode (and in tools such as **polar duplicate** that snap to sketch nodes). User-placed [Add node](#add-node-tool) points use a red **+** without a circle on every visible sketch. Color is set in **Settings -> Sketch -> Origin marker color**.
 
-| | |
-| ---: | --- |
-| **When created** | Added automatically when the sketch is created; you do not place it with a tool. |
-| **Location (reference plane)** | Sketch plane coordinates **(0, 0)** — the plane's built-in reference origin (XY, XZ, YZ, or offset reference planes). |
-| **Location (from face)** | **Center of the bounding box** of the face boundary wire when you use [Create sketch from planar face](#create-sketch-from-planar-face-tool). |
-| **Sketch List** | Listed as **Origin** under **Nodes** when you expand a sketch row (see [Sketch List](usage.md#sketch-list)). |
-| **Snapping** | Acts like any other sketch vertex when the marker is shown: axis guides, vertex lock, and distance snap apply. Origins from **other visible sketches** (with marker shown) are also snap targets on the current plane. When **Show origin marker** is off, the Origin is not a snap target. |
-| **Cannot delete** | The Origin cannot be selected or deleted. Hide it with **Show origin marker** in **Sketch properties** instead. |
-| **Marker size** | **Settings -> Sketch -> Permanent node annotation size** (`permanent_node_anno_scale`; see [usage-settings.md](usage-settings.md#settings-file-reference)). |
-| **Marker color** | **Settings -> Sketch -> Origin marker color** (`origin_marker_color`; active sketch only). |
-| **Sketch properties** | **Sketch List -> [P]** — **Show origin marker**, **Position** sliders (range follows the current view) with **Set** for typed values. |
+|                                |                                                                                                                                                                                                                                                                                             |
+| -----------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **When created**               | Added automatically when the sketch is created; you do not place it with a tool.                                                                                                                                                                                                            |
+| **Location (reference plane)** | Sketch plane coordinates **(0, 0)** — the plane's built-in reference origin (XY, XZ, YZ, or offset reference planes).                                                                                                                                                                       |
+| **Location (from face)**       | **Center of the bounding box** of the face boundary wire when you use [Create sketch from planar face](#create-sketch-from-planar-face-tool).                                                                                                                                               |
+| **Sketch List**                | Listed as **Origin** under **Nodes** when you expand a sketch row (see [Sketch List](usage.md#sketch-list)).                                                                                                                                                                                |
+| **Snapping**                   | Acts like any other sketch vertex when the marker is shown: axis guides, vertex lock, and distance snap apply. Origins from **other visible sketches** (with marker shown) are also snap targets on the current plane. When **Show origin marker** is off, the Origin is not a snap target. |
+| **Cannot delete**              | The Origin cannot be selected or deleted. Hide it with **Show origin marker** in **Sketch properties** instead.                                                                                                                                                                             |
+| **Marker size**                | **Settings -> Sketch -> Permanent node annotation size** (`permanent_node_anno_scale`; see [usage-settings.md](usage-settings.md#settings-file-reference)).                                                                                                                                 |
+| **Marker color**               | **Settings -> Sketch -> Origin marker color** (`origin_marker_color`; active sketch only).                                                                                                                                                                                                  |
+| **Sketch properties**          | **Sketch List -> [P]** — **Show origin marker**, **Position** sliders (range follows the current view) with **Set** for typed values.                                                                                                                                                       |
 
 **Tips**
 
@@ -68,16 +68,16 @@ See [Sketch origin](#sketch-origin) — every sketch includes one permanent refe
 
 While you draw or place points in sketch mode, EzyCad helps you align to existing geometry. **Snap dist**, **Snap guide mode**, and **All co-axial nodes** are in the Options panel; **Snap guide color**, **Snap guide line width**, and the same mode/co-axial toggles are in **Settings -> Sketch** (see [usage-settings.md](usage-settings.md#sketch-tools)).
 
-| | |
-| ---: | --- |
-| **Snap distance** | Larger **Snap dist** values let snaps engage from farther away (screen pixels, converted to the sketch plane at the cursor). |
-| **Snap guides** | **Snap guide mode**: *Traditional* (local markers at guide intersections), *Fullscreen* (view-spanning axis lines), or *Both*. **Snap guide color (node)** is used when both X and Y align to the same vertex; **Snap guide color (axis)** when only one axis aligns. A separate checkbox **All co-axial nodes** (in the sketch Options panel and in Settings) enables *global* mode: when on, full horizontal and vertical guide lines + markers are shown for *all* nodes in the current sketch and all other visible sketches (the complete set of co-axial alignments). When off (default), only the closest node per active axis is annotated (classic closest-relative behavior). |
-| **Axis alignment** | Near a snap target, the pick can align to that point's **X** or **Y** on the sketch plane; guides show which axis is active. When **both** axes align to the **same** point, the cursor **locks to that vertex**. |
-| **Sketch origin** | Each sketch's built-in **Origin** (see [Sketch origin](#sketch-origin)) is a snap target when its marker is shown. |
-| **Mid-point snap (Add node)** | A click near a **straight** edge (not at its ends) snaps onto the segment and **splits** it at commit time (see [Add node tool](#add-node-tool)). Separate from vertex lock. |
-| **Automatic splitting on edge intersections** | When you add a new straight (linear) edge using the Line Edge tool or Multi-Line Edge tool, if it crosses or touches the interior of any existing straight edge, the existing edge is automatically split at the intersection point. The new edge is also subdivided into atomic segments where needed. The same splitting occurs when an endpoint of the new edge snaps to the midpoint of an existing edge. When you add an **arc segment**, existing straight and arc edges are split at interior crossings, and the new arc is subdivided at intersection points on its interior. This produces correct T-junctions, crossings, and cleanly divided faces from a single sketch. |
-| **Other visible sketches** | Nodes from **other visible sketches** are projected onto the current sketch plane and act as snap targets (same distance rules). Each visible sketch contributes its **Origin** when that sketch's marker is shown, plus any user-placed nodes. Useful for multi-sketch layouts and tools such as **polar duplicate** that pick sketch points. |
-| **Operational axis mode** | While an operational axis is **defined** and **Operational axis** mode is active (mirror/revolve phase), sketch snap and permanent **+** node markers are **suppressed** so edge and face selection stays clear. Normal snapping applies again after **Clear axis** or when you leave the tool. Axis placement (before the axis exists) still uses snap. |
+|                                               |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --------------------------------------------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Snap distance**                             | Larger **Snap dist** values let snaps engage from farther away (screen pixels, converted to the sketch plane at the cursor).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| **Snap guides**                               | **Snap guide mode**: *Traditional* (local markers at guide intersections), *Fullscreen* (view-spanning axis lines), or *Both*. **Snap guide color (node)** is used when both X and Y align to the same vertex; **Snap guide color (axis)** when only one axis aligns. A separate checkbox **All co-axial nodes** (in the sketch Options panel and in Settings) enables *global* mode: when on, full horizontal and vertical guide lines + markers are shown for *all* nodes in the current sketch and all other visible sketches (the complete set of co-axial alignments). When off (default), only the closest node per active axis is annotated (classic closest-relative behavior). |
+| **Axis alignment**                            | Near a snap target, the pick can align to that point's **X** or **Y** on the sketch plane; guides show which axis is active. When **both** axes align to the **same** point, the cursor **locks to that vertex**.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| **Sketch origin**                             | Each sketch's built-in **Origin** (see [Sketch origin](#sketch-origin)) is a snap target when its marker is shown.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| **Mid-point snap (Add node)**                 | A click near a **straight** edge (not at its ends) snaps onto the segment and **splits** it at commit time (see [Add node tool](#add-node-tool)). Separate from vertex lock.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| **Automatic splitting on edge intersections** | When you add a new straight (linear) edge using the Line Edge tool or Multi-Line Edge tool, if it crosses or touches the interior of any existing straight edge, the existing edge is automatically split at the intersection point. The new edge is also subdivided into atomic segments where needed. The same splitting occurs when an endpoint of the new edge snaps to the midpoint of an existing edge. When you add an **arc segment**, existing straight and arc edges are split at interior crossings, and the new arc is subdivided at intersection points on its interior. This produces correct T-junctions, crossings, and cleanly divided faces from a single sketch.     |
+| **Other visible sketches**                    | Nodes from **other visible sketches** are projected onto the current sketch plane and act as snap targets (same distance rules). Each visible sketch contributes its **Origin** when that sketch's marker is shown, plus any user-placed nodes. Useful for multi-sketch layouts and tools such as **polar duplicate** that pick sketch points.                                                                                                                                                                                                                                                                                                                                          |
+| **Operational axis mode**                     | While an operational axis is **defined** and **Operational axis** mode is active (mirror/revolve phase), sketch snap and permanent **+** node markers are **suppressed** so edge and face selection stays clear. Normal snapping applies again after **Clear axis** or when you leave the tool. Axis placement (before the axis exists) still uses snap.                                                                                                                                                                                                                                                                                                                                |
 
 **Angle constraint:** When a line or add-node rubber band has an active angle constraint, vertex and axis snap may be disabled or relaxed so the typed angle stays exact (see each tool's section).
 
@@ -92,15 +92,15 @@ Common keyboard shortcuts (hotkeys) while working in 2D sketch mode or with sket
 
 ### Common sketch hotkeys
 
-| Hotkey                        | Action |
-| ---                           | --- |
-| <kbd>Tab</kbd>                | Open precise distance / length / radius / size input dialog (most creation tools) |
-| <kbd>Shift</kbd>+<kbd>Tab</kbd> | Open angle (degrees) input dialog for constrained line / multi-line / add-node placement |
-| <kbd>Esc</kbd>                | Cancel the current tool, step, or rubber-band preview |
-| <kbd>Enter</kbd>              | Confirm current numeric input or finalize the step |
-| <kbd>D</kbd>                  | Activate the Dimension tool |
-| <kbd>Shift</kbd>+<kbd>D</kbd> / <kbd>Delete</kbd> / <kbd>Backspace</kbd> | Delete the selected sketch element(s) or dimension |
-| <kbd>Right-click</kbd>        | In multi-line / sequences: complete current item and continue, or finish the whole operation |
+| Hotkey                                                                   | Action                                                                                       |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| <kbd>Tab</kbd>                                                           | Open precise distance / length / radius / size input dialog (most creation tools)            |
+| <kbd>Shift</kbd>+<kbd>Tab</kbd>                                          | Open angle (degrees) input dialog for constrained line / multi-line / add-node placement     |
+| <kbd>Esc</kbd>                                                           | Cancel the current tool, step, or rubber-band preview                                        |
+| <kbd>Enter</kbd>                                                         | Confirm current numeric input or finalize the step                                           |
+| <kbd>D</kbd>                                                             | Activate the Dimension tool                                                                  |
+| <kbd>Shift</kbd>+<kbd>D</kbd> / <kbd>Delete</kbd> / <kbd>Backspace</kbd> | Delete the selected sketch element(s) or dimension                                           |
+| <kbd>Right-click</kbd>                                                   | In multi-line / sequences: complete current item and continue, or finish the whole operation |
 
 **Notes:**
 - <kbd>Tab</kbd> / <kbd>Shift+Tab</kbd> work even when focus is in the 3D view (they are routed to the active sketch tool for precise entry).
@@ -109,11 +109,11 @@ Common keyboard shortcuts (hotkeys) while working in 2D sketch mode or with sket
 
 ### Move / rotate / polar axis constraints (when those options are active)
 
-| Hotkey   | Action |
-| ---      | --- |
+| Hotkey       | Action                                                                    |
+| ------------ | ------------------------------------------------------------------------- |
 | <kbd>X</kbd> | Toggle / cycle X axis constraint (move) or rotation axis (rotate / polar) |
-| <kbd>Y</kbd> | Toggle / cycle Y |
-| <kbd>Z</kbd> | Toggle / cycle Z |
+| <kbd>Y</kbd> | Toggle / cycle Y                                                          |
+| <kbd>Z</kbd> | Toggle / cycle Z                                                          |
 
 See the individual tool sections (and [usage.md#hotkeys](usage.md#hotkeys)) for full context and additional view / general hotkeys.
 
@@ -130,15 +130,15 @@ The single line edge tool allows you to create straight line segments between tw
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Two-point creation** | Click to set the start point, then click to set the end point |
-| **Real-time preview** | See the line shape while moving the mouse |
-| **Precise length control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact line lengths |
-| **Angle constraint** | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the line to a specific angle |
-| **Snap support** | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active) |
-| **Dimension annotations** | Optional length dimensions can be displayed |
-| **Tool Options** | **Add midpoint nodes** and **Place from center** checkboxes (see [Line edge Options](#line-edge-options) below); each has a **?** help button |
+|                            |                                                                                                                                               |
+| -------------------------: | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Two-point creation**     | Click to set the start point, then click to set the end point                                                                                 |
+| **Real-time preview**      | See the line shape while moving the mouse                                                                                                     |
+| **Precise length control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact line lengths                                                                     |
+| **Angle constraint**       | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the line to a specific angle                                        |
+| **Snap support**           | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active)                                                 |
+| **Dimension annotations**  | Optional length dimensions can be displayed                                                                                                   |
+| **Tool Options**           | **Add midpoint nodes** and **Place from center** checkboxes (see [Line edge Options](#line-edge-options) below); each has a **?** help button |
 
 (line-edge-options)=
 ### Line edge Options
@@ -178,13 +178,13 @@ When checked, the **first click** sets the **midpoint** of the new edge (not an 
 
 **Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>Tab</kbd> | Open distance input dialog for precise length control |
+|                                 |                                                                                              |
+| ------------------------------: | -------------------------------------------------------------------------------------------- |
+| <kbd>Tab</kbd>                  | Open distance input dialog for precise length control                                        |
 | <kbd>Shift</kbd>+<kbd>Tab</kbd> | Open angle input dialog to constrain the line to a specific angle (after first point is set) |
-| <kbd>Escape</kbd> | Cancel the current line creation |
-| <kbd>Enter</kbd> | Finalize the line (if using distance or angle input) |
-| <kbd>Right-click</kbd> | Complete the current line and start a new one |
+| <kbd>Escape</kbd>               | Cancel the current line creation                                                             |
+| <kbd>Enter</kbd>                | Finalize the line (if using distance or angle input)                                         |
+| <kbd>Right-click</kbd>          | Complete the current line and start a new one                                                |
 
 **Angle Constraint:**
 - After setting the first point, press **Shift+Tab** to open the angle input dialog
@@ -211,15 +211,15 @@ The multi-line edge tool allows you to create multiple connected line segments i
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Continuous edge creation** | Click multiple points to create a chain of connected line segments |
-| **Real-time preview** | See each edge shape while moving the mouse before clicking |
-| **Precise length control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact edge lengths |
-| **Angle constraint** | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the current edge to an angle (in degrees) |
-| **Snap support** | Automatically snaps to existing nodes and geometry |
-| **Distance annotations** | Real-time distance display for the current edge being drawn |
-| **Flexible finalization** | Continue adding edges until you right-click to finalize the entire sequence |
+|                              |                                                                                                                     |
+| ---------------------------: | ------------------------------------------------------------------------------------------------------------------- |
+| **Continuous edge creation** | Click multiple points to create a chain of connected line segments                                                  |
+| **Real-time preview**        | See each edge shape while moving the mouse before clicking                                                          |
+| **Precise length control**   | Use the distance input dialog (<kbd>Tab</kbd> key) for exact edge lengths                                           |
+| **Angle constraint**         | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the current edge to an angle (in degrees) |
+| **Snap support**             | Automatically snaps to existing nodes and geometry                                                                  |
+| **Distance annotations**     | Real-time distance display for the current edge being drawn                                                         |
+| **Flexible finalization**    | Continue adding edges until you right-click to finalize the entire sequence                                         |
 
 **How to use:**
 1. ![ls](res/icons/ls.png) Select the **Multi-line Edge** tool from the toolbar
@@ -234,13 +234,13 @@ The multi-line edge tool allows you to create multiple connected line segments i
 
 **Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>Tab</kbd> | Open distance input dialog for precise length control of the current edge |
+|                                 |                                                                                              |
+| ------------------------------: | -------------------------------------------------------------------------------------------- |
+| <kbd>Tab</kbd>                  | Open distance input dialog for precise length control of the current edge                    |
 | <kbd>Shift</kbd>+<kbd>Tab</kbd> | Open angle input dialog to constrain the current edge to an angle (after first point is set) |
-| <kbd>Escape</kbd> | Cancel the entire multi-line creation operation |
-| <kbd>Enter</kbd> | Finalize the current edge length (if using distance input) and continue to the next edge |
-| <kbd>Right-click</kbd> | Finalize the entire multi-line sequence and complete the operation |
+| <kbd>Escape</kbd>               | Cancel the entire multi-line creation operation                                              |
+| <kbd>Enter</kbd>                | Finalize the current edge length (if using distance input) and continue to the next edge     |
+| <kbd>Right-click</kbd>          | Finalize the entire multi-line sequence and complete the operation                           |
 
 **Workflow details:**
 - Each click after the first creates a new edge connected to the previous edge's end point
@@ -274,13 +274,13 @@ The center-radius circle tool allows you to create circles by defining a center 
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Two-point creation** | Click to set the center, then click to set the radius point |
-| **Real-time preview** | See the circle shape while dragging the radius point |
-| **Precise radius control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact radius values |
-| **Angle constraint** | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the direction from the center to the radius point |
-| **Snap support** | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active) |
+|                            |                                                                                                                             |
+| -------------------------: | --------------------------------------------------------------------------------------------------------------------------- |
+| **Two-point creation**     | Click to set the center, then click to set the radius point                                                                 |
+| **Real-time preview**      | See the circle shape while dragging the radius point                                                                        |
+| **Precise radius control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact radius values                                                  |
+| **Angle constraint**       | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the direction from the center to the radius point |
+| **Snap support**           | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active)                               |
 
 **How to use:**
 1. ![Circle Tool](res/icons/Sketcher_CreateCircle.png) Select the **Circle** tool from the toolbar
@@ -294,12 +294,12 @@ The center-radius circle tool allows you to create circles by defining a center 
 
 **Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>Tab</kbd> | Open distance input dialog for precise radius control |
+|                                 |                                                                                                       |
+| ------------------------------: | ----------------------------------------------------------------------------------------------------- |
+| <kbd>Tab</kbd>                  | Open distance input dialog for precise radius control                                                 |
 | <kbd>Shift</kbd>+<kbd>Tab</kbd> | Open angle input dialog to constrain the radius direction from the center (after center point is set) |
-| <kbd>Escape</kbd> | Cancel the current circle creation |
-| <kbd>Enter</kbd> | Finalize the circle (if using distance input) |
+| <kbd>Escape</kbd>               | Cancel the current circle creation                                                                    |
+| <kbd>Enter</kbd>                | Finalize the circle (if using distance input)                                                         |
 
 **Angle Constraint:**
 - After setting the center point, press **Shift+Tab** to open the angle input dialog
@@ -324,11 +324,11 @@ The three-point circle tool is planned for future development. This feature woul
 
 **Planned Features:**
 
-| | |
-| ---: | --- |
-| **Three-point creation** | Click three points that lie on the circle's circumference |
+|                                             |                                                                      |
+| ------------------------------------------: | -------------------------------------------------------------------- |
+| **Three-point creation**                    | Click three points that lie on the circle's circumference            |
 | **Automatic center and radius calculation** | The system would compute the center and radius from the three points |
-| **Geometric validation** | Ensure the three points are not collinear |
+| **Geometric validation**                    | Ensure the three points are not collinear                            |
 
 **Note**: ![Sketcher_Create3PointCircle](res/icons/Sketcher_Create3PointCircle.png) The toolbar icon exists but the functionality is not yet implemented.
 
@@ -345,20 +345,20 @@ The circle tool follows this workflow:
 
 **Common Operations with Circles:**
 
-| | |
-| ---: | --- |
-| **Extrusion** | Select the circle face and [extrude](usage.md#extrude-sketch-face-tool-e) to create cylindrical shapes |
-| **Boolean Operations** | Use circles in [cut, fuse, or common](usage.md#boolean-operations) operations |
-| **Pattern Creation** | Use circles as the basis for polar arrays or other patterns |
-| **Dimensioning** | Add radius or diameter dimensions to circles |
+|                        |                                                                                                        |
+| ---------------------: | ------------------------------------------------------------------------------------------------------ |
+| **Extrusion**          | Select the circle face and [extrude](usage.md#extrude-sketch-face-tool-e) to create cylindrical shapes |
+| **Boolean Operations** | Use circles in [cut, fuse, or common](usage.md#boolean-operations) operations                          |
+| **Pattern Creation**   | Use circles as the basis for polar arrays or other patterns                                            |
+| **Dimensioning**       | Add radius or diameter dimensions to circles                                                           |
 
 **Error Handling:**
 
-| | |
-| ---: | --- |
+|                       |                                                          |
+| --------------------: | -------------------------------------------------------- |
 | **Coincident Points** | The system prevents creation of circles with zero radius |
-| **Invalid Geometry** | Circles that would be too small are rejected |
-| **Snap Integration** | Use existing snap points for precise circle placement |
+| **Invalid Geometry**  | Circles that would be too small are rejected             |
+| **Snap Integration**  | Use existing snap points for precise circle placement    |
 
 ## Arc Segment Creation Tool
 
@@ -368,16 +368,16 @@ The arc segment tool creates a single circular arc edge from three clicks: **sta
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Three-point creation** | Click start, then a point on the arc that sets bulge/curvature, then end |
-| **Rubber-band preview** | After the first click, a straight preview line follows the cursor; after the second click, an arc preview follows the cursor until the third click |
-| **Automatic finalization** | The arc is created and added to the sketch after the third click |
-| **Circular arc** | One smooth circular arc through the three defining points |
-| **Intersection splitting** | Splits existing straight and arc edges at interior crossings; the new arc is subdivided where other edges cross its interior |
+|                                |                                                                                                                                                                 |
+| -----------------------------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Three-point creation**       | Click start, then a point on the arc that sets bulge/curvature, then end                                                                                        |
+| **Rubber-band preview**        | After the first click, a straight preview line follows the cursor; after the second click, an arc preview follows the cursor until the third click              |
+| **Automatic finalization**     | The arc is created and added to the sketch after the third click                                                                                                |
+| **Circular arc**               | One smooth circular arc through the three defining points                                                                                                       |
+| **Intersection splitting**     | Splits existing straight and arc edges at interior crossings; the new arc is subdivided where other edges cross its interior                                    |
 | **Optional arc midpoint node** | When **Add midpoint nodes** is on in the Options panel, a snap node is placed at the arc's geometric midpoint (see [Arc segment Options](#arc-segment-options)) |
-| **Snap support** | Snaps to existing nodes and geometry |
-| **Unique points** | All three clicks must be different (cannot be coincident) |
+| **Snap support**               | Snaps to existing nodes and geometry                                                                                                                            |
+| **Unique points**              | All three clicks must be different (cannot be coincident)                                                                                                       |
 
 **How to use:**
 1. ![Sketcher_Element_Arc_Edge](res/icons/Sketcher_Element_Arc_Edge.png) Select the **Arc Segment** tool from the toolbar
@@ -391,18 +391,18 @@ The arc segment tool creates a single circular arc edge from three clicks: **sta
 
 **Point order:**
 
-| | |
-| ---: | --- |
-| **First click** | Start — where the arc begins |
+|                  |                                                                                                                 |
+| ---------------: | --------------------------------------------------------------------------------------------------------------- |
+| **First click**  | Start — where the arc begins                                                                                    |
 | **Second click** | Bulge point — any point on the intended arc between start and end (sets which side of the chord the arc bulges) |
-| **Third click** | End — where the arc ends |
+| **Third click**  | End — where the arc ends                                                                                        |
 
 **Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>Escape</kbd> | Cancel the current arc creation (clears all points) |
-| **Note** | The arc is automatically finalized after the third click; no manual finalization is needed |
+|                   |                                                                                            |
+| ----------------: | ------------------------------------------------------------------------------------------ |
+| <kbd>Escape</kbd> | Cancel the current arc creation (clears all points)                                        |
+| **Note**          | The arc is automatically finalized after the third click; no manual finalization is needed |
 
 (arc-segment-options)=
 ### Arc segment Options
@@ -443,15 +443,15 @@ The square tool allows you to create perfect squares by defining a center point 
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Two-point creation** | Click to set the center point, then click to set the midpoint of one edge |
-| **Real-time preview** | See the square shape while moving the mouse |
-| **Perfect square** | Automatically ensures all sides are equal length |
-| **Orientation control** | The square's orientation is determined by the direction from center to edge midpoint |
-| **Precise size control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact side lengths |
-| **Angle constraint** | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the orientation (direction from center to edge midpoint) |
-| **Snap support** | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active) |
+|                          |                                                                                                                                    |
+| -----------------------: | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Two-point creation**   | Click to set the center point, then click to set the midpoint of one edge                                                          |
+| **Real-time preview**    | See the square shape while moving the mouse                                                                                        |
+| **Perfect square**       | Automatically ensures all sides are equal length                                                                                   |
+| **Orientation control**  | The square's orientation is determined by the direction from center to edge midpoint                                               |
+| **Precise size control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact side lengths                                                          |
+| **Angle constraint**     | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the orientation (direction from center to edge midpoint) |
+| **Snap support**         | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active)                                      |
 
 **How to use:**
 1. ![Sketcher_CreateSquare](res/icons/Sketcher_CreateSquare.png) Select the **Square** tool from the toolbar
@@ -465,12 +465,12 @@ The square tool allows you to create perfect squares by defining a center point 
 
 **Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>Tab</kbd> | Open distance input dialog for precise side length control |
+|                                 |                                                                                                                          |
+| ------------------------------: | ------------------------------------------------------------------------------------------------------------------------ |
+| <kbd>Tab</kbd>                  | Open distance input dialog for precise side length control                                                               |
 | <kbd>Shift</kbd>+<kbd>Tab</kbd> | Open angle input dialog to constrain the orientation (direction from center to edge midpoint; after center point is set) |
-| <kbd>Escape</kbd> | Cancel the current square creation |
-| <kbd>Enter</kbd> | Finalize the square (if using distance input) |
+| <kbd>Escape</kbd>               | Cancel the current square creation                                                                                       |
+| <kbd>Enter</kbd>                | Finalize the square (if using distance input)                                                                            |
 
 **Angle Constraint:**
 - After setting the center point, press **Shift+Tab** to open the angle input dialog
@@ -496,14 +496,14 @@ The rectangle tool allows you to create rectangles by defining two opposite corn
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Two-point creation** | Click to set the first corner, then click to set the opposite corner |
-| **Real-time preview** | See the rectangle shape while moving the mouse |
-| **Precise size control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact dimensions |
-| **Angle constraint** | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the direction from the first to the opposite corner |
-| **Snap support** | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active) |
-| **Automatic corner calculation** | The system automatically calculates the other two corners |
+|                                  |                                                                                                                               |
+| -------------------------------: | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Two-point creation**           | Click to set the first corner, then click to set the opposite corner                                                          |
+| **Real-time preview**            | See the rectangle shape while moving the mouse                                                                                |
+| **Precise size control**         | Use the distance input dialog (<kbd>Tab</kbd> key) for exact dimensions                                                       |
+| **Angle constraint**             | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the direction from the first to the opposite corner |
+| **Snap support**                 | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active)                                 |
+| **Automatic corner calculation** | The system automatically calculates the other two corners                                                                     |
 
 **How to use:**
 1. ![Sketcher_CreateRectangle](res/icons/Sketcher_CreateRectangle.png) Select the **Rectangle** tool from the toolbar
@@ -517,12 +517,12 @@ The rectangle tool allows you to create rectangles by defining two opposite corn
 
 **Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>Tab</kbd> | Open distance input dialog for precise dimension control |
+|                                 |                                                                                                                      |
+| ------------------------------: | -------------------------------------------------------------------------------------------------------------------- |
+| <kbd>Tab</kbd>                  | Open distance input dialog for precise dimension control                                                             |
 | <kbd>Shift</kbd>+<kbd>Tab</kbd> | Open angle input dialog to constrain the direction from the first to the opposite corner (after first corner is set) |
-| <kbd>Escape</kbd> | Cancel the current rectangle creation |
-| <kbd>Enter</kbd> | Finalize the rectangle (if using distance input) |
+| <kbd>Escape</kbd>               | Cancel the current rectangle creation                                                                                |
+| <kbd>Enter</kbd>                | Finalize the rectangle (if using distance input)                                                                     |
 
 **Angle Constraint:**
 - After setting the first corner point, press **Shift+Tab** to open the angle input dialog
@@ -549,14 +549,14 @@ The rectangle with center point tool allows you to create rectangles by defining
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Two-point creation** | Click to set the center point, then click to set a corner point |
-| **Real-time preview** | See the rectangle shape while moving the mouse |
-| **Centered creation** | The rectangle is centered on the first point |
-| **Precise size control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact dimensions |
-| **Angle constraint** | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the orientation (direction from center to corner point) |
-| **Snap support** | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active) |
+|                          |                                                                                                                                   |
+| -----------------------: | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Two-point creation**   | Click to set the center point, then click to set a corner point                                                                   |
+| **Real-time preview**    | See the rectangle shape while moving the mouse                                                                                    |
+| **Centered creation**    | The rectangle is centered on the first point                                                                                      |
+| **Precise size control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact dimensions                                                           |
+| **Angle constraint**     | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the orientation (direction from center to corner point) |
+| **Snap support**         | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active)                                     |
 
 **How to use:**
 1. ![Sketcher_CreateRectangle_Center](res/icons/Sketcher_CreateRectangle_Center.png) Select the **Rectangle with Center Point** tool from the toolbar
@@ -570,12 +570,12 @@ The rectangle with center point tool allows you to create rectangles by defining
 
 **Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>Tab</kbd> | Open distance input dialog for precise dimension control |
+|                                 |                                                                                                                         |
+| ------------------------------: | ----------------------------------------------------------------------------------------------------------------------- |
+| <kbd>Tab</kbd>                  | Open distance input dialog for precise dimension control                                                                |
 | <kbd>Shift</kbd>+<kbd>Tab</kbd> | Open angle input dialog to constrain the orientation (direction from center to corner point; after center point is set) |
-| <kbd>Escape</kbd> | Cancel the current rectangle creation |
-| <kbd>Enter</kbd> | Finalize the rectangle (if using distance input) |
+| <kbd>Escape</kbd>               | Cancel the current rectangle creation                                                                                   |
+| <kbd>Enter</kbd>                | Finalize the rectangle (if using distance input)                                                                        |
 
 **Angle Constraint:**
 - After setting the center point, press **Shift+Tab** to open the angle input dialog
@@ -596,11 +596,11 @@ The rectangle with center point tool allows you to create rectangles by defining
 
 **Comparison of Rectangle Tools:**
 
-| | |
-| ---: | --- |
-| **Rectangle (Two Points)** | Define opposite corners - useful when you know the corner positions |
+|                              |                                                                                            |
+| ---------------------------: | ------------------------------------------------------------------------------------------ |
+| **Rectangle (Two Points)**   | Define opposite corners - useful when you know the corner positions                        |
 | **Rectangle (Center Point)** | Define center and corner - useful when you want the rectangle centered on a specific point |
-| **Square** | Always creates a perfect square - use when you need equal sides |
+| **Square**                   | Always creates a perfect square - use when you need equal sides                            |
 
 ## Slot Creation Tool
 
@@ -610,16 +610,16 @@ The slot tool allows you to create an oblong or oval-shaped slot with rounded en
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Three-point creation** | Click to set the first arc center, then the second arc center, then a point to define the radius |
-| **Real-time preview** | See the slot shape while moving the mouse after setting the first two points |
-| **Automatic finalization** | The slot is automatically created and added to your sketch after the third point is clicked |
-| **Rounded ends** | Creates semicircular arcs at both ends with equal radius |
-| **Parallel edges** | The two straight edges connecting the arcs are always parallel |
-| **Precise size control** | Use the distance input dialog (<kbd>Tab</kbd> key) for exact dimensions |
-| **Angle constraint** | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the orientation (direction of the slot length between arc centers, or radius direction) |
-| **Snap support** | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active) |
+|                            |                                                                                                                                                                   |
+| -------------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Three-point creation**   | Click to set the first arc center, then the second arc center, then a point to define the radius                                                                  |
+| **Real-time preview**      | See the slot shape while moving the mouse after setting the first two points                                                                                      |
+| **Automatic finalization** | The slot is automatically created and added to your sketch after the third point is clicked                                                                       |
+| **Rounded ends**           | Creates semicircular arcs at both ends with equal radius                                                                                                          |
+| **Parallel edges**         | The two straight edges connecting the arcs are always parallel                                                                                                    |
+| **Precise size control**   | Use the distance input dialog (<kbd>Tab</kbd> key) for exact dimensions                                                                                           |
+| **Angle constraint**       | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the orientation (direction of the slot length between arc centers, or radius direction) |
+| **Snap support**           | Automatically snaps to existing nodes and geometry (disabled when angle constraint is active)                                                                     |
 
 **How to use:**
 1. ![Sketcher_CreateSlot](res/icons/Sketcher_CreateSlot.png) Select the **Slot** tool from the toolbar
@@ -645,13 +645,13 @@ The slot tool allows you to create an oblong or oval-shaped slot with rounded en
 
 **Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>Tab</kbd> | Open distance input dialog for precise dimension control (length of slot on first edge, or radius on third point) |
+|                                 |                                                                                                                                                          |
+| ------------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <kbd>Tab</kbd>                  | Open distance input dialog for precise dimension control (length of slot on first edge, or radius on third point)                                        |
 | <kbd>Shift</kbd>+<kbd>Tab</kbd> | Open angle input dialog to constrain the orientation (direction of the slot on first edge, or radius direction on third point; after previous point set) |
-| <kbd>Escape</kbd> | Cancel the current slot creation |
-| <kbd>Enter</kbd> | Finalize the slot (if using distance input) |
-| **Note** | The slot is automatically finalized after the third point, so no manual finalization is needed |
+| <kbd>Escape</kbd>               | Cancel the current slot creation                                                                                                                         |
+| <kbd>Enter</kbd>                | Finalize the slot (if using distance input)                                                                                                              |
+| **Note**                        | The slot is automatically finalized after the third point, so no manual finalization is needed                                                           |
 
 **Angle Constraint:**
 - The tool has two main rubber-band stages where angle/distance apply:
@@ -680,12 +680,12 @@ The slot tool allows you to create an oblong or oval-shaped slot with rounded en
 
 **Technical details:**
 
-| | |
-| ---: | --- |
+|                    |                                                                   |
+| -----------------: | ----------------------------------------------------------------- |
 | **Slot structure** | Four edges: two semicircular arcs and two straight parallel edges |
-| **Arcs** | Created using the arc segment functionality |
-| **Straight edges** | Connect the arcs at their endpoints |
-| **Closed shape** | Suitable for face creation and extrusion |
+| **Arcs**           | Created using the arc segment functionality                       |
+| **Straight edges** | Connect the arcs at their endpoints                               |
+| **Closed shape**   | Suitable for face creation and extrusion                          |
 
 **Common use cases:**
 - Creating mounting slots for screws or bolts
@@ -703,15 +703,15 @@ The axis reference line is **visible only while Operational axis mode is active*
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Two-point definition** | Click to set the start point, then click to set the end point of the axis line |
-| **Real-time preview** | See the axis line while moving the mouse |
-| **Visual length control (Tab)** | Use the distance input dialog (<kbd>Tab</kbd> key) to set the length of the *drawn helper segment* (purely visual/reference; the length has no effect on mirror or revolve results) |
-| **Angle constraint** | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the direction of the axis line |
-| **Mirror operations** | Use the defined axis to mirror selected edges |
-| **Revolve operations** | Use the defined axis to revolve selected edges or faces |
-| **Selection-friendly mirror/revolve** | After the axis is defined, permanent **+** markers and sketch snap are hidden so you can select edges and faces without snap clutter |
+|                                       |                                                                                                                                                                                     |
+| ------------------------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Two-point definition**              | Click to set the start point, then click to set the end point of the axis line                                                                                                      |
+| **Real-time preview**                 | See the axis line while moving the mouse                                                                                                                                            |
+| **Visual length control (Tab)**       | Use the distance input dialog (<kbd>Tab</kbd> key) to set the length of the *drawn helper segment* (purely visual/reference; the length has no effect on mirror or revolve results) |
+| **Angle constraint**                  | Use the angle input dialog (<kbd>Shift</kbd>+<kbd>Tab</kbd>) to constrain the direction of the axis line                                                                            |
+| **Mirror operations**                 | Use the defined axis to mirror selected edges                                                                                                                                       |
+| **Revolve operations**                | Use the defined axis to revolve selected edges or faces                                                                                                                             |
+| **Selection-friendly mirror/revolve** | After the axis is defined, permanent **+** markers and sketch snap are hidden so you can select edges and faces without snap clutter                                                |
 
 **How to Use:**
 
@@ -753,11 +753,11 @@ Once the axis exists, the Options panel (under the **Sketch operation** heading)
 **Using the Operation Axis (UI reference):**
 The controls that appear in the Options panel once an axis is defined are:
 
-| Control | Purpose |
-| --- | --- |
-| **Mirror** button | Mirrors selected edges across the operation axis (stays in 2D sketch). |
+| Control                                                  | Purpose                                                                                                                              |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **Mirror** button                                        | Mirrors selected edges across the operation axis (stays in 2D sketch).                                                               |
 | **Revolve** button + numeric field (e.g. 360.00) + **?** | Revolves selected edges or faces around the axis by the entered angle. Use **?** next to the angle field for solid-conversion notes. |
-| **Clear axis** button | Manually removes the current operation axis reference. |
+| **Clear axis** button                                    | Manually removes the current operation axis reference.                                                                               |
 
 The Revolve numeric field accepts any float angle (in degrees); 360 is the most common for closed solids.
 
@@ -765,11 +765,11 @@ The Revolve numeric field accepts any float angle (in degrees); 360 is the most 
 
 Open CASCADE often returns a **shell** or separate **faces** when you revolve a **closed loop of edges** rather than selecting a **face**. EzyCad then does its best to convert that result into a **solid** (sewing faces when needed, then wrapping a closed shell with `MakeSolid`) so downstream tools such as **chamfer**, **fillet**, and **booleans** can work.
 
-| Selection | Typical OCCT output | After conversion |
-| --- | --- | --- |
-| Closed **face** | Solid | Unchanged (already a solid) |
-| Closed **edges** (360°) | Shell or compound of faces | Converted to solid when possible |
-| Open edge or partial angle | Surface / open shape | Left as-is (cannot close into a solid) |
+| Selection                  | Typical OCCT output        | After conversion                       |
+| -------------------------- | -------------------------- | -------------------------------------- |
+| Closed **face**            | Solid                      | Unchanged (already a solid)            |
+| Closed **edges** (360°)    | Shell or compound of faces | Converted to solid when possible       |
+| Open edge or partial angle | Surface / open shape       | Left as-is (cannot close into a solid) |
 
 Use **View → Shape List → Shape info...** on the new body to confirm the root type is **Solid**. If conversion fails, try selecting the enclosed **face** instead of individual edges, or check that the profile is closed, does not cross the axis, and uses a **360°** angle.
 
@@ -783,11 +783,11 @@ The two points you pick define a *direction* and a point the axis passes through
 
 **Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>Tab</kbd> | Open distance input dialog to set the length of the drawn axis helper segment (visual only; length has no functional effect on mirror/revolve) |
-| <kbd>Shift</kbd>+<kbd>Tab</kbd> | Open angle input dialog to constrain the direction of the axis (after first point is set) |
-| <kbd>Escape</kbd> | Cancel the current axis definition |
+|                                 |                                                                                                                                                |
+| ------------------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <kbd>Tab</kbd>                  | Open distance input dialog to set the length of the drawn axis helper segment (visual only; length has no functional effect on mirror/revolve) |
+| <kbd>Shift</kbd>+<kbd>Tab</kbd> | Open angle input dialog to constrain the direction of the axis (after first point is set)                                                      |
+| <kbd>Escape</kbd>               | Cancel the current axis definition                                                                                                             |
 
 **Angle Constraint:**
 - After setting the first point, press **Shift+Tab** to open the angle input dialog
@@ -815,19 +815,19 @@ Edge dimension tool creates/removes **length dimensions between two sketch nodes
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Node-pair dimensions** | Dimensions are defined by two sketch nodes |
-| **Fast edge workflow** | Click a straight edge to toggle a dimension between its two endpoint nodes |
-| **Two-node workflow** | Click one node, then a second node, to toggle a dimension between them; after the first node, a **preview line** follows the cursor (same idea as the line-edge rubber band), so two-node mode is visually distinct from a single edge click |
-| **Selectable/deletable** | Dimension objects can be selected in sketch mode and deleted (for example with <kbd>Shift</kbd>+<kbd>D</kbd>, <kbd>Delete</kbd>, or <kbd>Backspace</kbd>) |
-| **Helpful for verification** | Quickly verify that your sketch has the correct dimensions |
+|                              |                                                                                                                                                                                                                                              |
+| ---------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Node-pair dimensions**     | Dimensions are defined by two sketch nodes                                                                                                                                                                                                   |
+| **Fast edge workflow**       | Click a straight edge to toggle a dimension between its two endpoint nodes                                                                                                                                                                   |
+| **Two-node workflow**        | Click one node, then a second node, to toggle a dimension between them; after the first node, a **preview line** follows the cursor (same idea as the line-edge rubber band), so two-node mode is visually distinct from a single edge click |
+| **Selectable/deletable**     | Dimension objects can be selected in sketch mode and deleted (for example with <kbd>Shift</kbd>+<kbd>D</kbd>, <kbd>Delete</kbd>, or <kbd>Backspace</kbd>)                                                                                    |
+| **Helpful for verification** | Quickly verify that your sketch has the correct dimensions                                                                                                                                                                                   |
 
 **Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>D</kbd> | Activate dimension tool |
+|                                                                           |                                                |
+| ------------------------------------------------------------------------: | ---------------------------------------------- |
+| <kbd>D</kbd>                                                              | Activate dimension tool                        |
 | <kbd>Shift</kbd>+<kbd>D</kbd>, <kbd>Delete</kbd>, or <kbd>Backspace</kbd> | Delete selected dimension (or other selection) |
 
 **How to Use:**
@@ -840,13 +840,13 @@ Edge dimension tool creates/removes **length dimensions between two sketch nodes
 
 **When to Use:**
 
-| | |
-| ---: | --- |
-| **Design verification** | Check that your sketch dimensions match your design requirements |
-| **Quality control** | Verify measurements before extruding or performing operations |
-| **Learning and debugging** | Understand how your sketch geometry is sized |
-| **Documentation** | Take screenshots with dimensions visible for reference |
-| **Selective display** | Show dimensions only for the node pairs you care about |
+|                            |                                                                  |
+| -------------------------: | ---------------------------------------------------------------- |
+| **Design verification**    | Check that your sketch dimensions match your design requirements |
+| **Quality control**        | Verify measurements before extruding or performing operations    |
+| **Learning and debugging** | Understand how your sketch geometry is sized                     |
+| **Documentation**          | Take screenshots with dimensions visible for reference           |
+| **Selective display**      | Show dimensions only for the node pairs you care about           |
 
 **Tips:**
 - Dimensions display the distance between the two referenced nodes
@@ -858,12 +858,12 @@ Edge dimension tool creates/removes **length dimensions between two sketch nodes
 
 **Technical Details:**
 
-| | |
-| ---: | --- |
-| **Dimension source** | Calculated from the two referenced nodes |
-| **Unit system** | Displays measurements in the current unit system |
-| **Auto-update** | Dimensions update automatically when geometry is modified |
-| **View-only** | Does not affect the underlying geometry |
+|                      |                                                           |
+| -------------------: | --------------------------------------------------------- |
+| **Dimension source** | Calculated from the two referenced nodes                  |
+| **Unit system**      | Displays measurements in the current unit system          |
+| **Auto-update**      | Dimensions update automatically when geometry is modified |
+| **View-only**        | Does not affect the underlying geometry                   |
 
 ## Add Node Tool
 
@@ -878,11 +878,11 @@ In both cases, Add node never leaves a **permanent edge** between two clicks the
 
 ### What else it does
 
-| | |
-| ---: | --- |
-| **Mid-point snap / split** | If a click lands near a **straight** (non-arc) edge (not at its endpoints), the pick snaps onto the segment and that edge is **replaced by two** meeting at the new vertex. Arc edges are **not** split this way. |
-| **No stored edge from anchor** | After a two-step placement from an anchor, **no** sketch edge is created between anchor and new node (unlike Line edge). |
-| **Angle constraint** | With an angle constraint active during rubber-band placement, the next click places the new node along that ray from the anchor; snapping may be relaxed to stay on that direction (similar to the line tool). |
+|                                |                                                                                                                                                                                                                   |
+| -----------------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Mid-point snap / split**     | If a click lands near a **straight** (non-arc) edge (not at its endpoints), the pick snaps onto the segment and that edge is **replaced by two** meeting at the new vertex. Arc edges are **not** split this way. |
+| **No stored edge from anchor** | After a two-step placement from an anchor, **no** sketch edge is created between anchor and new node (unlike Line edge).                                                                                          |
+| **Angle constraint**           | With an angle constraint active during rubber-band placement, the next click places the new node along that ray from the anchor; snapping may be relaxed to stay on that direction (similar to the line tool).    |
 
 ### Permanent “+” markers
 
@@ -899,12 +899,12 @@ Nodes you place with **Add node** are treated as **user-placed** points. When th
 
 ### Shortcuts
 
-| | |
-| ---: | --- |
-| <kbd>Tab</kbd> | Distance input for rubber-band placement (when an anchor is active). |
-| <kbd>Shift</kbd>+<kbd>Tab</kbd> | Angle input (degrees) for rubber-band placement. |
-| <kbd>Escape</kbd> | Cancel the current placement or rubber-band step. |
-| <kbd>Right-click</kbd> | Drop an incomplete rubber-band preview if you started from an anchor and have not placed the second point yet. |
+|                                 |                                                                                                                |
+| ------------------------------: | -------------------------------------------------------------------------------------------------------------- |
+| <kbd>Tab</kbd>                  | Distance input for rubber-band placement (when an anchor is active).                                           |
+| <kbd>Shift</kbd>+<kbd>Tab</kbd> | Angle input (degrees) for rubber-band placement.                                                               |
+| <kbd>Escape</kbd>               | Cancel the current placement or rubber-band step.                                                              |
+| <kbd>Right-click</kbd>          | Drop an incomplete rubber-band preview if you started from an anchor and have not placed the second point yet. |
 
 ### Tips
 
@@ -913,10 +913,10 @@ Nodes you place with **Add node** are treated as **user-placed** points. When th
 
 ### Add node vs. Line edge
 
-| | |
-| ---: | --- |
-| **Add node** | Rubber band is for **placement** only; **does not** add a permanent edge between the two clicks. |
-| **Line edge** | Two clicks (or numeric input) create a **new line edge** in the sketch. |
+|               |                                                                                                  |
+| ------------: | ------------------------------------------------------------------------------------------------ |
+| **Add node**  | Rubber band is for **placement** only; **does not** add a permanent edge between the two clicks. |
+| **Line edge** | Two clicks (or numeric input) create a **new line edge** in the sketch.                          |
 
 ## Create Sketch from Planar Face Tool
 
@@ -926,13 +926,13 @@ The create sketch from planar face tool allows you to extract the boundary of a 
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Face selection** | Click directly on a planar face from an existing 3D shape |
-| **Automatic boundary extraction** | Extracts the outer wire (boundary) of the selected face |
-| **New sketch creation** | Creates a new sketch with the face boundary as the initial geometry |
-| **Planar face requirement** | Only works with planar (flat) faces - curved or complex surfaces are not supported |
-| **Error handling** | Displays an error message if a non-planar face is selected |
+|                                   |                                                                                    |
+| --------------------------------: | ---------------------------------------------------------------------------------- |
+| **Face selection**                | Click directly on a planar face from an existing 3D shape                          |
+| **Automatic boundary extraction** | Extracts the outer wire (boundary) of the selected face                            |
+| **New sketch creation**           | Creates a new sketch with the face boundary as the initial geometry                |
+| **Planar face requirement**       | Only works with planar (flat) faces - curved or complex surfaces are not supported |
+| **Error handling**                | Displays an error message if a non-planar face is selected                         |
 
 **How to Use:**
 1. **Activate Tool**: ![Macro_FaceToSketch_48](res/icons/Macro_FaceToSketch_48.png) Click the **Create Sketch from Planar Face** tool from the toolbar
@@ -971,22 +971,22 @@ The create sketch from planar face tool allows you to extract the boundary of a 
 
 **Common Use Cases:**
 
-| | |
-| ---: | --- |
-| **Reverse engineering** | Extract profiles from imported 3D models |
+|                          |                                                                                                                              |
+| -----------------------: | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Reverse engineering**  | Extract profiles from imported 3D models                                                                                     |
 | **Feature modification** | Create a sketch from an existing face, modify it, and [extrude](usage.md#extrude-sketch-face-tool-e) to create a new feature |
-| **Reference geometry** | Use existing face boundaries as reference for new sketches |
-| **Model editing** | Extract a face boundary, modify it, and use it in [boolean operations](usage.md#boolean-operations) |
-| **Workflow efficiency** | Quickly create sketches from existing geometry instead of manually recreating profiles |
+| **Reference geometry**   | Use existing face boundaries as reference for new sketches                                                                   |
+| **Model editing**        | Extract a face boundary, modify it, and use it in [boolean operations](usage.md#boolean-operations)                          |
+| **Workflow efficiency**  | Quickly create sketches from existing geometry instead of manually recreating profiles                                       |
 
 **Technical Details:**
 
-| | |
-| ---: | --- |
-| **Boundary extraction** | Uses `BRepTools::OuterWire()` on the selected face |
-| **Sketch plane** | Determined from the face's underlying surface geometry |
-| **Supported faces** | Only `Geom_Plane` surfaces - other surface types are rejected |
-| **Sketch list** | Created sketch is added and can be managed like any other sketch |
+|                         |                                                                  |
+| ----------------------: | ---------------------------------------------------------------- |
+| **Boundary extraction** | Uses `BRepTools::OuterWire()` on the selected face               |
+| **Sketch plane**        | Determined from the face's underlying surface geometry           |
+| **Supported faces**     | Only `Geom_Plane` surfaces - other surface types are rejected    |
+| **Sketch list**         | Created sketch is added and can be managed like any other sketch |
 
 ## Image underlay
 
@@ -994,27 +994,27 @@ Import a reference image (PNG, JPEG, or BMP) behind a sketch for tracing or alig
 
 **Sketch List shortcuts**
 
-| Control | Action |
-| --- | --- |
+| Control           | Action                                                                   |
+| ----------------- | ------------------------------------------------------------------------ |
 | Underlay checkbox | Show or hide the underlay for that sketch (only when an image is loaded) |
-| **`[P]`** | Open **Sketch properties** for import, calibration, and transform |
+| **`[P]`**         | Open **Sketch properties** for import, calibration, and transform        |
 
 **Sketch properties — Image underlay**
 
-| Control | Action |
-| --- | --- |
-| **Import image...** | Load PNG/JPEG/BMP into the current sketch |
-| **Remove underlay** | Clear the image from the sketch |
-| **White paper -> transparent** | Treat bright pixels as clear (typical for scanned line drawings; turn off for photos) |
+| Control                                 | Action                                                                                                       |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Import image...**                     | Load PNG/JPEG/BMP into the current sketch                                                                    |
+| **Remove underlay**                     | Clear the image from the sketch                                                                              |
+| **White paper -> transparent**          | Treat bright pixels as clear (typical for scanned line drawings; turn off for photos)                        |
 | **Tint visible lines** / **Line color** | Recolor non-transparent pixels after the white key (default **amber/gold** for contrast on dark backgrounds) |
-| **Opacity** | Overall underlay transparency (**0**–**1**) |
+| **Opacity**                             | Overall underlay transparency (**0**–**1**)                                                                  |
 
 **Calibrate from sketch edges** (sketch must be **current** in the Sketch List):
 
-| Button | Action |
-| --- | --- |
+| Button                 | Action                                                                                                     |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------- |
 | **Set X from edge...** | Two clicks along bitmap width (+U), then enter the real drawing distance (same units as sketch dimensions) |
-| **Set Y from edge...** | Two clicks along bitmap height (+V), then enter the drawing distance for Y |
+| **Set Y from edge...** | Two clicks along bitmap height (+V), then enter the drawing distance for Y                                 |
 
 After edge calibration, bitmap axes may be non-orthogonal (shear). In that case the **Transform** section switches to a 6-DOF affine editor instead of the sliders:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -129,12 +129,12 @@ Right-click a shape **name** or the **M** button in the Shape List and choose **
 
 The dialog reports document fields (name, material, shaded vs wireframe display, visibility) and Open CASCADE (OCCT) topology and measurements, including:
 
-| Category | Examples |
-| --- | --- |
-| **Topology** | Root type (Solid, Shell, Face, Compound, etc.), validity, whether the shape has a location transform, closed-shell flag when the root is a shell |
-| **Counts** | Compounds, CompSolids, Solids, Shells, Faces, Wires, Edges, Vertices (nested sub-shapes included) |
-| **Bounds** | Axis-aligned bounding box min/max and overall size |
-| **Mass properties** | Volume and center of mass (when the shape encloses volume), surface area, length (for wire-like geometry) |
+| Category            | Examples                                                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Topology**        | Root type (Solid, Shell, Face, Compound, etc.), validity, whether the shape has a location transform, closed-shell flag when the root is a shell |
+| **Counts**          | Compounds, CompSolids, Solids, Shells, Faces, Wires, Edges, Vertices (nested sub-shapes included)                                                |
+| **Bounds**          | Axis-aligned bounding box min/max and overall size                                                                                               |
+| **Mass properties** | Volume and center of mass (when the shape encloses volume), surface area, length (for wire-like geometry)                                        |
 
 This is useful after **Revolve**, **Extrude**, booleans, or imports when you need to confirm whether a result is a closed **Solid** or an open **Shell** / surface, or to check face and edge counts and overall size. The dialog closes automatically if the shape is deleted from the document.
 
@@ -224,30 +224,30 @@ The typical modeling workflow in EzyCad follows these steps:
 
 **Key Concepts:**
 
-| | |
-| ---: | --- |
-| **Sketches** | 2D drawings on a plane that define the profile of your 3D shape |
-| **Origin** | One permanent **+** reference node per sketch ([details](usage-sketch.md#sketch-origin)); snap target; listed as **Origin** in the Sketch List |
-| **Faces** | Closed regions within a sketch that can be [extruded](#extrude-sketch-face-tool-e) into 3D |
-| **Shapes** | 3D solid objects created from extruded sketch faces |
-| **Feature Operations** | Transform sketches into 3D geometry or modify existing 3D shapes |
+|                        |                                                                                                                                                |
+| ---------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Sketches**           | 2D drawings on a plane that define the profile of your 3D shape                                                                                |
+| **Origin**             | One permanent **+** reference node per sketch ([details](usage-sketch.md#sketch-origin)); snap target; listed as **Origin** in the Sketch List |
+| **Faces**              | Closed regions within a sketch that can be [extruded](#extrude-sketch-face-tool-e) into 3D                                                     |
+| **Shapes**             | 3D solid objects created from extruded sketch faces                                                                                            |
+| **Feature Operations** | Transform sketches into 3D geometry or modify existing 3D shapes                                                                               |
 
 ### Importing 3D Geometries
 
 In addition to creating 3D shapes from sketches, EzyCad supports importing existing 3D geometry from external CAD files. This allows you to:
 
-| | |
-| ---: | --- |
-| **Work with existing designs** | Import models created in other CAD software |
-| **Combine workflows** | Use imported geometry alongside sketched shapes |
-| **Modify imported models** | Apply EzyCad's modeling tools to imported shapes |
+|                                |                                                  |
+| -----------------------------: | ------------------------------------------------ |
+| **Work with existing designs** | Import models created in other CAD software      |
+| **Combine workflows**          | Use imported geometry alongside sketched shapes  |
+| **Modify imported models**     | Apply EzyCad's modeling tools to imported shapes |
 
 **Supported import formats:**
 
-| | |
-| ---: | --- |
-| **STEP** (`.step`, `.stp`) | Precise B-rep (boundary representation) CAD exchange |
-| **PLY** (`.ply`) | Triangle mesh; fast to load compared to heavy STEP assemblies |
+|                            |                                                               |
+| -------------------------: | ------------------------------------------------------------- |
+| **STEP** (`.step`, `.stp`) | Precise B-rep (boundary representation) CAD exchange          |
+| **PLY** (`.ply`)           | Triangle mesh; fast to load compared to heavy STEP assemblies |
 
 **How to import:**
 1. Use **File -> Import**
@@ -270,12 +270,12 @@ In addition to creating 3D shapes from sketches, EzyCad supports importing exist
 
 Use **File -> Export** to save the current model for other CAD tools, CAM, or 3D printing.
 
-| | |
-| ---: | --- |
-| **STEP** (`.step`) | Precise B-rep exchange |
-| **IGES** (`.igs`) | Legacy CAD exchange |
-| **STL** | Triangle mesh; files are written in **binary** form |
-| **PLY** (`.ply`) | Triangle mesh in **binary little-endian** PLY (tessellated like STL) |
+|                    |                                                                      |
+| -----------------: | -------------------------------------------------------------------- |
+| **STEP** (`.step`) | Precise B-rep exchange                                               |
+| **IGES** (`.igs`)  | Legacy CAD exchange                                                  |
+| **STL**            | Triangle mesh; files are written in **binary** form                  |
+| **PLY** (`.ply`)   | Triangle mesh in **binary little-endian** PLY (tessellated like STL) |
 
 **Scope:** If one or more 3D shapes are selected in the viewer, only those shapes are exported (with their current move/rotate/scale applied). If nothing is selected, all shapes in the document are exported together.
 
@@ -291,13 +291,13 @@ For detailed information on creating 2D geometry, see the [2D Sketching](usage-s
 
 Every sketch has exactly one **Origin**: a fixed point on the sketch plane, shown as a **+ inside a circle** on the **active sketch only** in sketch mode (distinct from red **+** [Add node](usage-sketch.md#add-node-tool) markers on visible sketches; you cannot delete the Origin).
 
-| | |
-| ---: | --- |
-| **Reference-plane sketch** | Origin at plane coordinates **(0, 0)**. |
-| **Sketch from planar face** | Origin at the **bounding-box center** of the extracted face boundary. |
-| **Sketch List** | Listed as **Origin** under **Nodes** when you expand a sketch row. |
-| **Sketch properties** | **[P]** on the sketch row: **Show origin marker**, **Position** sliders with **Set**, for typed values. |
-| **Snapping** | Full vertex and axis snap when the marker is shown; other visible sketches' origins snap when their marker is shown. |
+|                             |                                                                                                                      |
+| --------------------------: | -------------------------------------------------------------------------------------------------------------------- |
+| **Reference-plane sketch**  | Origin at plane coordinates **(0, 0)**.                                                                              |
+| **Sketch from planar face** | Origin at the **bounding-box center** of the extracted face boundary.                                                |
+| **Sketch List**             | Listed as **Origin** under **Nodes** when you expand a sketch row.                                                   |
+| **Sketch properties**       | **[P]** on the sketch row: **Show origin marker**, **Position** sliders with **Set**, for typed values.              |
+| **Snapping**                | Full vertex and axis snap when the marker is shown; other visible sketches' origins snap when their marker is shown. |
 
 Full details (marker size, operational-axis visibility, tips): **[Sketch origin](usage-sketch.md#sketch-origin)** in the 2D sketching guide.
 
@@ -305,12 +305,12 @@ See the **[2D Sketching guide](usage-sketch.md)** for full documentation of sket
 
 **Sketch snap (overview):** While drawing or using **Add node**, picks can snap to existing geometry within **Snap dist** (Options panel). The main behaviors:
 
-| | |
-| ---: | --- |
-| **Vertex snap** | Lock to an existing corner when horizontal and vertical axis guides both align to the same point. |
-| **Sketch origin** | Every sketch's built-in **Origin** is a snap target when its marker is shown (see [Sketch origin](usage-sketch.md#sketch-origin)). |
+|                    |                                                                                                                                                                                                               |
+| -----------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Vertex snap**    | Lock to an existing corner when horizontal and vertical axis guides both align to the same point.                                                                                                             |
+| **Sketch origin**  | Every sketch's built-in **Origin** is a snap target when its marker is shown (see [Sketch origin](usage-sketch.md#sketch-origin)).                                                                            |
 | **Mid-point snap** | With **Add node**, a click near a **straight** edge (but not at its ends) snaps onto the segment; EzyCad places a new vertex there and **splits** the edge into two. You do not need to hit the line exactly. |
-| **Edge midpoint** | Straight edges often expose a geometric **midpoint** as a snap target while drawing; that is separate from mid-point snap and from user-placed **+** nodes. |
+| **Edge midpoint**  | Straight edges often expose a geometric **midpoint** as a snap target while drawing; that is separate from mid-point snap and from user-placed **+** nodes.                                                   |
 
 More detail: [Sketch snapping](usage-sketch.md#sketch-snapping) in the sketch guide.
 
@@ -329,13 +329,13 @@ The shape move tool allows you to reposition selected shapes in the 3D viewer wi
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Axis Constraints** | Restrict movement to the X, Y, or Z axis by toggling axis constraints in the options panel or using keyboard shortcuts. |
+|                                  |                                                                                                                                         |
+| -------------------------------: | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Axis Constraints**             | Restrict movement to the X, Y, or Z axis by toggling axis constraints in the options panel or using keyboard shortcuts.                 |
 | **Interactive Distance Editing** | Enter or adjust the distance moved along each axis for precise control. Real-time feedback is provided in the viewer and options panel. |
-| **Improved Plane Handling** | The move plane is automatically estimated based on the center of the selected shapes, making movement more intuitive. |
-| **Finalization Logic** | The move operation completes when you confirm the action (e.g., <kbd>left mouse button</kbd>). |
-| **Reset and Cancel** | Press <kbd>Esc</kbd> to cancel and revert to the original position at any time during the move operation. |
+| **Improved Plane Handling**      | The move plane is automatically estimated based on the center of the selected shapes, making movement more intuitive.                   |
+| **Finalization Logic**           | The move operation completes when you confirm the action (e.g., <kbd>left mouse button</kbd>).                                          |
+| **Reset and Cancel**             | Press <kbd>Esc</kbd> to cancel and revert to the original position at any time during the move operation.                               |
 
 **How to Use:**
 1. ![Assembly_AxialMove](res/icons/Assembly_AxialMove.png) **Activate Move Tool:** Select one or more shapes and press <kbd>G</kbd> or click the icon.
@@ -362,11 +362,11 @@ The shape rotate tool enables precise rotation of selected shapes around a speci
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Rotation Axis Options** | Choose between view-to-object rotation or constrain rotation to X, Y, or Z axis. |
-| **Interactive Angle Editing** | Enter or adjust the rotation angle for precise control with real-time preview. |
-| **Visual Feedback** | The rotation axis is displayed with color-coded indicators (Red for X, Green for Y, Blue for Z). |
+|                               |                                                                                                  |
+| ----------------------------: | ------------------------------------------------------------------------------------------------ |
+| **Rotation Axis Options**     | Choose between view-to-object rotation or constrain rotation to X, Y, or Z axis.                 |
+| **Interactive Angle Editing** | Enter or adjust the rotation angle for precise control with real-time preview.                   |
+| **Visual Feedback**           | The rotation axis is displayed with color-coded indicators (Red for X, Green for Y, Blue for Z). |
 
 **How to Use:**
 1. **Activate Rotate Tool:** ![Draft_Rotate](res/icons/Draft_Rotate.png) Select one or more shapes and press <kbd>R</kbd> or click the icon. You can also activate the tool and select the shape(s) to rotate afterwards.
@@ -405,12 +405,12 @@ The shape scale tool allows you to uniformly scale selected shapes around a comp
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Automatic center detection** | The scale center is estimated from the bounding box center of the selected shapes. |
-| **Screen-plane scaling** | Scaling happens in a plane derived from the current view, making the interaction intuitive. |
-| **Interactive preview** | Moving the mouse adjusts the scale factor and updates the shapes in real time. |
-| **Safe bounds** | The scale factor is clamped to a reasonable range (e.g., between very small and very large values) to avoid degenerate geometry. |
+|                                |                                                                                                                                  |
+| -----------------------------: | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Automatic center detection** | The scale center is estimated from the bounding box center of the selected shapes.                                               |
+| **Screen-plane scaling**       | Scaling happens in a plane derived from the current view, making the interaction intuitive.                                      |
+| **Interactive preview**        | Moving the mouse adjusts the scale factor and updates the shapes in real time.                                                   |
+| **Safe bounds**                | The scale factor is clamped to a reasonable range (e.g., between very small and very large values) to avoid degenerate geometry. |
 
 **How to Use:**
 
@@ -437,14 +437,14 @@ The extrude tool allows you to create 3D solid shapes by extruding 2D sketch fac
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Direct face selection** | Click directly on a sketch face to select it for extrusion |
-| **Automatic view adjustment** | The view automatically rotates if the face plane is parallel to the view plane (within 5 degrees), providing better visibility for the extrusion operation |
-| **Real-time preview** | See the extruded shape update in real-time as you move the mouse |
-| **Interactive distance control** | Drag the mouse to adjust extrusion distance, or use the distance input dialog (<kbd>Tab</kbd> key) for precise control |
-| **Distance annotation** | A dimension annotation displays the current extrusion distance |
-| **Bidirectional extrusion** | The extrusion direction is determined by which side of the face plane you move the mouse to |
+|                                  |                                                                                                                                                            |
+| -------------------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Direct face selection**        | Click directly on a sketch face to select it for extrusion                                                                                                 |
+| **Automatic view adjustment**    | The view automatically rotates if the face plane is parallel to the view plane (within 5 degrees), providing better visibility for the extrusion operation |
+| **Real-time preview**            | See the extruded shape update in real-time as you move the mouse                                                                                           |
+| **Interactive distance control** | Drag the mouse to adjust extrusion distance, or use the distance input dialog (<kbd>Tab</kbd> key) for precise control                                     |
+| **Distance annotation**          | A dimension annotation displays the current extrusion distance                                                                                             |
+| **Bidirectional extrusion**      | The extrusion direction is determined by which side of the face plane you move the mouse to                                                                |
 
 **How to Use:**
 1. ![Design456_Extrude](res/icons/Design456_Extrude.png) **Activate Extrude Tool**: Press <kbd>E</kbd> or click the icon to enter extrude mode
@@ -460,12 +460,12 @@ The extrude tool allows you to create 3D solid shapes by extruding 2D sketch fac
 
 **Keyboard Shortcuts:**
 
-| | |
-| ---: | --- |
-| <kbd>E</kbd> | Activate extrude mode |
-| <kbd>Tab</kbd> | Open distance input dialog for precise extrusion distance |
-| <kbd>Esc</kbd> | Cancel current extrusion operation |
-| <kbd>Enter</kbd> | Finalize extrusion (when using distance input) |
+|                  |                                                           |
+| ---------------: | --------------------------------------------------------- |
+| <kbd>E</kbd>     | Activate extrude mode                                     |
+| <kbd>Tab</kbd>   | Open distance input dialog for precise extrusion distance |
+| <kbd>Esc</kbd>   | Cancel current extrusion operation                        |
+| <kbd>Enter</kbd> | Finalize extrusion (when using distance input)            |
 
 **Tips:**
 - Extrude works best when the view is not directly parallel to the sketch plane - the system will automatically rotate the view if needed
@@ -476,12 +476,12 @@ The extrude tool allows you to create 3D solid shapes by extruding 2D sketch fac
 
 **Common Use Cases:**
 
-| | |
-| ---: | --- |
-| **Extrusion** | Select the circle face and [extrude](#extrude-sketch-face-tool-e) to create cylindrical shapes |
-| **Base features** | Create the base feature of a part by [extruding](#extrude-sketch-face-tool-e) a profile |
-| **Additive features** | [Extrude](#extrude-sketch-face-tool-e) additional features on existing parts |
-| **Through features** | Extrude holes or cutouts by using the [Cut](#boolean-operations) operation after extrusion |
+|                       |                                                                                                |
+| --------------------: | ---------------------------------------------------------------------------------------------- |
+| **Extrusion**         | Select the circle face and [extrude](#extrude-sketch-face-tool-e) to create cylindrical shapes |
+| **Base features**     | Create the base feature of a part by [extruding](#extrude-sketch-face-tool-e) a profile        |
+| **Additive features** | [Extrude](#extrude-sketch-face-tool-e) additional features on existing parts                   |
+| **Through features**  | Extrude holes or cutouts by using the [Cut](#boolean-operations) operation after extrusion     |
 
 #### Shape Polar Duplicate Tool
 
@@ -491,14 +491,14 @@ The polar duplicate tool allows you to create multiple copies of selected shapes
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Circular array** | Creates multiple copies of shapes arranged in a circular pattern |
-| **Configurable angle** | Set the total angle for the pattern (default: 360 degrees) |
-| **Configurable count** | Set the number of duplicate elements to create (default: 5) |
-| **Rotation option** | Choose whether duplicates are rotated as they're copied (default: enabled) |
-| **Combine option** | Choose whether to combine all duplicates into a single shape (default: enabled) |
-| **Polar arm definition** | Define the rotation center and direction by clicking a point |
+|                          |                                                                                 |
+| -----------------------: | ------------------------------------------------------------------------------- |
+| **Circular array**       | Creates multiple copies of shapes arranged in a circular pattern                |
+| **Configurable angle**   | Set the total angle for the pattern (default: 360 degrees)                      |
+| **Configurable count**   | Set the number of duplicate elements to create (default: 5)                     |
+| **Rotation option**      | Choose whether duplicates are rotated as they're copied (default: enabled)      |
+| **Combine option**       | Choose whether to combine all duplicates into a single shape (default: enabled) |
+| **Polar arm definition** | Define the rotation center and direction by clicking a point                    |
 
 **How to use:**
 1. ![Draft_PolarArray](res/icons/Draft_PolarArray.png) **Activate Polar Duplicate Tool**: Click the icon to enter polar duplicate mode
@@ -514,18 +514,18 @@ The polar duplicate tool allows you to create multiple copies of selected shapes
 
 **Options explained:**
 
-| | |
-| ---: | --- |
-| **Polar angle** | The total angular span of the pattern. 360 deg creates a full circle, 180 deg creates a half circle, etc. |
-| **Num Elms** | The number of duplicate elements to create. The original shape is not counted, so 5 elements means 5 copies plus the original. |
-| **Rotate dups** | When enabled, each duplicate is rotated around its own center as it's positioned. When disabled, duplicates maintain their original orientation. |
-| **Combine dups** | When enabled, all duplicates are fused together into a single shape. When disabled, each duplicate remains a separate shape. |
-| **Material** | Preset for new solids from **Dup**; matches **Normal** mode Options **Material**. Existing shapes: [Shape List](#shape-list). |
+|                  |                                                                                                                                                  |
+| ---------------: | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Polar angle**  | The total angular span of the pattern. 360 deg creates a full circle, 180 deg creates a half circle, etc.                                        |
+| **Num Elms**     | The number of duplicate elements to create. The original shape is not counted, so 5 elements means 5 copies plus the original.                   |
+| **Rotate dups**  | When enabled, each duplicate is rotated around its own center as it's positioned. When disabled, duplicates maintain their original orientation. |
+| **Combine dups** | When enabled, all duplicates are fused together into a single shape. When disabled, each duplicate remains a separate shape.                     |
+| **Material**     | Preset for new solids from **Dup**; matches **Normal** mode Options **Material**. Existing shapes: [Shape List](#shape-list).                    |
 
 **Keyboard shortcuts:**
 
-| | |
-| ---: | --- |
+|                   |                                              |
+| ----------------: | -------------------------------------------- |
 | <kbd>Escape</kbd> | Cancel the current polar duplicate operation |
 
 **Tips:**
@@ -562,16 +562,16 @@ These tools are in the main toolbar (after the polar duplicate button). They are
 
 **Features:**
 
-| | |
-| ---: | --- |
-| **Multi-select input** | Select any two or more solids in Normal/Inspection mode, then activate the desired boolean |
-| **Order matters for Cut** | The first selected shape is the base body; all others are used as cutters (subtracted) |
-| **Inputs are consumed** | The original selected shapes are removed and replaced by a single result shape (destructive / non-parametric) |
-| **Result naming** | New shape is named "Cut", "Fused", or "Common". Rename it in the **Shape List** pane for clarity |
-| **Material** | The result receives the current document default material (the one shown in Normal mode Options → Material, or last chosen preset) |
-| **Undoable** | Every boolean pushes an undo snapshot. Use <kbd>Ctrl</kbd>+<kbd>Z</kbd> (or Edit → Undo) to restore the input shapes |
-| **Broad compatibility** | Works with extruded solids, imported STEP/IGES/PLY bodies, previous boolean results, and shapes produced by polar duplicate (especially with "Combine dups" enabled) |
-| **Selection filter aware** | Use the **Selection Mode** filter (Options panel or <kbd>1</kbd>–<kbd>9</kbd> keys) to pick only Solids, Compounds, etc. |
+|                            |                                                                                                                                                                      |
+| -------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Multi-select input**     | Select any two or more solids in Normal/Inspection mode, then activate the desired boolean                                                                           |
+| **Order matters for Cut**  | The first selected shape is the base body; all others are used as cutters (subtracted)                                                                               |
+| **Inputs are consumed**    | The original selected shapes are removed and replaced by a single result shape (destructive / non-parametric)                                                        |
+| **Result naming**          | New shape is named "Cut", "Fused", or "Common". Rename it in the **Shape List** pane for clarity                                                                     |
+| **Material**               | The result receives the current document default material (the one shown in Normal mode Options → Material, or last chosen preset)                                   |
+| **Undoable**               | Every boolean pushes an undo snapshot. Use <kbd>Ctrl</kbd>+<kbd>Z</kbd> (or Edit → Undo) to restore the input shapes                                                 |
+| **Broad compatibility**    | Works with extruded solids, imported STEP/IGES/PLY bodies, previous boolean results, and shapes produced by polar duplicate (especially with "Combine dups" enabled) |
+| **Selection filter aware** | Use the **Selection Mode** filter (Options panel or <kbd>1</kbd>–<kbd>9</kbd> keys) to pick only Solids, Compounds, etc.                                             |
 
 **How to Use:**
 
@@ -600,14 +600,14 @@ If fewer than two shapes are selected you will see an error message and nothing 
 
 **Common Use Cases:**
 
-| Goal | Typical workflow |
-|------|------------------|
-| Create a hole or pocket | Sketch and extrude a closed profile through (or into) the target body, then **Cut** the extrusion from the main solid |
-| Merge separate parts into one | Position solids so they overlap or adjoin, multi-select them, and **Fuse** |
-| Compute intersection volume | Overlap two or more bodies and use **Common** to extract the shared region |
-| Clean up or simplify imports | Fuse multiple imported bodies; cut away unwanted protrusions |
-| Build complex machined parts | Repeated extrude + boolean sequence (base block → cuts for pockets → fuses for bosses) |
-| Radial patterns with merging | Use polar duplicate with **Combine dups** checked, then boolean the result with other geometry |
+| Goal                          | Typical workflow                                                                                                      |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Create a hole or pocket       | Sketch and extrude a closed profile through (or into) the target body, then **Cut** the extrusion from the main solid |
+| Merge separate parts into one | Position solids so they overlap or adjoin, multi-select them, and **Fuse**                                            |
+| Compute intersection volume   | Overlap two or more bodies and use **Common** to extract the shared region                                            |
+| Clean up or simplify imports  | Fuse multiple imported bodies; cut away unwanted protrusions                                                          |
+| Build complex machined parts  | Repeated extrude + boolean sequence (base block → cuts for pockets → fuses for bosses)                                |
+| Radial patterns with merging  | Use polar duplicate with **Combine dups** checked, then boolean the result with other geometry                        |
 
 **Keyboard notes:**
 
@@ -619,46 +619,46 @@ For more on 3D solids and the viewer, see [3D viewer (Open CASCADE)](usage-occt-
 
 ### General Operations
 
-| | |
-| ---: | --- |
-| <kbd>Ctrl</kbd>+<kbd>Z</kbd> | Undo last operation |
-| <kbd>Ctrl</kbd>+<kbd>Y</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> | Redo |
-| <kbd>Ctrl</kbd>+<kbd>O</kbd> | Open file |
-| <kbd>Ctrl</kbd>+<kbd>S</kbd> | Save file |
-| <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Save as |
-| <kbd>Esc</kbd> | [Cancel current operation or step to parent mode](#cancel-current-operation-esc) |
-| <kbd>Enter</kbd> | Confirm current operation |
-| <kbd>Tab</kbd> | Distance/dimension input |
-| <kbd>Shift</kbd>+<kbd>Tab</kbd> | Angle input (for line edges with angle constraint) |
-| <kbd>Shift</kbd>+<kbd>D</kbd>, <kbd>Delete</kbd>, or <kbd>Backspace</kbd> | Remove selected elements |
+|                                                                              |                                                                                  |
+| ---------------------------------------------------------------------------: | -------------------------------------------------------------------------------- |
+| <kbd>Ctrl</kbd>+<kbd>Z</kbd>                                                 | Undo last operation                                                              |
+| <kbd>Ctrl</kbd>+<kbd>Y</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> | Redo                                                                             |
+| <kbd>Ctrl</kbd>+<kbd>O</kbd>                                                 | Open file                                                                        |
+| <kbd>Ctrl</kbd>+<kbd>S</kbd>                                                 | Save file                                                                        |
+| <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd>                                | Save as                                                                          |
+| <kbd>Esc</kbd>                                                               | [Cancel current operation or step to parent mode](#cancel-current-operation-esc) |
+| <kbd>Enter</kbd>                                                             | Confirm current operation                                                        |
+| <kbd>Tab</kbd>                                                               | Distance/dimension input                                                         |
+| <kbd>Shift</kbd>+<kbd>Tab</kbd>                                              | Angle input (for line edges with angle constraint)                               |
+| <kbd>Shift</kbd>+<kbd>D</kbd>, <kbd>Delete</kbd>, or <kbd>Backspace</kbd>    | Remove selected elements                                                         |
 
 ### Modeling Shortcuts
 
-| | |
-| ---: | --- |
-| <kbd>G</kbd> | Move mode |
-| <kbd>R</kbd> | Rotate mode |
-| <kbd>S</kbd> | Scale mode |
-| <kbd>E</kbd> | Extrude mode |
-| <kbd>C</kbd> | Chamfer mode |
-| <kbd>F</kbd> | Fillet mode |
+|              |                         |
+| -----------: | ----------------------- |
+| <kbd>G</kbd> | Move mode               |
+| <kbd>R</kbd> | Rotate mode             |
+| <kbd>S</kbd> | Scale mode              |
+| <kbd>E</kbd> | Extrude mode            |
+| <kbd>C</kbd> | Chamfer mode            |
+| <kbd>F</kbd> | Fillet mode             |
 | <kbd>D</kbd> | Dimension tool (sketch) |
 
 
 ### View navigation
 
-| | |
-| ---: | --- |
-| <kbd>NumPad 8</kbd> | Orbit [up](#view-orbit-numpad) (same sense as dragging the view up). Step: **Settings -> 3D view navigation -> View rotation step** (default **45** degrees). |
-| <kbd>NumPad 2</kbd> | Orbit [down](#view-orbit-numpad). |
-| <kbd>NumPad 4</kbd> | Orbit [left](#view-orbit-numpad). |
-| <kbd>NumPad 6</kbd> | Orbit [right](#view-orbit-numpad). |
-| <kbd>Shift</kbd>+<kbd>NumPad 4</kbd>, <kbd>Shift</kbd>+<kbd>4</kbd>, or <kbd>Shift</kbd>+<kbd>Left</kbd> | [Roll the 3D view](#view-roll) one way (same step setting as orbit). |
-| <kbd>Shift</kbd>+<kbd>NumPad 6</kbd>, <kbd>Shift</kbd>+<kbd>6</kbd>, or <kbd>Shift</kbd>+<kbd>Right</kbd> | [Roll the 3D view](#view-roll) the other way. |
-| <kbd>NumPad 5</kbd> | Snap to the nearest world-axis view (top, bottom, front, back, left, or right): keeps the current eye-target distance, aligns the view direction to +/- **X** / **Y** / **Z**, and resets roll to a standard **Up** (same convention as the initial top view: **Up** is **+Y** when looking along **Z**, else **+Z** when looking along **X** or **Y**). |
-| <kbd>NumPad +</kbd> / <kbd>NumPad -</kbd> | Zoom in / out at the cursor; step size uses **Settings -> 3D view navigation -> Zoom scroll scale** (default **4**, same role as the former fixed wheel multiplier). **Hold** the key for continuous zoom (system key repeat). |
-| <kbd>Shift</kbd>+<kbd>=</kbd> (often labeled **+**) | Zoom in (same as **NumPad +** on US layouts); hold for repeat. With **Shift**, Blender-style **finer** zoom (**x0.1** on the scroll delta). |
-| <kbd>-</kbd> (main keyboard) | Zoom out (same as **NumPad -**); hold for repeat. **Shift** gives finer zoom. |
+|                                                                                                           |                                                                                                                                                                                                                                                                                                                                                          |
+| --------------------------------------------------------------------------------------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <kbd>NumPad 8</kbd>                                                                                       | Orbit [up](#view-orbit-numpad) (same sense as dragging the view up). Step: **Settings -> 3D view navigation -> View rotation step** (default **45** degrees).                                                                                                                                                                                            |
+| <kbd>NumPad 2</kbd>                                                                                       | Orbit [down](#view-orbit-numpad).                                                                                                                                                                                                                                                                                                                        |
+| <kbd>NumPad 4</kbd>                                                                                       | Orbit [left](#view-orbit-numpad).                                                                                                                                                                                                                                                                                                                        |
+| <kbd>NumPad 6</kbd>                                                                                       | Orbit [right](#view-orbit-numpad).                                                                                                                                                                                                                                                                                                                       |
+| <kbd>Shift</kbd>+<kbd>NumPad 4</kbd>, <kbd>Shift</kbd>+<kbd>4</kbd>, or <kbd>Shift</kbd>+<kbd>Left</kbd>  | [Roll the 3D view](#view-roll) one way (same step setting as orbit).                                                                                                                                                                                                                                                                                     |
+| <kbd>Shift</kbd>+<kbd>NumPad 6</kbd>, <kbd>Shift</kbd>+<kbd>6</kbd>, or <kbd>Shift</kbd>+<kbd>Right</kbd> | [Roll the 3D view](#view-roll) the other way.                                                                                                                                                                                                                                                                                                            |
+| <kbd>NumPad 5</kbd>                                                                                       | Snap to the nearest world-axis view (top, bottom, front, back, left, or right): keeps the current eye-target distance, aligns the view direction to +/- **X** / **Y** / **Z**, and resets roll to a standard **Up** (same convention as the initial top view: **Up** is **+Y** when looking along **Z**, else **+Z** when looking along **X** or **Y**). |
+| <kbd>NumPad +</kbd> / <kbd>NumPad -</kbd>                                                                 | Zoom in / out at the cursor; step size uses **Settings -> 3D view navigation -> Zoom scroll scale** (default **4**, same role as the former fixed wheel multiplier). **Hold** the key for continuous zoom (system key repeat).                                                                                                                           |
+| <kbd>Shift</kbd>+<kbd>=</kbd> (often labeled **+**)                                                       | Zoom in (same as **NumPad +** on US layouts); hold for repeat. With **Shift**, Blender-style **finer** zoom (**x0.1** on the scroll delta).                                                                                                                                                                                                              |
+| <kbd>-</kbd> (main keyboard)                                                                              | Zoom out (same as **NumPad -**); hold for repeat. **Shift** gives finer zoom.                                                                                                                                                                                                                                                                            |
 
 **Num Lock (numeric keypad):** **Num Lock off** is what we test against and recommend. The shortcuts below assume the keypad produces **NumPad** key codes (orbit, axis snap, zoom, roll, and keypad selection digits). With **Num Lock on**, Windows and other systems often remap the keypad (digits vs arrow/Home/End behavior), so numpad shortcuts may not match this document. Use the alternatives in the table (main-row <kbd>4</kbd> / <kbd>6</kbd>, <kbd>Shift</kbd>+<kbd>Left</kbd> / <kbd>Right</kbd>, main <kbd>+</kbd> / <kbd>-</kbd>, main <kbd>1</kbd>-<kbd>9</kbd> for selection) or turn **Num Lock off**.
 
@@ -668,17 +668,17 @@ Same idea as Blender **View Roll** for <kbd>Shift</kbd>+<kbd>NumPad 4</kbd> / <k
 
 In **Normal** mode, number keys set the **Selection Mode** filter for picking 3D shapes (same control as **Options -> Selection Mode**). Main keyboard **<kbd>1</kbd>-<kbd>9</kbd>** and keypad **<kbd>1</kbd>-<kbd>9</kbd>** are supported, except **keypad <kbd>5</kbd>** and **keypad <kbd>2</kbd>**, **<kbd>4</kbd>**, **<kbd>6</kbd>**, **<kbd>8</kbd>** (see [View navigation](#view-navigation)). The key order matches the list in the **Selection Mode** control (from compound down to whole shape):
 
-| Key | Filter |
-| ---: | --- |
-| <kbd>1</kbd> | Compound |
+| Key          | Filter    |
+| -----------: | --------- |
+| <kbd>1</kbd> | Compound  |
 | <kbd>2</kbd> | CompSolid |
-| <kbd>3</kbd> | Solid |
-| <kbd>4</kbd> | Shell |
-| <kbd>5</kbd> | Face |
-| <kbd>6</kbd> | Wire |
-| <kbd>7</kbd> | Edge |
-| <kbd>8</kbd> | Vertex |
-| <kbd>9</kbd> | Shape |
+| <kbd>3</kbd> | Solid     |
+| <kbd>4</kbd> | Shell     |
+| <kbd>5</kbd> | Face      |
+| <kbd>6</kbd> | Wire      |
+| <kbd>7</kbd> | Edge      |
+| <kbd>8</kbd> | Vertex    |
+| <kbd>9</kbd> | Shape     |
 
 While focus is in a text field (dimension input, script console, etc.), **<kbd>1</kbd>-<kbd>9</kbd>** are left to the UI: `main.cpp` does not call the global key handler when ImGui reports `WantTextInput`. Chamfer, fillet, and sketch modes may change the filter automatically when you enter them.
 
@@ -690,13 +690,13 @@ Open or close the **Lua** or **Python** consoles from **View -> Lua Console** or
 
 ### Mouse Controls
 
-| | |
-| ---: | --- |
-| **Left Click** | Select object |
-| **Left drag** | Orbit view |
-| **Middle drag** | Pan view |
-| **Right drag** | Zoom |
-| **Scroll Wheel** | Zoom in/out (**Zoom scroll scale** in Settings; hold **Shift** for finer steps) |
+|                                                                                        |                                                                                    |
+| -------------------------------------------------------------------------------------: | ---------------------------------------------------------------------------------- |
+| **Left Click**                                                                         | Select object                                                                      |
+| **Left drag**                                                                          | Orbit view                                                                         |
+| **Middle drag**                                                                        | Pan view                                                                           |
+| **Right drag**                                                                         | Zoom                                                                               |
+| **Scroll Wheel**                                                                       | Zoom in/out (**Zoom scroll scale** in Settings; hold **Shift** for finer steps)    |
 | <kbd>NumPad +</kbd> / <kbd>NumPad -</kbd>, <kbd>Shift</kbd>+<kbd>=</kbd>, <kbd>-</kbd> | Zoom in/out ([keyboard](#view-navigation); settings scale; <kbd>Shift</kbd> finer) |
 
 ### View orbit (NumPad)
@@ -713,13 +713,13 @@ More context on the 3D viewer stack: **[3D viewer (Open CASCADE)](usage-occt-vie
 
 ### View Options
 
-| | |
-| ---: | --- |
-| **Reset view** | Reset the 3D view |
-| **Fit to screen** | Fit the model to the viewport |
-| **Toggle wireframe** | Switch wireframe display |
-| **Change material appearance** | Adjust material display |
-| **Adjust lighting** | Change lighting settings |
+|                                |                               |
+| -----------------------------: | ----------------------------- |
+| **Reset view**                 | Reset the 3D view             |
+| **Fit to screen**              | Fit the model to the viewport |
+| **Toggle wireframe**           | Switch wireframe display      |
+| **Change material appearance** | Adjust material display       |
+| **Adjust lighting**            | Change lighting settings      |
 
 ## Tips and Tricks
 

--- a/scripts/align_md_tables.py
+++ b/scripts/align_md_tables.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Align GFM pipe tables in Markdown files (source-readable + preview-safe).
+
+Skips fenced code blocks. Excludes third_party / build / vendor trees.
+Usage: python scripts/align_md_tables.py [--check] [paths...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+SKIP_DIR_NAMES = {
+    ".git",
+    "third_party",
+    "node_modules",
+    "_build",
+    "_deps",
+    "build",
+    "out",
+    ".venv",
+    "venv",
+}
+
+# Also skip CMake / local build trees (build-vs18, build-wasm, etc.).
+SKIP_DIR_PREFIXES = ("build-", "cmake-build")
+
+ROW_RE = re.compile(r"^\s*\|.*\|\s*$")
+SEP_CELL_RE = re.compile(r"^:?-+:?$")
+
+
+def is_separator_row(cells: list[str]) -> bool:
+    if not cells:
+        return False
+    return all(SEP_CELL_RE.match(c.replace(" ", "")) for c in cells)
+
+
+def split_row(line: str) -> list[str]:
+    s = line.strip()
+    if s.startswith("|"):
+        s = s[1:]
+    if s.endswith("|"):
+        s = s[:-1]
+    return [c.strip() for c in s.split("|")]
+
+
+def format_separator(width: int, cell: str) -> str:
+    raw = cell.replace(" ", "")
+    left = raw.startswith(":")
+    right = raw.endswith(":") and raw != ":"
+    # Minimum three dashes for GFM.
+    inner = max(3, width - (1 if left else 0) - (1 if right else 0))
+    body = "-" * inner
+    if left and right:
+        return f":{body}:"
+    if left:
+        return f":{body}"
+    if right:
+        return f"{body}:"
+    return body
+
+
+def align_table(lines: list[str]) -> list[str]:
+    rows = [split_row(line) for line in lines]
+    col_count = max(len(r) for r in rows)
+    for r in rows:
+        while len(r) < col_count:
+            r.append("")
+
+    widths = [0] * col_count
+    for r in rows:
+        if is_separator_row(r):
+            continue
+        for i, cell in enumerate(r):
+            widths[i] = max(widths[i], len(cell))
+    # Separators need at least 3 dashes of content width.
+    for i in range(col_count):
+        widths[i] = max(widths[i], 3)
+
+    out: list[str] = []
+    for r in rows:
+        if is_separator_row(r):
+            cells = [format_separator(widths[i], r[i]) for i in range(col_count)]
+            # Pad separator visual width to column width.
+            padded = []
+            for i, cell in enumerate(cells):
+                pad = widths[i] - len(cell)
+                if pad > 0:
+                    # Insert extra dashes before any trailing colon.
+                    if cell.endswith(":"):
+                        cell = cell[:-1] + ("-" * pad) + ":"
+                    else:
+                        cell = cell + ("-" * pad)
+                padded.append(cell)
+            out.append("| " + " | ".join(padded) + " |")
+        else:
+            cells = [r[i].ljust(widths[i]) for i in range(col_count)]
+            out.append("| " + " | ".join(cells) + " |")
+    return out
+
+
+def process_text(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    out: list[str] = []
+    i = 0
+    in_fence = False
+    fence_marker = ""
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.lstrip()
+
+        if not in_fence and stripped.startswith("```"):
+            in_fence = True
+            fence_marker = stripped[:3]
+            out.append(line)
+            i += 1
+            continue
+        if in_fence:
+            out.append(line)
+            if stripped.startswith(fence_marker):
+                in_fence = False
+                fence_marker = ""
+            i += 1
+            continue
+
+        if ROW_RE.match(line):
+            block: list[str] = []
+            raw_block: list[str] = []
+            while i < len(lines) and ROW_RE.match(lines[i]):
+                raw_block.append(lines[i])
+                # Preserve original newline style via keepends content without NL for align.
+                block.append(lines[i].rstrip("\r\n"))
+                i += 1
+            # Only treat as a table if there is a separator row.
+            cells_rows = [split_row(b) for b in block]
+            if any(is_separator_row(r) for r in cells_rows) and len(block) >= 2:
+                aligned = align_table(block)
+                nl = "\n"
+                if raw_block and raw_block[0].endswith("\r\n"):
+                    nl = "\r\n"
+                elif raw_block and raw_block[0].endswith("\n"):
+                    nl = "\n"
+                for a in aligned:
+                    out.append(a + nl)
+            else:
+                out.extend(raw_block)
+            continue
+
+        out.append(line)
+        i += 1
+
+    return "".join(out)
+
+
+def should_skip(path: Path) -> bool:
+    for part in path.parts:
+        if part in SKIP_DIR_NAMES:
+            return True
+        if part.startswith(SKIP_DIR_PREFIXES):
+            return True
+    return False
+
+
+def iter_md_files(roots: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for root in roots:
+        if root.is_file() and root.suffix.lower() == ".md":
+            if not should_skip(root):
+                files.append(root)
+            continue
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*.md"):
+            if should_skip(path):
+                continue
+            files.append(path)
+    return sorted(set(files))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[Path(".")],
+        help="Files or directories (default: repo root)",
+    )
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if any file would change; do not write",
+    )
+    args = ap.parse_args()
+
+    changed: list[Path] = []
+    for path in iter_md_files(args.paths):
+        original = path.read_text(encoding="utf-8")
+        updated = process_text(original)
+        # Preserve final newline presence.
+        if original.endswith("\n") and not updated.endswith("\n"):
+            updated += "\n"
+        if updated != original:
+            changed.append(path)
+            if not args.check:
+                path.write_text(updated, encoding="utf-8", newline="")
+
+    if args.check:
+        if changed:
+            print("Would align tables in:")
+            for p in changed:
+                print(f"  {p}")
+            return 1
+        print("All Markdown tables already aligned.")
+        return 0
+
+    if changed:
+        print(f"Aligned tables in {len(changed)} file(s):")
+        for p in changed:
+            print(f"  {p}")
+    else:
+        print("No Markdown table changes needed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/doc/gui.md
+++ b/src/doc/gui.md
@@ -20,11 +20,11 @@ Typical responsibilities:
 
 ### Lifetime and ownership
 
-| Object | Owner | Notes |
-| --- | --- | --- |
-| `GUI` | `main` / Emscripten singleton | Constructs `std::unique_ptr<Occt_view> m_view` in constructor |
-| `Occt_view` | `GUI::m_view` | Holds sketches, shapes, undo stacks, shape operation subobjects |
-| `GLFWwindow*` | Passed to `GUI::init` | Also wrapped by `Occt_glfw_win` inside the view |
+| Object        | Owner                         | Notes                                                           |
+| ------------- | ----------------------------- | --------------------------------------------------------------- |
+| `GUI`         | `main` / Emscripten singleton | Constructs `std::unique_ptr<Occt_view> m_view` in constructor   |
+| `Occt_view`   | `GUI::m_view`                 | Holds sketches, shapes, undo stacks, shape operation subobjects |
+| `GLFWwindow*` | Passed to `GUI::init`         | Also wrapped by `Occt_glfw_win` inside the view                 |
 
 `GUI` and `Occt_view` reference each other (`Occt_view(GUI& gui)`, `m_view->gui()`). Both must outlive the session.
 
@@ -32,12 +32,12 @@ Typical responsibilities:
 
 `GUI::set_mode` (in `gui_mode.cpp`):
 
-| Step | Action |
-| --- | --- |
-| 1 | `cancel_underlay_calib_()` |
-| 2 | Set `m_mode`, call `m_view->on_mode()` |
-| 3 | `sync_sketch_add_mid_pt_edges_if_applicable_()` |
-| 4 | Update toolbar active state |
+| Step | Action                                          |
+| ---- | ----------------------------------------------- |
+| 1    | `cancel_underlay_calib_()`                      |
+| 2    | Set `m_mode`, call `m_view->on_mode()`          |
+| 3    | `sync_sketch_add_mid_pt_edges_if_applicable_()` |
+| 4    | Update toolbar active state                     |
 
 `set_parent_mode()` maps each tool mode back to `Normal` or `Sketch_inspection_mode` (see parent map in `gui_mode.cpp`).
 
@@ -45,12 +45,12 @@ Typical responsibilities:
 
 `gui.ui_verbosity` gates panes and help (Settings slider). Derived tiers on `GUI`:
 
-| API | Meaning |
-| --- | --- |
-| `ui_feature_tier()` | `(verbosity + 1) / 2` -- Options, lists, log at tier 1+ |
-| `ui_help_tier()` | `verbosity / 2` -- contextual help depth |
-| `ui_show_contextual_help()` | `verbosity >= 5` -- `?` buttons and doc links |
-| `show_*_effective()` | Pane flag AND feature tier |
+| API                         | Meaning                                                 |
+| --------------------------- | ------------------------------------------------------- |
+| `ui_feature_tier()`         | `(verbosity + 1) / 2` -- Options, lists, log at tier 1+ |
+| `ui_help_tier()`            | `verbosity / 2` -- contextual help depth                |
+| `ui_show_contextual_help()` | `verbosity >= 5` -- `?` buttons and doc links           |
+| `show_*_effective()`        | Pane flag AND feature tier                              |
 
 Constants and ranges live in `gui.h` (`k_gui_ui_verbosity_*`, dimension defaults, view roll/zoom ranges).
 
@@ -80,23 +80,23 @@ CMake IDE group: `src\gui` (files matching `gui*` or `occt*` prefix).
 
 Dear ImGui **docking branch** (`third_party/imgui`, tag `v1.92.7-docking`) is vendored with `IMGUI_HAS_DOCK`.
 
-| Platform | Flags | Behavior |
-| --- | --- | --- |
-| Native | `DockingEnable`, `ViewportsEnable` | In-canvas dock/tab/split; panels may detach to OS windows |
-| WASM | `DockingEnable` | In-canvas dock/tab/split only (no multi-viewport OS windows) |
+| Platform | Flags                              | Behavior                                                     |
+| -------- | ---------------------------------- | ------------------------------------------------------------ |
+| Native   | `DockingEnable`, `ViewportsEnable` | In-canvas dock/tab/split; panels may detach to OS windows    |
+| WASM     | `DockingEnable`                    | In-canvas dock/tab/split only (no multi-viewport OS windows) |
 
 ### WASM HiDPI / canvas sizing
 
 Shared `#canvas` is used by ImGui and OCCT. Model follows the physical-pixel approach from
 [imgui#7519](https://github.com/ocornut/imgui/issues/7519#issuecomment-2629628233):
 
-| Piece | Role |
-| --- | --- |
-| HTML CSS (`width`/`height: 100%`) | On-screen (CSS) size of the canvas |
-| `ImGui_ImplGlfw_OnCanvasSizeChange` (vendored patch) | Sets `canvas.width/height` and GLFW window to `CSS * devicePixelRatio` |
-| ImGui `main_scale` | `devicePixelRatio` via `ScaleAllSizes` / `FontScaleDpi` so widgets keep CSS-logical on-screen size |
-| `io.DisplayFramebufferScale` | Stays `1` (window size == framebuffer size in physical px) - fonts/icons are not upscaled |
-| OCCT `Wasm_Window("#canvas", false)` + `SetDevicePixelRatio(1)` | Shares the ImGui-sized backing store; mouse/view coords match GLFW |
+| Piece                                                           | Role                                                                                               |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| HTML CSS (`width`/`height: 100%`)                               | On-screen (CSS) size of the canvas                                                                 |
+| `ImGui_ImplGlfw_OnCanvasSizeChange` (vendored patch)            | Sets `canvas.width/height` and GLFW window to `CSS * devicePixelRatio`                             |
+| ImGui `main_scale`                                              | `devicePixelRatio` via `ScaleAllSizes` / `FontScaleDpi` so widgets keep CSS-logical on-screen size |
+| `io.DisplayFramebufferScale`                                    | Stays `1` (window size == framebuffer size in physical px) - fonts/icons are not upscaled          |
+| OCCT `Wasm_Window("#canvas", false)` + `SetDevicePixelRatio(1)` | Shares the ImGui-sized backing store; mouse/view coords match GLFW                                 |
 
 Do **not** set `GLFW_SCALE_TO_MONITOR` on wasm: Emscripten then forces canvas CSS size to the GLFW window size (`!important`), which fights the 100% CSS layout.
 
@@ -120,99 +120,99 @@ Overlay popups (`FloatEdit`, `AngleEdit`, `MessageStatus`, modals) keep `NoSaved
 
 ### Keyboard (`GUI::on_key` in `gui_mode.cpp`)
 
-| Input | Condition | Handler |
-| --- | --- | --- |
-| `+` / `-` / numpad +/- | No Ctrl/Alt | `Occt_view::zoom_view_wheel_notches` |
-| Shift + 4/6 / arrows / numpad 4/6 | No Ctrl/Alt | `Occt_view::roll_view_z_deg` |
-| Numpad 5 | No modifiers | `Occt_view::snap_view_to_nearest_standard_axis` |
-| Numpad 2/4/6/8 | No modifiers | `Occt_view::orbit_view_screen_step_deg` |
-| Ctrl+N/O/S | | `new_project_` / `open_file_dialog_` / `save_file_dialog_` |
-| Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y | | `Occt_view::undo` / `redo` |
-| `1`-`9` / numpad `1`-`9` | `Mode::Normal` only | `set_shp_selection_mode` (TopAbs enum index) |
-| Esc | | `cancel_underlay_calib_`, `Occt_view::cancel`, hide dist/angle edit |
-| Tab | | `Occt_view::dimension_input` |
-| Shift+Tab | | `Occt_view::angle_input` |
-| Enter | | hide edits, `Occt_view::on_enter` |
-| D | | `Mode::Sketch_dim_anno` |
-| Shift+D / Delete / Backspace | | `Occt_view::delete_selected` |
-| G / R / E / S / C / F | | Move / Rotate / Extrude / Scale / Chamfer / Fillet modes |
-| Move-mode keys | `Mode::Move` | `on_key_move_mode_` (axis constraints X/Y/Z) |
-| Rotate-mode keys | `Mode::Rotate` | `on_key_rotate_mode_` (axis pick, Tab angle) |
+| Input                             | Condition           | Handler                                                             |
+| --------------------------------- | ------------------- | ------------------------------------------------------------------- |
+| `+` / `-` / numpad +/-            | No Ctrl/Alt         | `Occt_view::zoom_view_wheel_notches`                                |
+| Shift + 4/6 / arrows / numpad 4/6 | No Ctrl/Alt         | `Occt_view::roll_view_z_deg`                                        |
+| Numpad 5                          | No modifiers        | `Occt_view::snap_view_to_nearest_standard_axis`                     |
+| Numpad 2/4/6/8                    | No modifiers        | `Occt_view::orbit_view_screen_step_deg`                             |
+| Ctrl+N/O/S                        |                     | `new_project_` / `open_file_dialog_` / `save_file_dialog_`          |
+| Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y    |                     | `Occt_view::undo` / `redo`                                          |
+| `1`-`9` / numpad `1`-`9`          | `Mode::Normal` only | `set_shp_selection_mode` (TopAbs enum index)                        |
+| Esc                               |                     | `cancel_underlay_calib_`, `Occt_view::cancel`, hide dist/angle edit |
+| Tab                               |                     | `Occt_view::dimension_input`                                        |
+| Shift+Tab                         |                     | `Occt_view::angle_input`                                            |
+| Enter                             |                     | hide edits, `Occt_view::on_enter`                                   |
+| D                                 |                     | `Mode::Sketch_dim_anno`                                             |
+| Shift+D / Delete / Backspace      |                     | `Occt_view::delete_selected`                                        |
+| G / R / E / S / C / F             |                     | Move / Rotate / Extrude / Scale / Chamfer / Fillet modes            |
+| Move-mode keys                    | `Mode::Move`        | `on_key_move_mode_` (axis constraints X/Y/Z)                        |
+| Rotate-mode keys                  | `Mode::Rotate`      | `on_key_rotate_mode_` (axis pick, Tab angle)                        |
 
 See also [`src/doc/sketch.md`](sketch.md) and [`src/doc/shape.md`](shape.md) for per-mode mouse routing after `GUI` delegates to `Occt_view`.
 
 ### Mouse move (`GUI::on_mouse_pos`)
 
-| `Mode` | Delegate |
-| --- | --- |
-| `Move` | `shp_move().move_selected` |
-| `Rotate` | `shp_rotate().rotate_selected` |
-| `Scale` | `shp_scale().scale_selected` |
-| `Shape_polar_duplicate` | `shp_polar_dup().move_point` |
-| Sketch tool modes (line, arc, rect, dim, axis, ...) | `curr_sketch().sketch_pt_move` |
-| `Sketch_face_extrude` | `sketch_face_extrude(..., true)` |
+| `Mode`                                              | Delegate                         |
+| --------------------------------------------------- | -------------------------------- |
+| `Move`                                              | `shp_move().move_selected`       |
+| `Rotate`                                            | `shp_rotate().rotate_selected`   |
+| `Scale`                                             | `shp_scale().scale_selected`     |
+| `Shape_polar_duplicate`                             | `shp_polar_dup().move_point`     |
+| Sketch tool modes (line, arc, rect, dim, axis, ...) | `curr_sketch().sketch_pt_move`   |
+| `Sketch_face_extrude`                               | `sketch_face_extrude(..., true)` |
 
 Always calls `m_view->on_mouse_move(screen_coords)` first.
 
 ### Mouse buttons (`GUI::on_mouse_button` + `on_left_click_`)
 
-| Event | Handler |
-| --- | --- |
-| LMB (underlay calib active) | `try_underlay_calib_click_` (early return) |
-| LMB | `m_view->on_mouse_button` then `on_left_click_` |
-| RMB press | `finalize_elm` for line / multi-line sketch modes |
-| LMB in `on_left_click_` | Mode-specific: transform finalize, sketch `add_sketch_pt`, fillet/chamfer click, polar dup `add_point`, extrude pick |
+| Event                       | Handler                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| LMB (underlay calib active) | `try_underlay_calib_click_` (early return)                                                                           |
+| LMB                         | `m_view->on_mouse_button` then `on_left_click_`                                                                      |
+| RMB press                   | `finalize_elm` for line / multi-line sketch modes                                                                    |
+| LMB in `on_left_click_`     | Mode-specific: transform finalize, sketch `add_sketch_pt`, fillet/chamfer click, polar dup `add_point`, extrude pick |
 
 Tests use `sketch_left_click` to simulate sketch LMB without ImGui mouse position.
 
 ### Scroll / resize
 
-| Callback | Delegate |
-| --- | --- |
+| Callback          | Delegate                                          |
+| ----------------- | ------------------------------------------------- |
 | `on_mouse_scroll` | `Occt_view::on_mouse_scroll` (Shift = finer zoom) |
-| `on_resize` | `Occt_view::on_resize` |
+| `on_resize`       | `Occt_view::on_resize`                            |
 
 ## Options panel dispatch
 
 `GUI::options_()` switches on `get_mode()`:
 
-| `Mode` | Options function |
-| --- | --- |
-| `Normal` | `options_normal_mode_` (selection filter, orthographic) |
-| `Move` / `Rotate` / `Scale` | `options_*_mode_` (constraints, axis, material) |
-| `Shape_chamfer` / `Shape_fillet` | mode + radius/distance |
-| `Shape_polar_duplicate` | angle, count, rotate/combine, **Dup** button |
-| `Sketch_inspection_mode` | `options_sketch_common_` |
-| Each sketch tool mode | Matching `options_sketch_*_mode_` |
-| `Sketch_operation_axis` | Mirror / Revolve / Clear axis |
-| `Sketch_face_extrude` | Both sides, material |
+| `Mode`                           | Options function                                        |
+| -------------------------------- | ------------------------------------------------------- |
+| `Normal`                         | `options_normal_mode_` (selection filter, orthographic) |
+| `Move` / `Rotate` / `Scale`      | `options_*_mode_` (constraints, axis, material)         |
+| `Shape_chamfer` / `Shape_fillet` | mode + radius/distance                                  |
+| `Shape_polar_duplicate`          | angle, count, rotate/combine, **Dup** button            |
+| `Sketch_inspection_mode`         | `options_sketch_common_`                                |
+| Each sketch tool mode            | Matching `options_sketch_*_mode_`                       |
+| `Sketch_operation_axis`          | Mirror / Revolve / Clear axis                           |
+| `Sketch_face_extrude`            | Both sides, material                                    |
 
 Shared sketch controls (snap, midpoint nodes, place-from-center) live in `options_sketch_common_` and helpers in `gui_mode.cpp`.
 
 ## ImGui frame order (`render_gui`)
 
-| Order | Function | Purpose |
-| --- | --- | --- |
-| 1 | `flush_view_events` | Sync camera before UI uses projection |
-| 2 | `menu_bar_`, `toolbar_` | File / View / mode tools |
-| 3 | `dist_edit_`, `angle_edit_` | Floating numeric entry |
-| 4 | `sketch_list_`, `sketch_properties_dialog_` | Sketch List + underlay/properties |
-| 5 | `shape_list_`, `shape_info_dialog_` | Shape List + info popup |
-| 6 | `options_` | Mode-specific Options pane |
-| 7 | `message_status_window_`, `about_dialog_` | Status + About |
-| 8 | `add_*_dialog_` | Primitive / sketch creation popups |
-| 9 | `log_window_`, consoles, `settings_`, `dbg_` | Log, Lua/Python, Settings |
+| Order | Function                                     | Purpose                               |
+| ----- | -------------------------------------------- | ------------------------------------- |
+| 1     | `flush_view_events`                          | Sync camera before UI uses projection |
+| 2     | `menu_bar_`, `toolbar_`                      | File / View / mode tools              |
+| 3     | `dist_edit_`, `angle_edit_`                  | Floating numeric entry                |
+| 4     | `sketch_list_`, `sketch_properties_dialog_`  | Sketch List + underlay/properties     |
+| 5     | `shape_list_`, `shape_info_dialog_`          | Shape List + info popup               |
+| 6     | `options_`                                   | Mode-specific Options pane            |
+| 7     | `message_status_window_`, `about_dialog_`    | Status + About                        |
+| 8     | `add_*_dialog_`                              | Primitive / sketch creation popups    |
+| 9     | `log_window_`, consoles, `settings_`, `dbg_` | Log, Lua/Python, Settings             |
 
 3D redraw: `render_occt()` -> `Occt_view::do_frame()` (separate from ImGui pass).
 
 ## Settings and persistence
 
-| File | Role |
-| --- | --- |
-| `gui_settings.cpp` | Settings dialog UI; read/write `ezycad_settings.json` |
-| `save_occt_view_settings` | Persists `gui.*`, `occt_view.*`, pane visibility, last project path |
-| `load_occt_view_settings_` | Called from `GUI::init` |
-| `occt_view_settings_json()` | Scripting API for settings blob |
+| File                        | Role                                                                |
+| --------------------------- | ------------------------------------------------------------------- |
+| `gui_settings.cpp`          | Settings dialog UI; read/write `ezycad_settings.json`               |
+| `save_occt_view_settings`   | Persists `gui.*`, `occt_view.*`, pane visibility, last project path |
+| `load_occt_view_settings_`  | Called from `GUI::init`                                             |
+| `occt_view_settings_json()` | Scripting API for settings blob                                     |
 
 User-visible key tables: [`docs/usage-settings.md`](../../docs/usage-settings.md). When adding a Settings control, follow [agents/conventions/user-docs-sync.md](../../agents/conventions/user-docs-sync.md).
 
@@ -248,19 +248,19 @@ Occt_view* view = gui.get_view();
 
 ## Testing
 
-| Item | Notes |
-| --- | --- |
-| Sketch tests | `GUI_access` friend in `tests/sketch_test_fixture.*` |
+| Item                   | Notes                                                |
+| ---------------------- | ---------------------------------------------------- |
+| Sketch tests           | `GUI_access` friend in `tests/sketch_test_fixture.*` |
 | Headless / partial GUI | `sketch_left_click`, message getters on `GUI_access` |
-| Full UI | Manual smoke; no dedicated `gui_tests` target |
+| Full UI                | Manual smoke; no dedicated `gui_tests` target        |
 
 ## Related code outside `src/gui*`
 
-| Location | Role |
-| --- | --- |
-| [`mode.h`](../mode.h) | `Mode`, `Fillet_mode`, `Chamfer_mode`, sketch/shape mode helpers |
-| [`main.cpp`](../main.cpp) | GLFW callbacks -> `GUI`; dist/angle edit key guard |
-| [`src/doc/sketch.md`](sketch.md) | Sketch methods called from `GUI` / `Occt_view` |
-| [`src/doc/shape.md`](shape.md) | Shape operations invoked from toolbar, Options, mouse |
-| [`scr_lua_console.cpp`](../scr_lua_console.cpp) / [`scr_python_console.cpp`](../scr_python_console.cpp) | Script consoles embedded in `render_gui` |
-| [`utl_settings.cpp`](../utl_settings.cpp) | User settings file path and I/O helpers |
+| Location                                                                                                | Role                                                             |
+| ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [`mode.h`](../mode.h)                                                                                   | `Mode`, `Fillet_mode`, `Chamfer_mode`, sketch/shape mode helpers |
+| [`main.cpp`](../main.cpp)                                                                               | GLFW callbacks -> `GUI`; dist/angle edit key guard               |
+| [`src/doc/sketch.md`](sketch.md)                                                                        | Sketch methods called from `GUI` / `Occt_view`                   |
+| [`src/doc/shape.md`](shape.md)                                                                          | Shape operations invoked from toolbar, Options, mouse            |
+| [`scr_lua_console.cpp`](../scr_lua_console.cpp) / [`scr_python_console.cpp`](../scr_python_console.cpp) | Script consoles embedded in `render_gui`                         |
+| [`utl_settings.cpp`](../utl_settings.cpp)                                                               | User settings file path and I/O helpers                          |

--- a/src/doc/script.md
+++ b/src/doc/script.md
@@ -8,9 +8,9 @@ Maintainers: update this file when script bindings, console UI, or startup scrip
 
 The `scr_*` translation units embed **interactive script consoles** in the ImGui UI. They expose live `ezy.*` and `view.*` APIs to Lua and Python so users can inspect the document, add primitives, tweak the camera, and log messages while EzyCad runs.
 
-| Class | File | Runtime |
-| --- | --- | --- |
-| `Lua_console` | `scr_lua_console.cpp` | Lua C API (native + Emscripten) |
+| Class            | File                     | Runtime                                    |
+| ---------------- | ------------------------ | ------------------------------------------ |
+| `Lua_console`    | `scr_lua_console.cpp`    | Lua C API (native + Emscripten)            |
 | `Python_console` | `scr_python_console.cpp` | pybind11 embed (`EZYCAD_HAVE_PYTHON` only) |
 
 Both are owned by `GUI` and rendered from `GUI::render_gui()` when feature tier allows (`show_lua_console_effective` / `show_python_console_effective`).
@@ -19,28 +19,28 @@ Both are owned by `GUI` and rendered from `GUI::render_gui()` when feature tier 
 
 ### Lifetime and threading
 
-| Object | Notes |
-| --- | --- |
-| `Lua_console` / `Python_console` | Constructed with `GUI*`; must not outlive `GUI` |
-| `lua_State* m_L` | Created in ctor, closed in dtor |
-| Python runtime | `Ezycad_python_runtime` (pybind11) initialized in `init_python_()` |
+| Object                           | Notes                                                              |
+| -------------------------------- | ------------------------------------------------------------------ |
+| `Lua_console` / `Python_console` | Constructed with `GUI*`; must not outlive `GUI`                    |
+| `lua_State* m_L`                 | Created in ctor, closed in dtor                                    |
+| Python runtime                   | `Ezycad_python_runtime` (pybind11) initialized in `init_python_()` |
 
 Script callbacks run on the **main UI thread** during console input handling. Do not call OCCT or ImGui from worker threads without existing app synchronization.
 
 ### Script file locations
 
-| Platform | Lua | Python |
-| --- | --- | --- |
-| Native | `res/scripts/lua/*.lua` | `res/scripts/python/*.py` |
-| Emscripten | `/res/scripts/lua/*.lua` (preloaded) | Not built |
+| Platform   | Lua                                  | Python                    |
+| ---------- | ------------------------------------ | ------------------------- |
+| Native     | `res/scripts/lua/*.lua`              | `res/scripts/python/*.py` |
+| Emscripten | `/res/scripts/lua/*.lua` (preloaded) | Not built                 |
 
 On startup, **Lua** files in that directory are loaded into tabbed `TextEditor` buffers and **executed once** to define helpers. Python tabs load file contents but are not auto-run on startup (run manually or from input line).
 
 ### Index conventions
 
-| API | Index base |
-| --- | --- |
-| Lua `view.get_shape(i)` | **1-based**; returns `nil` out of range |
+| API                        | Index base                                    |
+| -------------------------- | --------------------------------------------- |
+| Lua `view.get_shape(i)`    | **1-based**; returns `nil` out of range       |
 | Python `view.get_shape(i)` | **0-based**; raises `IndexError` out of range |
 
 Document this when adding parallel bindings.
@@ -71,101 +71,101 @@ Implementation lives in the `.cpp` files; [`docs/scripting.md`](../../docs/scrip
 
 ### `ezy` table (both runtimes)
 
-| Method | C++ delegate |
-| --- | --- |
-| `ezy.log(msg)` | `GUI::log_message` + console history |
-| `ezy.msg(text)` | `GUI::show_message` |
-| `ezy.get_mode()` | `GUI::get_mode()` -> mode name string |
-| `ezy.set_mode(name)` | `GUI::set_mode(mode_from_string(...))` |
-| `ezy.save_occt_view_settings()` | `GUI::save_occt_view_settings()` |
-| `ezy.occt_view_settings_json()` | `GUI::occt_view_settings_json()` |
-| `ezy.help()` / global `help()` | Prints binding summary to console |
+| Method                          | C++ delegate                           |
+| ------------------------------- | -------------------------------------- |
+| `ezy.log(msg)`                  | `GUI::log_message` + console history   |
+| `ezy.msg(text)`                 | `GUI::show_message`                    |
+| `ezy.get_mode()`                | `GUI::get_mode()` -> mode name string  |
+| `ezy.set_mode(name)`            | `GUI::set_mode(mode_from_string(...))` |
+| `ezy.save_occt_view_settings()` | `GUI::save_occt_view_settings()`       |
+| `ezy.occt_view_settings_json()` | `GUI::occt_view_settings_json()`       |
+| `ezy.help()` / global `help()`  | Prints binding summary to console      |
 
 Lua overrides global `print` to call `ezy.log`. Python bootstrap assigns `builtins.print` similarly.
 
 ### `view` table
 
-| Method | Notes |
-| --- | --- |
-| `sketch_count()` | `Occt_view::get_sketches().size()` |
-| `shape_count()` | `Occt_view::get_shapes().size()` |
-| `curr_sketch_name()` | Current sketch display name |
-| `add_box(...)` / `add_sphere(...)` | `Occt_view` primitive helpers |
-| `get_camera()` | `{ eye, center, up }` tables / dicts |
-| `set_camera(ex,ey,ez,cx,cy,cz,ux,uy,uz)` | `Occt_view::set_camera` |
-| `get_shape(i)` | Returns `Shp` wrapper |
+| Method                                   | Notes                                |
+| ---------------------------------------- | ------------------------------------ |
+| `sketch_count()`                         | `Occt_view::get_sketches().size()`   |
+| `shape_count()`                          | `Occt_view::get_shapes().size()`     |
+| `curr_sketch_name()`                     | Current sketch display name          |
+| `add_box(...)` / `add_sphere(...)`       | `Occt_view` primitive helpers        |
+| `get_camera()`                           | `{ eye, center, up }` tables / dicts |
+| `set_camera(ex,ey,ez,cx,cy,cz,ux,uy,uz)` | `Occt_view::set_camera`              |
+| `get_shape(i)`                           | Returns `Shp` wrapper                |
 
 **Lua and Python** (current sketch inspection):
 
-| Method | Returns |
-| --- | --- |
-| `curr_sketch_node_count()` | Node count |
-| `curr_sketch_node(i)` | `(x, y)` plane coords (Lua: 1-based index; Python: 0-based) |
-| `curr_sketch_dim_count()` | Length dimension count |
-| `curr_sketch_dim(i)` | `(lo, hi, visible, offset, name, distance)` (Lua: 1-based indices) |
+| Method                     | Returns                                                            |
+| -------------------------- | ------------------------------------------------------------------ |
+| `curr_sketch_node_count()` | Node count                                                         |
+| `curr_sketch_node(i)`      | `(x, y)` plane coords (Lua: 1-based index; Python: 0-based)        |
+| `curr_sketch_dim_count()`  | Length dimension count                                             |
+| `curr_sketch_dim(i)`       | `(lo, hi, visible, offset, name, distance)` (Lua: 1-based indices) |
 
 **Lua and Python** (sketch creation):
 
-| Method | Notes |
-| --- | --- |
+| Method                                 | Notes                                                      |
+| -------------------------------------- | ---------------------------------------------------------- |
 | `add_sketch(plane, offset, base_name)` | `Occt_view::add_sketch_on_ref_plane`; plane `XY`/`XZ`/`YZ` |
-| `add_edge(x1,y1,x2,y2)` | `Occt_view::curr_sketch_add_edge` |
-| `finish_sketch_edges()` | `Occt_view::curr_sketch_rebuild_faces` |
+| `add_edge(x1,y1,x2,y2)`                | `Occt_view::curr_sketch_add_edge`                          |
+| `finish_sketch_edges()`                | `Occt_view::curr_sketch_rebuild_faces`                     |
 
 ### `Shp` object
 
-| Method | Lua | Python |
-| --- | --- | --- |
-| `name()` / `set_name(s)` | userdata metatable | `ezycad_native.Shp` methods |
-| `visible()` / `set_visible(v)` | same | same |
+| Method                         | Lua                | Python                      |
+| ------------------------------ | ------------------ | --------------------------- |
+| `name()` / `set_name(s)`       | userdata metatable | `ezycad_native.Shp` methods |
+| `visible()` / `set_visible(v)` | same               | same                        |
 
 Lua stores `Shp_ptr` in userdata with `__gc`; Python wraps `Ezy_shp{ Shp_ptr shp }`.
 
 ## Console UI flow
 
-| UI region | Behavior |
-| --- | --- |
-| Output history | `m_history` lines (errors flagged) |
-| Input line | `ImGui::InputTextWithHint`; Enter runs `execute()` |
-| Command history | Up/down browses prior input lines |
-| Script tabs | One tab per file in scripts dir; Save writes buffer to disk |
+| UI region       | Behavior                                                    |
+| --------------- | ----------------------------------------------------------- |
+| Output history  | `m_history` lines (errors flagged)                          |
+| Input line      | `ImGui::InputTextWithHint`; Enter runs `execute()`          |
+| Command history | Up/down browses prior input lines                           |
+| Script tabs     | One tab per file in scripts dir; Save writes buffer to disk |
 
 `Lua_console::text_edit_callback` / `Python_console::text_edit_callback` hook editor keyboard shortcuts (shared pattern with dist/angle edit).
 
 ## Adding a new binding
 
-| Step | Lua | Python |
-| --- | --- | --- |
-| 1 | Add `l_*` C function using `get_gui(L)` | Add `m.def("view_foo", ...)` in `PYBIND11_EMBEDDED_MODULE` |
-| 2 | Register in `register_bindings()` on `ezy` or `view` table | Expose on `view` in bootstrap `exec()` string |
-| 3 | Update help text in `l_ezy_help` / `ezy_help` | same |
-| 4 | Update [`docs/scripting.md`](../../docs/scripting.md) | same |
+| Step | Lua                                                        | Python                                                     |
+| ---- | ---------------------------------------------------------- | ---------------------------------------------------------- |
+| 1    | Add `l_*` C function using `get_gui(L)`                    | Add `m.def("view_foo", ...)` in `PYBIND11_EMBEDDED_MODULE` |
+| 2    | Register in `register_bindings()` on `ezy` or `view` table | Expose on `view` in bootstrap `exec()` string              |
+| 3    | Update help text in `l_ezy_help` / `ezy_help`              | same                                                       |
+| 4    | Update [`docs/scripting.md`](../../docs/scripting.md)      | same                                                       |
 
 Prefer thin wrappers: validate args, call `GUI` / `Occt_view` / `Shp` methods, return simple types.
 
 ## Build flags
 
-| Flag | Effect |
-| --- | --- |
-| (default) | Lua console always linked (bundled Lua sources) |
+| Flag                 | Effect                                                                |
+| -------------------- | --------------------------------------------------------------------- |
+| (default)            | Lua console always linked (bundled Lua sources)                       |
 | `EZYCAD_HAVE_PYTHON` | Enables Python console, pybind11 embed, `python3.dll` copy on Windows |
 
 If Python init fails, `Python_console` shows an error in history and disables execution.
 
 ## Testing
 
-| Item | Notes |
-| --- | --- |
-| Automated API tests | Limited; bindings exercised manually and via `res/scripts/*` |
-| Regression | Run sample lines from `docs/scripting.md` after binding changes |
-| Lua on WASM | Verify `/res/scripts/lua` preload paths |
+| Item                | Notes                                                           |
+| ------------------- | --------------------------------------------------------------- |
+| Automated API tests | Limited; bindings exercised manually and via `res/scripts/*`    |
+| Regression          | Run sample lines from `docs/scripting.md` after binding changes |
+| Lua on WASM         | Verify `/res/scripts/lua` preload paths                         |
 
 ## Related code outside `src/scr*`
 
-| Location | Role |
-| --- | --- |
-| [`gui.cpp`](../gui.cpp) | Owns consoles, `lua_console_()` / `python_console_()` |
-| [`gui.h`](../gui.h) | `get_view()`, settings JSON, mode API used by bindings |
-| [`mode.h`](../mode.h) | `mode_from_string`, `c_mode_strs` |
-| [`gui_occt_view.h`](../gui_occt_view.h) | Document access from `view.*` |
-| [`shp.h`](../shp.h) | Shape wrapper type |
+| Location                                | Role                                                   |
+| --------------------------------------- | ------------------------------------------------------ |
+| [`gui.cpp`](../gui.cpp)                 | Owns consoles, `lua_console_()` / `python_console_()`  |
+| [`gui.h`](../gui.h)                     | `get_view()`, settings JSON, mode API used by bindings |
+| [`mode.h`](../mode.h)                   | `mode_from_string`, `c_mode_strs`                      |
+| [`gui_occt_view.h`](../gui_occt_view.h) | Document access from `view.*`                          |
+| [`shp.h`](../shp.h)                     | Shape wrapper type                                     |

--- a/src/doc/shape.md
+++ b/src/doc/shape.md
@@ -39,11 +39,11 @@ Typical uses:
 
 Always go through `Occt_view::add_shp_(Shp_ptr&)` (or a wrapper that calls it):
 
-| Step | Action |
-| --- | --- |
-| 1 | Apply the view default material and shading refresh |
-| 2 | Set the document-wide shape selection mode (`m_shp_selection_mode`) |
-| 3 | Redisplay and append to `m_shps` |
+| Step | Action                                                              |
+| ---- | ------------------------------------------------------------------- |
+| 1    | Apply the view default material and shading refresh                 |
+| 2    | Set the document-wide shape selection mode (`m_shp_selection_mode`) |
+| 3    | Redisplay and append to `m_shps`                                    |
 
 `add_shp_()` does **not** push undo; callers that mutate the document should call `view().push_undo_snapshot()` first when appropriate.
 
@@ -51,9 +51,9 @@ Always go through `Occt_view::add_shp_(Shp_ptr&)` (or a wrapper that calls it):
 
 Each operation object inherits `Shp_operation_base` and uses **`m_shps`** as a lazy cache of shapes involved in the current operation:
 
-| Helper | Requirement |
-| --- | --- |
-| `ensure_operation_shps_()` | One or more selected `Shp` objects |
+| Helper                           | Requirement                                     |
+| -------------------------------- | ----------------------------------------------- |
+| `ensure_operation_shps_()`       | One or more selected `Shp` objects              |
 | `ensure_operation_multi_shps_()` | Two or more selected shapes (fuse, cut, common) |
 
 On first call, `m_shps` is filled from `get_selected_shps_()` (viewer selection filtered to `Shp`). Cleared on `reset()` / cancel paths in interactive tools.
@@ -62,19 +62,19 @@ Do not confuse this vector with `Occt_view::m_shps` (the document list).
 
 ### Transform preview vs bake
 
-| Phase | Move / rotate / scale | Booleans / fillet / chamfer |
-| --- | --- | --- |
-| **Preview** | `SetLocalTransformation()`; `redisplay_operation_shps_after_transform_()` | N/A (immediate replace) |
-| **Finalize** | `operation_shps_finalize_()` -> `bake_transform_into_geometry()` | New `Shp`; `delete_operation_shps_()`; `add_shp_()` |
-| **Cancel** | `operation_shps_cancel_()` -> `ResetTransformation()` | N/A |
+| Phase        | Move / rotate / scale                                                     | Booleans / fillet / chamfer                         |
+| ------------ | ------------------------------------------------------------------------- | --------------------------------------------------- |
+| **Preview**  | `SetLocalTransformation()`; `redisplay_operation_shps_after_transform_()` | N/A (immediate replace)                             |
+| **Finalize** | `operation_shps_finalize_()` -> `bake_transform_into_geometry()`          | New `Shp`; `delete_operation_shps_()`; `add_shp_()` |
+| **Cancel**   | `operation_shps_cancel_()` -> `ResetTransformation()`                     | N/A                                                 |
 
 ### Sketch-linked geometry
 
-| Operation | Module | Sketch tie-in |
-| --- | --- | --- |
-| Face extrude | `Shp_extrude` | Picks `Sketch_face_shp`; uses owning sketch plane |
-| Polar duplicate | `Shp_polar_dup` | Rotation axis and arm on `curr_sketch().get_plane()` |
-| Revolve | `Sketch::revolve_selected` | Returns `Shp_rslt`; view calls `add_shp_()` |
+| Operation       | Module                     | Sketch tie-in                                        |
+| --------------- | -------------------------- | ---------------------------------------------------- |
+| Face extrude    | `Shp_extrude`              | Picks `Sketch_face_shp`; uses owning sketch plane    |
+| Polar duplicate | `Shp_polar_dup`            | Rotation axis and arm on `curr_sketch().get_plane()` |
+| Revolve         | `Sketch::revolve_selected` | Returns `Shp_rslt`; view calls `add_shp_()`          |
 
 ### Result type
 
@@ -115,51 +115,51 @@ class Shp : public AIS_Shape {
 
 Protected helpers used by all operation classes:
 
-| Method | Purpose |
-| --- | --- |
-| `get_selected_shps_()` | Current viewer selection as `Shp_ptr` vector |
-| `ensure_operation_shps_()` / `ensure_operation_multi_shps_()` | Lazy-fill `m_shps` from selection |
-| `delete_operation_shps_()` | Remove operation shapes from viewer and document list |
-| `operation_shps_finalize_()` | Bake local transforms into geometry |
-| `operation_shps_cancel_()` | Reset local transforms |
-| `get_shape_` / `get_face_` / `get_wire_` / `get_edge_` | Pick sub-shapes at screen coords |
-| `add_shp_(Shp_ptr&)` | Register new shape in the document |
-| `copy_shape_material_from_(dest, src)` | Preserve material after replace-style ops |
+| Method                                                        | Purpose                                               |
+| ------------------------------------------------------------- | ----------------------------------------------------- |
+| `get_selected_shps_()`                                        | Current viewer selection as `Shp_ptr` vector          |
+| `ensure_operation_shps_()` / `ensure_operation_multi_shps_()` | Lazy-fill `m_shps` from selection                     |
+| `delete_operation_shps_()`                                    | Remove operation shapes from viewer and document list |
+| `operation_shps_finalize_()`                                  | Bake local transforms into geometry                   |
+| `operation_shps_cancel_()`                                    | Reset local transforms                                |
+| `get_shape_` / `get_face_` / `get_wire_` / `get_edge_`        | Pick sub-shapes at screen coords                      |
+| `add_shp_(Shp_ptr&)`                                          | Register new shape in the document                    |
+| `copy_shape_material_from_(dest, src)`                        | Preserve material after replace-style ops             |
 
 ## Operation modules
 
-| File | Type | Behavior |
-| --- | --- | --- |
-| `shp_create.h` | `namespace shp_create` | Pure functions: `create_box`, `create_pyramid`, `create_sphere`, `create_cylinder`, `create_cone`, `create_torus` -> `TopoDS_Shape`. Called from `Occt_view::add_*` helpers. |
-| `shp_extrude.h` | `Shp_extrude` | Two-click extrude of `Sketch_face_shp`; live preview solid + tmp length dimension; `finalize` / `cancel`; optional both-sides extrude. |
-| `shp_fuse.h` | `Shp_fuse` | `selected_fuse()` -- sequential `BRepAlgoAPI_Fuse` on all selected shapes -> one new `Shp`. |
-| `shp_cut.h` | `Shp_cut` | `selected_cut()` -- first selected = blank, rest = tools (`BRepAlgoAPI_Cut`). |
-| `shp_common.h` | `Shp_common` | `selected_common()` -- sequential `BRepAlgoAPI_Common` (intersection). |
-| `shp_move.h` | `Shp_move` | Drag on view plane; axis constraints (`Move_options`); Tab distance entry; finalize bakes translation. |
-| `shp_rotate.h` | `Shp_rotate` | Rotate about view axis, global X/Y/Z, or view-to-object; angle Tab entry; optional axis/center AIS guides. |
-| `shp_scale.h` | `Shp_scale` | Uniform scale from bbox center vs mouse distance; clamped factor 0.01..100. |
-| `shp_fillet.h` | `Shp_fillet` | `add_fillet(..., Fillet_mode)` -- `BRepFilletAPI_MakeFillet`; modes: Shape, Face, Wire, Edge (`mode.h`). |
-| `shp_chamfer.h` | `Shp_chamfer` | `add_chamfer(..., Chamfer_mode)` -- diagonal distance converted to setback (`dist/sqrt(2)`). |
-| `shp_polar_dup.h` | `Shp_polar_dup` | Arm on sketch plane; `dup()` copies selection at polar steps; options: rotate copies, combine into one solid. |
-| `shp_info.h` | `namespace shp_info` | `collect(TopoDS_Shape, Display_meta*)` -> labeled lines for Shape info dialog. |
+| File              | Type                   | Behavior                                                                                                                                                                     |
+| ----------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shp_create.h`    | `namespace shp_create` | Pure functions: `create_box`, `create_pyramid`, `create_sphere`, `create_cylinder`, `create_cone`, `create_torus` -> `TopoDS_Shape`. Called from `Occt_view::add_*` helpers. |
+| `shp_extrude.h`   | `Shp_extrude`          | Two-click extrude of `Sketch_face_shp`; live preview solid + tmp length dimension; `finalize` / `cancel`; optional both-sides extrude.                                       |
+| `shp_fuse.h`      | `Shp_fuse`             | `selected_fuse()` -- sequential `BRepAlgoAPI_Fuse` on all selected shapes -> one new `Shp`.                                                                                  |
+| `shp_cut.h`       | `Shp_cut`              | `selected_cut()` -- first selected = blank, rest = tools (`BRepAlgoAPI_Cut`).                                                                                                |
+| `shp_common.h`    | `Shp_common`           | `selected_common()` -- sequential `BRepAlgoAPI_Common` (intersection).                                                                                                       |
+| `shp_move.h`      | `Shp_move`             | Drag on view plane; axis constraints (`Move_options`); Tab distance entry; finalize bakes translation.                                                                       |
+| `shp_rotate.h`    | `Shp_rotate`           | Rotate about view axis, global X/Y/Z, or view-to-object; angle Tab entry; optional axis/center AIS guides.                                                                   |
+| `shp_scale.h`     | `Shp_scale`            | Uniform scale from bbox center vs mouse distance; clamped factor 0.01..100.                                                                                                  |
+| `shp_fillet.h`    | `Shp_fillet`           | `add_fillet(..., Fillet_mode)` -- `BRepFilletAPI_MakeFillet`; modes: Shape, Face, Wire, Edge (`mode.h`).                                                                     |
+| `shp_chamfer.h`   | `Shp_chamfer`          | `add_chamfer(..., Chamfer_mode)` -- diagonal distance converted to setback (`dist/sqrt(2)`).                                                                                 |
+| `shp_polar_dup.h` | `Shp_polar_dup`        | Arm on sketch plane; `dup()` copies selection at polar steps; options: rotate copies, combine into one solid.                                                                |
+| `shp_info.h`      | `namespace shp_info`   | `collect(TopoDS_Shape, Display_meta*)` -> labeled lines for Shape info dialog.                                                                                               |
 
 ## Input routing (from UI / `Occt_view`)
 
 `GUI` and `Occt_view` dispatch by `Mode` and toolbar actions:
 
-| Mode / action | Mouse move (`GUI::on_mouse_pos`) | Left click | Tab / Enter | Esc (`Occt_view::cancel`) |
-| --- | --- | --- | --- | --- |
-| `Mode::Move` | `shp_move().move_selected` | `shp_move().finalize` | `shp_move().show_dist_edit` (`gui_mode`) | `shp_move().cancel` -> `Normal` |
-| `Mode::Rotate` | `shp_rotate().rotate_selected` | `shp_rotate().finalize` | `shp_rotate().show_angle_edit` | `shp_rotate().cancel` -> `Normal` |
-| `Mode::Scale` | `shp_scale().scale_selected` | `shp_scale().finalize` | -- | `shp_scale().cancel` -> `Normal` |
-| `Mode::Sketch_face_extrude` | `sketch_face_extrude(..., true)` | 1st click: pick face; 2nd click (view): `finalize_sketch_extrude_` if active | `dimension_input` / `on_enter` refresh preview | `m_shp_extrude.cancel` |
-| `Mode::Shape_fillet` | -- | `shp_fillet().add_fillet(..., Fillet_mode)` | -- | -- |
-| `Mode::Shape_chamfer` | -- | `shp_chamfer().add_chamfer(..., Chamfer_mode)` | -- | -- |
-| `Mode::Shape_polar_duplicate` | `shp_polar_dup().move_point` | `shp_polar_dup().add_point` | -- | `shp_polar_dup().reset` on mode change |
-| Fuse / cut / common (toolbar) | -- | `selected_fuse` / `selected_cut` / `selected_common` (one-shot) | -- | -- |
-| Primitives (menu / script) | -- | `Occt_view::add_box`, `add_sphere`, ... | -- | -- |
-| Revolve (sketch Options) | -- | `Occt_view::revolve_selected` -> `add_shp_` | -- | -- |
-| Polar duplicate commit | -- | Options **Dup** button -> `shp_polar_dup().dup()` | -- | -- |
+| Mode / action                 | Mouse move (`GUI::on_mouse_pos`) | Left click                                                                   | Tab / Enter                                    | Esc (`Occt_view::cancel`)              |
+| ----------------------------- | -------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------- |
+| `Mode::Move`                  | `shp_move().move_selected`       | `shp_move().finalize`                                                        | `shp_move().show_dist_edit` (`gui_mode`)       | `shp_move().cancel` -> `Normal`        |
+| `Mode::Rotate`                | `shp_rotate().rotate_selected`   | `shp_rotate().finalize`                                                      | `shp_rotate().show_angle_edit`                 | `shp_rotate().cancel` -> `Normal`      |
+| `Mode::Scale`                 | `shp_scale().scale_selected`     | `shp_scale().finalize`                                                       | --                                             | `shp_scale().cancel` -> `Normal`       |
+| `Mode::Sketch_face_extrude`   | `sketch_face_extrude(..., true)` | 1st click: pick face; 2nd click (view): `finalize_sketch_extrude_` if active | `dimension_input` / `on_enter` refresh preview | `m_shp_extrude.cancel`                 |
+| `Mode::Shape_fillet`          | --                               | `shp_fillet().add_fillet(..., Fillet_mode)`                                  | --                                             | --                                     |
+| `Mode::Shape_chamfer`         | --                               | `shp_chamfer().add_chamfer(..., Chamfer_mode)`                               | --                                             | --                                     |
+| `Mode::Shape_polar_duplicate` | `shp_polar_dup().move_point`     | `shp_polar_dup().add_point`                                                  | --                                             | `shp_polar_dup().reset` on mode change |
+| Fuse / cut / common (toolbar) | --                               | `selected_fuse` / `selected_cut` / `selected_common` (one-shot)              | --                                             | --                                     |
+| Primitives (menu / script)    | --                               | `Occt_view::add_box`, `add_sphere`, ...                                      | --                                             | --                                     |
+| Revolve (sketch Options)      | --                               | `Occt_view::revolve_selected` -> `add_shp_`                                  | --                                             | --                                     |
+| Polar duplicate commit        | --                               | Options **Dup** button -> `shp_polar_dup().dup()`                            | --                                             | --                                     |
 
 On mode change, the view cancels in-progress move, rotate, scale, and sketch extrude sessions.
 
@@ -167,11 +167,11 @@ Full GLFW -> `GUI` routing before these delegates: [`src/doc/gui.md`](gui.md).
 
 ## Undo
 
-| Mechanism | When |
-| --- | --- |
-| `Occt_view::push_undo_snapshot()` | Before booleans, fillet/chamfer, primitive add, polar dup, transform finalize, extrude commit, revolve |
-| Transform preview only | No undo until **finalize** (not on each mouse move) |
-| `Sketch_op_delta` (sketch subsystem) | Separate from shape ops; shape list captured in view snapshots |
+| Mechanism                            | When                                                                                                   |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `Occt_view::push_undo_snapshot()`    | Before booleans, fillet/chamfer, primitive add, polar dup, transform finalize, extrude commit, revolve |
+| Transform preview only               | No undo until **finalize** (not on each mouse move)                                                    |
+| `Sketch_op_delta` (sketch subsystem) | Separate from shape ops; shape list captured in view snapshots                                         |
 
 ## Persistence
 
@@ -216,21 +216,21 @@ auto lines = shp_info::collect(shp->Shape(), &meta);
 
 ## Testing
 
-| Item | Notes |
-| --- | --- |
-| GTest suite | `tests/shp_tests.cpp` — filters `Shp_create.*`, `Shp_info.*`, `Shp_test.*` |
-| Coverage | `shp_create` volumes/bboxes; `shp_info::collect`; `Occt_view::add_*` / unique names; fuse/cut/common via AIS selection injection |
-| Fixture | `Shp_test` inherits `Sketch_test` (headless `Occt_view`) |
-| Related | Sketch-face extrude / revolve still live under `Sketch_test.*` |
-| Build target | `EzyCad_tests` ([`agents/workflows/local-dev.md`](../../agents/workflows/local-dev.md)) |
+| Item         | Notes                                                                                                                            |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| GTest suite  | `tests/shp_tests.cpp` — filters `Shp_create.*`, `Shp_info.*`, `Shp_test.*`                                                       |
+| Coverage     | `shp_create` volumes/bboxes; `shp_info::collect`; `Occt_view::add_*` / unique names; fuse/cut/common via AIS selection injection |
+| Fixture      | `Shp_test` inherits `Sketch_test` (headless `Occt_view`)                                                                         |
+| Related      | Sketch-face extrude / revolve still live under `Sketch_test.*`                                                                   |
+| Build target | `EzyCad_tests` ([`agents/workflows/local-dev.md`](../../agents/workflows/local-dev.md))                                          |
 
 ## Related code outside `src/shp_*`
 
-| Location | Role |
-| --- | --- |
-| `occt_view.h` / `gui_occt_view.cpp` | Shape list, `add_shp_`, primitives, I/O, operation member objects |
-| `sketch_ais.h` | `Sketch_face_shp` extrusion source |
-| `sketch_operations.cpp` | `Sketch::revolve_selected` -> `Shp_rslt` |
-| `mode.h` | `Fillet_mode`, `Chamfer_mode`, tool modes |
-| `gui.h` / `gui.cpp` | Toolbar, Shape List, fillet/chamfer mode, material UI |
-| `utl_geom.h` | Plane projection, bbox center, rotation helpers used by transforms and polar dup |
+| Location                            | Role                                                                             |
+| ----------------------------------- | -------------------------------------------------------------------------------- |
+| `occt_view.h` / `gui_occt_view.cpp` | Shape list, `add_shp_`, primitives, I/O, operation member objects                |
+| `sketch_ais.h`                      | `Sketch_face_shp` extrusion source                                               |
+| `sketch_operations.cpp`             | `Sketch::revolve_selected` -> `Shp_rslt`                                         |
+| `mode.h`                            | `Fillet_mode`, `Chamfer_mode`, tool modes                                        |
+| `gui.h` / `gui.cpp`                 | Toolbar, Shape List, fillet/chamfer mode, material UI                            |
+| `utl_geom.h`                        | Plane projection, bbox center, rotation helpers used by transforms and polar dup |

--- a/src/doc/sketch.md
+++ b/src/doc/sketch.md
@@ -35,10 +35,10 @@ Typical uses:
 
 ### Transient vs committed state
 
-| Layer | Owner | Cleared by |
-| --- | --- | --- |
-| **Committed** edges, faces, dimensions, permanent "+" markers | `Sketch_edges`, `Sketch_topo`, `Sketch_dims`, `Sketch_node_marks` | Explicit remove / undo delta |
-| **Transient** tmp edges, tmp nodes, rubber-band previews | `Sketch_tools` | `cancel_elm()` or `finalize_elm()` |
+| Layer                                                         | Owner                                                             | Cleared by                         |
+| ------------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------- |
+| **Committed** edges, faces, dimensions, permanent "+" markers | `Sketch_edges`, `Sketch_topo`, `Sketch_dims`, `Sketch_node_marks` | Explicit remove / undo delta       |
+| **Transient** tmp edges, tmp nodes, rubber-band previews      | `Sketch_tools`                                                    | `cancel_elm()` or `finalize_elm()` |
 
 Do not mix transient edges into the persistent list; tools finalize through `Sketch_edges` and `Sketch_topo`.
 
@@ -49,10 +49,10 @@ Do not mix transient edges into the persistent list; tools finalize through `Ske
 
 ### Global sketch options (static)
 
-| API | Effect |
-| --- | --- |
+| API                                  | Effect                                                                                                                                 |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `Sketch::set_add_mid_pt_edges(bool)` | When true, linear edge tools create midpoint snap nodes on new segments. Default off in the app; many unit tests enable it in `SetUp`. |
-| `Sketch::set_edge_from_center(bool)` | When true, rectangle/circle/slot tools place from center instead of corner. |
+| `Sketch::set_edge_from_center(bool)` | When true, rectangle/circle/slot tools place from center instead of corner.                                                            |
 
 Snap distance, guide mode, and guide colors live on `Sketch_nodes` (static setters).
 
@@ -95,16 +95,16 @@ The wire overload creates a sketch **from a planar face**; `m_originating_face` 
 
 The viewer and `GUI` forward pointer and keyboard events to the **current** sketch:
 
-| Event | `Occt_view` / `GUI` | `Sketch` method |
-| --- | --- | --- |
-| Mouse move (sketch tools) | `GUI::on_mouse_pos` | `sketch_pt_move` |
-| Left click (place point) | `GUI::on_left_click_` | `add_sketch_pt` |
-| Tab (length) | `Occt_view::dimension_input` | `dimension_input` |
-| Shift+Tab (angle) | `Occt_view::angle_input` | `angle_input` |
-| Enter (confirm numeric input) | `Occt_view::on_enter` | `on_enter` |
-| Esc (cancel in-progress tool) | `Occt_view::cancel` | `cancel_elm` |
-| Right click (finish line / multi-line) | `GUI::on_mouse_button` | `finalize_elm` |
-| Mode change | (via `GUI::set_mode`) | `on_mode` |
+| Event                                  | `Occt_view` / `GUI`          | `Sketch` method   |
+| -------------------------------------- | ---------------------------- | ----------------- |
+| Mouse move (sketch tools)              | `GUI::on_mouse_pos`          | `sketch_pt_move`  |
+| Left click (place point)               | `GUI::on_left_click_`        | `add_sketch_pt`   |
+| Tab (length)                           | `Occt_view::dimension_input` | `dimension_input` |
+| Shift+Tab (angle)                      | `Occt_view::angle_input`     | `angle_input`     |
+| Enter (confirm numeric input)          | `Occt_view::on_enter`        | `on_enter`        |
+| Esc (cancel in-progress tool)          | `Occt_view::cancel`          | `cancel_elm`      |
+| Right click (finish line / multi-line) | `GUI::on_mouse_button`       | `finalize_elm`    |
+| Mode change                            | (via `GUI::set_mode`)        | `on_mode`         |
 
 Face extrude mode (`Mode::Sketch_face_extrude`) routes mouse, Tab, and Enter through `Occt_view::sketch_face_extrude` / `Shp_extrude` instead of the sketch tool paths above.
 
@@ -114,32 +114,32 @@ Full GLFW -> `GUI` -> view routing: [`src/doc/gui.md`](gui.md).
 
 ### Visibility and display
 
-| Method | Purpose |
-| --- | --- |
-| `set_visible` / `is_visible` | Show or hide the whole sketch in the viewer |
-| `set_show_faces` / `set_show_edges` / `set_show_dims` | Layer toggles for faces, edges, dimensions |
-| `set_edge_style(Full \| Background \| Hidden)` | Current vs background sketch appearance |
-| `set_current()` | Make this sketch current in `Occt_view` |
-| `refresh_annotations(Sketch_annotation_refresh)` | Rebuild length dimensions and/or permanent node marks after settings changes |
-| `append_list_hover_ais(out)` | AIS objects to highlight when the Sketch List row is hovered |
+| Method                                                | Purpose                                                                      |          |                                         |
+| ---                                                   | ---                                                                          |          |                                         |
+| `set_visible` / `is_visible`                          | Show or hide the whole sketch in the viewer                                  |          |                                         |
+| `set_show_faces` / `set_show_edges` / `set_show_dims` | Layer toggles for faces, edges, dimensions                                   |          |                                         |
+| `set_edge_style(Full \                                | Background \                                                                 | Hidden)` | Current vs background sketch appearance |
+| `set_current()`                                       | Make this sketch current in `Occt_view`                                      |          |                                         |
+| `refresh_annotations(Sketch_annotation_refresh)`      | Rebuild length dimensions and/or permanent node marks after settings changes |          |                                         |
+| `append_list_hover_ais(out)`                          | AIS objects to highlight when the Sketch List row is hovered                 |          |                                         |
 
 ### Geometry queries and inspector
 
-| Method | Purpose |
-| --- | --- |
-| `has_edges`, `edge_count`, `face_count`, `length_dimension_count` | Counts for UI and mode selection after undo |
-| `inspector_*_labels()` | Human-readable labels for Sketch List / inspector panels |
-| `get_plane()`, `get_nodes()`, `underlay()` | Access plane, nodes, and image underlay |
+| Method                                                            | Purpose                                                  |
+| ----------------------------------------------------------------- | -------------------------------------------------------- |
+| `has_edges`, `edge_count`, `face_count`, `length_dimension_count` | Counts for UI and mode selection after undo              |
+| `inspector_*_labels()`                                            | Human-readable labels for Sketch List / inspector panels |
+| `get_plane()`, `get_nodes()`, `underlay()`                        | Access plane, nodes, and image underlay                  |
 
 ### Operations
 
-| Method | Purpose |
-| --- | --- |
-| `mirror_selected_edges()` | Mirror selected edges about `m_operation_axis` (requires axis + selection) |
-| `revolve_selected(angle)` | Revolve selected edges/faces into a 3D solid |
-| `clear_operation_axis` / `has_operation_axis` | Operation-axis lifecycle |
-| `remove_edge`, `remove_permanent_node_mark` | Delete committed geometry from selection |
-| `toggle_edge_dim_anno`, `try_remove_length_dimension` | Dimension tool and deletion |
+| Method                                                | Purpose                                                                    |
+| ----------------------------------------------------- | -------------------------------------------------------------------------- |
+| `mirror_selected_edges()`                             | Mirror selected edges about `m_operation_axis` (requires axis + selection) |
+| `revolve_selected(angle)`                             | Revolve selected edges/faces into a 3D solid                               |
+| `clear_operation_axis` / `has_operation_axis`         | Operation-axis lifecycle                                                   |
+| `remove_edge`, `remove_permanent_node_mark`           | Delete committed geometry from selection                                   |
+| `toggle_edge_dim_anno`, `try_remove_length_dimension` | Dimension tool and deletion                                                |
 
 ### Dimensions (delegated to `Sketch_dims`)
 
@@ -194,31 +194,31 @@ Prefer these visitors in JSON/delta/topo code over iterating `std::list<Sketch_e
 
 ## Module responsibilities (detail)
 
-| File | Responsibility |
-| --- | --- |
-| `sketch.h` / `sketch.cpp` | Coordinator: input routing, edge shape updates, snap aggregation, inspector labels, static options |
-| `sketch_edge.h` | `Sketch_edge` struct; `sketch_edge_is_linear` / `sketch_edge_is_arc`; `sketch_edge_outgoing_dir_2d` / `sketch_edge_incoming_dir_2d` |
-| `sketch_edges.h` | Persistent `std::list<Sketch_edge>`; add linear/arc edges; split at intersections; pick and selection |
-| `sketch_topo.h` | Planar face extraction from edge graph; automatic splitting at interior nodes and arc crossings |
-| `sketch_nodes.h` | Node storage, snap, snap guides, outside-sketch snap points |
-| `sketch_node_marks.h` | AIS "+" markers for permanent nodes only |
-| `sketch_dims.h` | Length dimensions between node pairs; Tab/Shift+Tab input; dimension-tool pick state |
-| `sketch_tools.h` | Mode-specific click/move/finalize/cancel for all sketch creation tools |
-| `sketch_underlay.h` | Calibrated raster underlay on the sketch plane |
-| `sketch_ais.h` | OCCT AIS wrappers tied back to owning `Sketch` |
-| `sketch_display.cpp` | Visibility, edge/face styling, `set_current`, list hover |
-| `sketch_operations.cpp` | Operation axis, mirror, revolve |
-| `sketch_json.h` | `.ezy` / project JSON for sketches |
-| `sketch_op_recorder.h` | Undo/redo recorder; `Sketch_op_delta` lives in `.cpp` |
+| File                      | Responsibility                                                                                                                      |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `sketch.h` / `sketch.cpp` | Coordinator: input routing, edge shape updates, snap aggregation, inspector labels, static options                                  |
+| `sketch_edge.h`           | `Sketch_edge` struct; `sketch_edge_is_linear` / `sketch_edge_is_arc`; `sketch_edge_outgoing_dir_2d` / `sketch_edge_incoming_dir_2d` |
+| `sketch_edges.h`          | Persistent `std::list<Sketch_edge>`; add linear/arc edges; split at intersections; pick and selection                               |
+| `sketch_topo.h`           | Planar face extraction from edge graph; automatic splitting at interior nodes and arc crossings                                     |
+| `sketch_nodes.h`          | Node storage, snap, snap guides, outside-sketch snap points                                                                         |
+| `sketch_node_marks.h`     | AIS "+" markers for permanent nodes only                                                                                            |
+| `sketch_dims.h`           | Length dimensions between node pairs; Tab/Shift+Tab input; dimension-tool pick state                                                |
+| `sketch_tools.h`          | Mode-specific click/move/finalize/cancel for all sketch creation tools                                                              |
+| `sketch_underlay.h`       | Calibrated raster underlay on the sketch plane                                                                                      |
+| `sketch_ais.h`            | OCCT AIS wrappers tied back to owning `Sketch`                                                                                      |
+| `sketch_display.cpp`      | Visibility, edge/face styling, `set_current`, list hover                                                                            |
+| `sketch_operations.cpp`   | Operation axis, mirror, revolve                                                                                                     |
+| `sketch_json.h`           | `.ezy` / project JSON for sketches                                                                                                  |
+| `sketch_op_recorder.h`    | Undo/redo recorder; `Sketch_op_delta` lives in `.cpp`                                                                               |
 
 ## Edge and face model
 
-| Entity | Storage | Notes |
-| --- | --- | --- |
-| **Linear edge** | `Sketch_edge` in `Sketch_edges` | `node_idx_a`, `node_idx_b`; optional `node_idx_mid` when add-midpoint is on |
-| **Arc edge** | same | Start, end, arc midpoint nodes; `node_idx_arc_pt` for curve snap |
-| **Face** | Derived in `Sketch_topo` | Rebuilt by `update_faces()` into `Sketch_face_shp`; drives extrude/revolve and face selection |
-| **Auto-split** | `Sketch_topo` / edge add | New edges crossing existing ones split at intersections (T-junctions, divided regions) |
+| Entity          | Storage                         | Notes                                                                                         |
+| --------------- | ------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Linear edge** | `Sketch_edge` in `Sketch_edges` | `node_idx_a`, `node_idx_b`; optional `node_idx_mid` when add-midpoint is on                   |
+| **Arc edge**    | same                            | Start, end, arc midpoint nodes; `node_idx_arc_pt` for curve snap                              |
+| **Face**        | Derived in `Sketch_topo`        | Rebuilt by `update_faces()` into `Sketch_face_shp`; drives extrude/revolve and face selection |
+| **Auto-split**  | `Sketch_topo` / edge add        | New edges crossing existing ones split at intersections (T-junctions, divided regions)        |
 
 ### Face extraction (`Sketch_topo::update_faces`)
 
@@ -234,17 +234,17 @@ See [`docs/usage-sketch.md`](../../docs/usage-sketch.md) for user-facing splitti
 
 ## Testing
 
-| Item | Location |
-| --- | --- |
-| GTest suite | `tests/sketch_*_tests.cpp` (+ `tests/sketch_test_fixture.*`), filter `Sketch_test.*` |
-| Build target | `EzyCad_tests` ([`agents/workflows/local-dev.md`](../../agents/workflows/local-dev.md)) |
-| Pattern | Construct `Occt_view`, create `Sketch` on a plane, drive via `add_sketch_pt` or test helpers |
+| Item         | Location                                                                                     |
+| ------------ | -------------------------------------------------------------------------------------------- |
+| GTest suite  | `tests/sketch_*_tests.cpp` (+ `tests/sketch_test_fixture.*`), filter `Sketch_test.*`         |
+| Build target | `EzyCad_tests` ([`agents/workflows/local-dev.md`](../../agents/workflows/local-dev.md))      |
+| Pattern      | Construct `Occt_view`, create `Sketch` on a plane, drive via `add_sketch_pt` or test helpers |
 
 ## Related code outside `src/sketch*`
 
-| Location | Role |
-| --- | --- |
+| Location                        | Role                                                            |
+| ------------------------------- | --------------------------------------------------------------- |
 | `occt_view.h` / `occt_view.cpp` | Sketch list, current sketch, input forwarding, sketch-from-face |
-| `mode.h` | `Mode` enum selects the active sketch tool |
-| `gui.cpp` | Toolbar and Sketch List UI wired to `Sketch` methods |
-| `shp.h` | `Shp_rslt` from `revolve_selected` |
+| `mode.h`                        | `Mode` enum selects the active sketch tool                      |
+| `gui.cpp`                       | Toolbar and Sketch List UI wired to `Sketch` methods            |
+| `shp.h`                         | `Shp_rslt` from `revolve_selected`                              |

--- a/src/doc/undo-redo.md
+++ b/src/doc/undo-redo.md
@@ -14,10 +14,10 @@ EzyCad keeps a bounded history of user edits so **Ctrl+Z** / **Ctrl+Y** (and Edi
 
 The implementation uses **two strategies** on one stack:
 
-| Strategy | When used | Stored payload |
-| --- | --- | --- |
-| **Element delta** | Sketch geometry edits | `std::unique_ptr<Delta>` (`Sketch_op_delta` in `sketch_op_recorder.cpp`) |
-| **Full JSON snapshot** | Everything else | `to_json()` string of the whole document |
+| Strategy               | When used             | Stored payload                                                           |
+| ---------------------- | --------------------- | ------------------------------------------------------------------------ |
+| **Element delta**      | Sketch geometry edits | `std::unique_ptr<Delta>` (`Sketch_op_delta` in `sketch_op_recorder.cpp`) |
+| **Full JSON snapshot** | Everything else       | `to_json()` string of the whole document                                 |
 
 Sketch deltas are cheaper and precise; JSON snapshots are simple and cover arbitrary document changes (shape booleans, sketch add/remove, file load, etc.).
 
@@ -33,11 +33,11 @@ Sketch deltas are cheaper and precise; JSON snapshots are simple and cover arbit
 
 Each stack frame stores:
 
-| Field | Role |
-| --- | --- |
+| Field   | Role                                                              |
+| ------- | ----------------------------------------------------------------- |
 | `delta` | Non-null for sketch element steps; mutually exclusive with `json` |
-| `json` | Full-document snapshot when `delta` is null |
-| `mode` | `Mode` active when the operation ran; restored on undo/redo |
+| `json`  | Full-document snapshot when `delta` is null                       |
+| `mode`  | `Mode` active when the operation ran; restored on undo/redo       |
 
 ### `m_restoring` guard
 
@@ -111,14 +111,14 @@ RAII scope around one sketch edit:
 
 Recorder notes (deduplicated by geometry):
 
-| Method | Meaning |
-| --- | --- |
-| `note_prev_linear_edge` | Edge removed or split away (must have existed at op start) |
-| `note_curr_linear_edge` | New linear segment added |
-| `note_prev_arc_edge` / `note_curr_arc_edge` | Arc circle segment removed / added |
-| `note_curr_node` | New node not live at op start (stores `permanent` for redo) |
-| `note_prev_length_dim` / `note_curr_length_dim` | Dimension removed / added |
-| `note_prev_operation_axis` / `note_curr_operation_axis` | Operation axis before / after |
+| Method                                                  | Meaning                                                     |
+| ------------------------------------------------------- | ----------------------------------------------------------- |
+| `note_prev_linear_edge`                                 | Edge removed or split away (must have existed at op start)  |
+| `note_curr_linear_edge`                                 | New linear segment added                                    |
+| `note_prev_arc_edge` / `note_curr_arc_edge`             | Arc circle segment removed / added                          |
+| `note_curr_node`                                        | New node not live at op start (stores `permanent` for redo) |
+| `note_prev_length_dim` / `note_curr_length_dim`         | Dimension removed / added                                   |
+| `note_prev_operation_axis` / `note_curr_operation_axis` | Operation axis before / after                               |
 
 `note_prev_linear_edge` only records edges that were present when the recorder opened (`linear_edge_at_op_start_`), so incidental splits of pre-existing geometry are not mistaken for undoable removals of the user's new work.
 
@@ -148,24 +148,24 @@ Geometry is matched by **2D coordinates** (`Precision::SquareConfusion()`), not 
 
 ### Sketch deltas (`Sketch_op_recorder` + `commit()`)
 
-| Area | Trigger |
-| --- | --- |
-| `Sketch_tools::finalize` | Line, multi-edge, rectangle, square, circle, slot, operation axis |
-| `Sketch_dims` | Add/remove length dimension; dimension tool finalize |
-| `Sketch_tools` / `Sketch_dims` | Add-node tool (split at interior node) |
-| `sketch_operations.cpp` | Mirror selected edges |
+| Area                           | Trigger                                                           |
+| ------------------------------ | ----------------------------------------------------------------- |
+| `Sketch_tools::finalize`       | Line, multi-edge, rectangle, square, circle, slot, operation axis |
+| `Sketch_dims`                  | Add/remove length dimension; dimension tool finalize              |
+| `Sketch_tools` / `Sketch_dims` | Add-node tool (split at interior node)                            |
+| `sketch_operations.cpp`        | Mirror selected edges                                             |
 | `Sketch_edges` / `Sketch_topo` | Splits during edge add (via recorder passed into add/split paths) |
 
 Interactive tools create the recorder internally. Direct `add_edge_(..., rec)` calls are for tests and delta replay.
 
 ### JSON snapshots (`push_undo_snapshot()`)
 
-| Area | Operation |
-| --- | --- |
+| Area        | Operation                                                                                                                                               |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Occt_view` | New file, add/remove sketch, sketch from face, sketch extrude finalize, revolve, delete shapes/sketches, primitives (box, sphere, ...), STEP/PLY import |
-| `shp_*` | Fuse, cut, common, fillet, chamfer, move, rotate, scale, polar duplicate, extrude finalize |
-| `GUI` | Open project, underlay import/remove/calibration/transform sliders, underlay orthogonalize |
-| `GUI` | Underlay panel edits push on `IsItemActivated` so one snapshot covers a drag |
+| `shp_*`     | Fuse, cut, common, fillet, chamfer, move, rotate, scale, polar duplicate, extrude finalize                                                              |
+| `GUI`       | Open project, underlay import/remove/calibration/transform sliders, underlay orthogonalize                                                              |
+| `GUI`       | Underlay panel edits push on `IsItemActivated` so one snapshot covers a drag                                                                            |
 
 ### `pop_undo_snapshot()` (abort without restoring)
 
@@ -177,12 +177,12 @@ Used when a snapshot was pushed optimistically but the operation failed or made 
 
 ## User interface
 
-| Input | Action |
-| --- | --- |
-| Ctrl+Z | Undo |
-| Ctrl+Shift+Z or Ctrl+Y | Redo |
-| Edit menu | Undo / Redo (disabled when stack empty) |
-| Settings pane | Shows stack sizes: `Undo: N | Redo: M [max 50]` |
+| Input                  | Action                                  |                   |
+| ---                    | ---                                     |                   |
+| Ctrl+Z                 | Undo                                    |                   |
+| Ctrl+Shift+Z or Ctrl+Y | Redo                                    |                   |
+| Edit menu              | Undo / Redo (disabled when stack empty) |                   |
+| Settings pane          | Shows stack sizes: `Undo: N             | Redo: M [max 50]` |
 
 Hotkeys are handled in `GUI::on_key` (`gui_mode.cpp`) when dist/angle edit popups are not active.
 

--- a/src/doc/utility.md
+++ b/src/doc/utility.md
@@ -18,20 +18,20 @@ Typical uses:
 
 ## Module map
 
-| File | Responsibility |
-| --- | --- |
-| [`utl.h`](../utl.h) / [`utl.cpp`](../utl.cpp) | `Status`, `Result<T>`, `CHK_RET`, `clear_all`, textures, image decode, name uniquification |
-| [`utl_types.h`](../utl_types.h) | OCCT/AIS handle typedefs, `ScreenCoords`, `Export_format`, `DECL_PTR`, `SafeType` |
-| [`utl_geom.h`](../utl_geom.h) / [`.cpp`](../utl_geom.cpp) | 2D/3D geometry, wires, dimensions, Boost polygon tests, plane projection |
-| [`utl_geom_boost.inl`](../utl_geom_boost.inl) | `ezy_geom` Boost.Geometry aliases |
-| [`utl_occt.h`](../utl_occt.h) / [`.cpp`](../utl_occt.cpp) | `TopAbs` name table, `try_make_solid` |
-| [`utl_json.h`](../utl_json.h) / [`.cpp`](../utl_json.cpp) | JSON serializers for `gp_Pnt`, `gp_Pln`, etc. |
-| [`utl_io.h`](../utl_io.h) / [`.cpp`](../utl_io.cpp) | `.ezy` zip v3 pack/unpack, format sniff, base64 |
-| [`utl_asset_store.h`](../utl_asset_store.h) / [`.cpp`](../utl_asset_store.cpp) | Content-addressed RGBA blobs for sketch underlay assets |
-| [`utl_settings.h`](../utl_settings.h) / [`.cpp`](../utl_settings.cpp) | User settings file paths, startup project blob I/O |
-| [`utl_ply_io.h`](../utl_ply_io.h) / [`.cpp`](../utl_ply_io.cpp) | PLY import/export for mesh shapes |
-| [`utl_log.h`](../utl_log.h) / [`.cpp`](../utl_log.cpp) | `Log_strm` redirecting stdout/stderr to `GUI::log_message` |
-| [`utl_dbg.h`](../utl_dbg.h) | `EZY_ASSERT`, `DBG_MSG`, debug break macros |
+| File                                                                           | Responsibility                                                                             |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| [`utl.h`](../utl.h) / [`utl.cpp`](../utl.cpp)                                  | `Status`, `Result<T>`, `CHK_RET`, `clear_all`, textures, image decode, name uniquification |
+| [`utl_types.h`](../utl_types.h)                                                | OCCT/AIS handle typedefs, `ScreenCoords`, `Export_format`, `DECL_PTR`, `SafeType`          |
+| [`utl_geom.h`](../utl_geom.h) / [`.cpp`](../utl_geom.cpp)                      | 2D/3D geometry, wires, dimensions, Boost polygon tests, plane projection                   |
+| [`utl_geom_boost.inl`](../utl_geom_boost.inl)                                  | `ezy_geom` Boost.Geometry aliases                                                          |
+| [`utl_occt.h`](../utl_occt.h) / [`.cpp`](../utl_occt.cpp)                      | `TopAbs` name table, `try_make_solid`                                                      |
+| [`utl_json.h`](../utl_json.h) / [`.cpp`](../utl_json.cpp)                      | JSON serializers for `gp_Pnt`, `gp_Pln`, etc.                                              |
+| [`utl_io.h`](../utl_io.h) / [`.cpp`](../utl_io.cpp)                            | `.ezy` zip v3 pack/unpack, format sniff, base64                                            |
+| [`utl_asset_store.h`](../utl_asset_store.h) / [`.cpp`](../utl_asset_store.cpp) | Content-addressed RGBA blobs for sketch underlay assets                                    |
+| [`utl_settings.h`](../utl_settings.h) / [`.cpp`](../utl_settings.cpp)          | User settings file paths, startup project blob I/O                                         |
+| [`utl_ply_io.h`](../utl_ply_io.h) / [`.cpp`](../utl_ply_io.cpp)                | PLY import/export for mesh shapes                                                          |
+| [`utl_log.h`](../utl_log.h) / [`.cpp`](../utl_log.cpp)                         | `Log_strm` redirecting stdout/stderr to `GUI::log_message`                                 |
+| [`utl_dbg.h`](../utl_dbg.h)                                                    | `EZY_ASSERT`, `DBG_MSG`, debug break macros                                                |
 
 CMake IDE group: `src\utl` (pattern `^utl(_|\.)`).
 
@@ -39,33 +39,33 @@ CMake IDE group: `src\utl` (pattern `^utl(_|\.)`).
 
 ### `Status` and `Result<T>`
 
-| Type | Use |
-| --- | --- |
-| `Status::ok()` / `user_error(msg)` | Void operations; user-facing message string |
-| `Result<T>` | Value or error (`Shp_rslt` = `Result<Shp_ptr>` in `shp.h`) |
-| `CHK_RET(expr)` | Early-return if sub-call returns non-ok `Status` |
+| Type                               | Use                                                        |
+| ---------------------------------- | ---------------------------------------------------------- |
+| `Status::ok()` / `user_error(msg)` | Void operations; user-facing message string                |
+| `Result<T>`                        | Value or error (`Shp_rslt` = `Result<Shp_ptr>` in `shp.h`) |
+| `CHK_RET(expr)`                    | Early-return if sub-call returns non-ok `Status`           |
 
 ### General helpers
 
-| API | Purpose |
-| --- | --- |
-| `clear_all(...)` | Reset optional/containers/arithmetic in one call |
-| `unique_sequential_name(base, existing)` | `Name`, `Name.001`, ... for sketches/shapes |
-| `load_texture(path)` | Toolbar icon loading |
-| `decode_image_bytes(bytes)` | stb_image -> RGBA for underlay import |
-| `safe_cstr_copy` | ImGui fixed-buffer copies (MSVC-safe) |
+| API                                      | Purpose                                          |
+| ---------------------------------------- | ------------------------------------------------ |
+| `clear_all(...)`                         | Reset optional/containers/arithmetic in one call |
+| `unique_sequential_name(base, existing)` | `Name`, `Name.001`, ... for sketches/shapes      |
+| `load_texture(path)`                     | Toolbar icon loading                             |
+| `decode_image_bytes(bytes)`              | stb_image -> RGBA for underlay import            |
+| `safe_cstr_copy`                         | ImGui fixed-buffer copies (MSVC-safe)            |
 
 ## Geometry (`utl_geom`)
 
 Large module; grouped by concern:
 
-| Area | Examples |
-| --- | --- |
-| Plane / 2D | `to_2d`, `to_3d`, `xy_plane`, `sketch_reference_plane`, `Plane_side` |
-| Profile wires | `make_square_wire`, `make_circle_wire`, `make_slot_wire`, `create_wire_box` |
-| Sketch dimensions | `Length_dimension_style`, `create_distance_annotation`, `apply_length_dimension_style` |
-| Analysis | `to_boost` (polygon), `to_boost_ls` (edge `linestring_2d`), `get_shape_bbox_center`, `plane_from_face`, `side_of_plane` |
-| Tests / debug | `to_wkt_string` (linestring / ring / polygon), `ezy_geom::area`, `is_valid`; Geometry Watch in `scripts/ezycad_graphical_debugging.xml` (`ring_2d` inherits vector as Ring; `linestring_2d` uses named `points` as Linestring). Re-select the XML path in Options after editing it. |
+| Area              | Examples                                                                                                                                                                                                                                                                            |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plane / 2D        | `to_2d`, `to_3d`, `xy_plane`, `sketch_reference_plane`, `Plane_side`                                                                                                                                                                                                                |
+| Profile wires     | `make_square_wire`, `make_circle_wire`, `make_slot_wire`, `create_wire_box`                                                                                                                                                                                                         |
+| Sketch dimensions | `Length_dimension_style`, `create_distance_annotation`, `apply_length_dimension_style`                                                                                                                                                                                              |
+| Analysis          | `to_boost` (polygon), `to_boost_ls` (edge `linestring_2d`), `get_shape_bbox_center`, `plane_from_face`, `side_of_plane`                                                                                                                                                             |
+| Tests / debug     | `to_wkt_string` (linestring / ring / polygon), `ezy_geom::area`, `is_valid`; Geometry Watch in `scripts/ezycad_graphical_debugging.xml` (`ring_2d` inherits vector as Ring; `linestring_2d` uses named `points` as Linestring). Re-select the XML path in Options after editing it. |
 
 Includes [`utl_geom_boost.inl`](../utl_geom_boost.inl) for `ezy_geom` polygon / linestring types used in tests and face validation.
 
@@ -73,39 +73,39 @@ Includes [`utl_geom_boost.inl`](../utl_geom_boost.inl) for `ezy_geom` polygon / 
 
 ### `.ezy` v3 zip layout
 
-| Path in archive | Content |
-| --- | --- |
-| `manifest.json` | Document JSON (sketches, shapes, view state) |
+| Path in archive    | Content                                           |
+| ------------------ | ------------------------------------------------- |
+| `manifest.json`    | Document JSON (sketches, shapes, view state)      |
 | `assets/<id>.rgba` | Raw RGBA pixels for underlay `"asset"` references |
 
-| Function | Role |
-| --- | --- |
-| `is_ezy_zip` / `is_ezy_json` | Sniff loaded bytes |
-| `unpack_ezy(bytes)` | -> manifest + asset map |
-| `pack_ezy(manifest, store)` | Build zip from manifest + store entries referenced by underlays |
-| `ezy_base64_encode` / `decode` | Emscripten startup project in localStorage |
+| Function                       | Role                                                            |
+| ------------------------------ | --------------------------------------------------------------- |
+| `is_ezy_zip` / `is_ezy_json`   | Sniff loaded bytes                                              |
+| `unpack_ezy(bytes)`            | -> manifest + asset map                                         |
+| `pack_ezy(manifest, store)`    | Build zip from manifest + store entries referenced by underlays |
+| `ezy_base64_encode` / `decode` | Emscripten startup project in localStorage                      |
 
 `Ezy_asset_store` deduplicates RGBA by FNV-1a id (`register_rgba`, `get`, `import_asset`). Owned on `Occt_view` for the session.
 
 ## Settings (`settings` namespace)
 
-| API | Role |
-| --- | --- |
-| `load_defaults()` | Ship defaults from `res/ezycad_settings.json` |
-| `load_with_defaults()` | User file or defaults + save |
-| `save(content)` | Native file or Wasm localStorage |
-| `user_config_directory()` | `%APPDATA%/EzyCad`, etc. |
-| `user_settings_json_path()` | Persisted GUI/OCCT settings |
-| `load/save/clear_user_startup_project()` | Optional startup `.ezy` blob |
+| API                                      | Role                                          |
+| ---------------------------------------- | --------------------------------------------- |
+| `load_defaults()`                        | Ship defaults from `res/ezycad_settings.json` |
+| `load_with_defaults()`                   | User file or defaults + save                  |
+| `save(content)`                          | Native file or Wasm localStorage              |
+| `user_config_directory()`                | `%APPDATA%/EzyCad`, etc.                      |
+| `user_settings_json_path()`              | Persisted GUI/OCCT settings                   |
+| `load/save/clear_user_startup_project()` | Optional startup `.ezy` blob                  |
 
 `GUI::load_occt_view_settings_` / `save_occt_view_settings` parse and emit JSON keys documented in [`docs/usage-settings.md`](../../docs/usage-settings.md).
 
 ## OCCT helpers (`utl_occt`)
 
-| API | Role |
-| --- | --- |
+| API                        | Role                                                     |
+| -------------------------- | -------------------------------------------------------- |
 | `c_names_TopAbs_ShapeEnum` | String names parallel to OCCT enum (selection filter UI) |
-| `try_make_solid(shape)` | Wrap closed shell as solid when possible |
+| `try_make_solid(shape)`    | Wrap closed shell as solid when possible                 |
 
 ## JSON geom (`utl_json`)
 
@@ -113,18 +113,18 @@ Symmetric `to_json` / `from_json_*` for `gp_Pnt2d`, `gp_Pnt`, `gp_Dir`, `gp_Pln`
 
 ## PLY (`utl_ply_io`)
 
-| API | Role |
-| --- | --- |
-| `import_ply_shape(bytes, out)` | ASCII or binary_little_endian PLY -> `TopoDS_Shape` |
-| `export_ply_binary_file(shape, path)` | Mesh export (mesh shape first) |
+| API                                   | Role                                                |
+| ------------------------------------- | --------------------------------------------------- |
+| `import_ply_shape(bytes, out)`        | ASCII or binary_little_endian PLY -> `TopoDS_Shape` |
+| `export_ply_binary_file(shape, path)` | Mesh export (mesh shape first)                      |
 
 ## Logging and debug
 
-| Component | Role |
-| --- | --- |
-| `Log_strm` | Installed on cout/cerr in `GUI::setup_log_redirection_` |
-| `EZY_ASSERT` / `EZY_ASSERT_MSG` | Debug-break assertions (`utl_dbg.h`) |
-| `DBG_MSG` | Verbose debug logging macro |
+| Component                       | Role                                                    |
+| ------------------------------- | ------------------------------------------------------- |
+| `Log_strm`                      | Installed on cout/cerr in `GUI::setup_log_redirection_` |
+| `EZY_ASSERT` / `EZY_ASSERT_MSG` | Debug-break assertions (`utl_dbg.h`)                    |
+| `DBG_MSG`                       | Verbose debug logging macro                             |
 
 ## Typical developer usage
 
@@ -155,27 +155,27 @@ gp_Pnt back = to_3d(sketch.get_plane(), uv);
 
 ## Dependencies and layering
 
-| Layer | May include |
-| --- | --- |
-| Low | `utl_dbg`, `utl_types` |
-| Mid | `utl`, `utl_json`, `utl_occt`, `utl_io`, `utl_asset_store`, `utl_settings` |
-| Heavy | `utl_geom` (OCCT + Boost + glm), `utl_ply_io` |
+| Layer | May include                                                                |
+| ----- | -------------------------------------------------------------------------- |
+| Low   | `utl_dbg`, `utl_types`                                                     |
+| Mid   | `utl`, `utl_json`, `utl_occt`, `utl_io`, `utl_asset_store`, `utl_settings` |
+| Heavy | `utl_geom` (OCCT + Boost + glm), `utl_ply_io`                              |
 
 Avoid circular includes: `utl_types.h` pulls sketch AIS typedefs via `sketch_ais.h`; geometry code should not include GUI headers.
 
 ## Testing
 
-| Item | Location |
-| --- | --- |
-| Geometry / polygon | `tests/sketch_topo_tests.cpp` (`ezy_geom::`, `to_wkt_string`) |
-| `.ezy` zip / underlay | `tests/sketch_json_tests.cpp` (`pack_ezy`, `is_ezy_zip`) |
-| Settings | Manual; paths vary by platform |
+| Item                  | Location                                                      |
+| --------------------- | ------------------------------------------------------------- |
+| Geometry / polygon    | `tests/sketch_topo_tests.cpp` (`ezy_geom::`, `to_wkt_string`) |
+| `.ezy` zip / underlay | `tests/sketch_json_tests.cpp` (`pack_ezy`, `is_ezy_zip`)      |
+| Settings              | Manual; paths vary by platform                                |
 
 ## Related code outside `src/utl*`
 
-| Location | Role |
-| --- | --- |
-| [`gui.cpp`](../gui.cpp) | `pack_ezy` / `unpack_ezy` for file open/save |
-| [`sketch_underlay.cpp`](../sketch_underlay.cpp) | `Ezy_asset_store` for underlay pixels |
-| [`sketch_json.cpp`](../sketch_json.cpp) | Manifest JSON + asset references |
-| [`gui_settings.cpp`](../gui_settings.cpp) | Parses `gui.*` / `occt_view.*` keys into members |
+| Location                                        | Role                                             |
+| ----------------------------------------------- | ------------------------------------------------ |
+| [`gui.cpp`](../gui.cpp)                         | `pack_ezy` / `unpack_ezy` for file open/save     |
+| [`sketch_underlay.cpp`](../sketch_underlay.cpp) | `Ezy_asset_store` for underlay pixels            |
+| [`sketch_json.cpp`](../sketch_json.cpp)         | Manifest JSON + asset references                 |
+| [`gui_settings.cpp`](../gui_settings.cpp)       | Parses `gui.*` / `occt_view.*` keys into members |


### PR DESCRIPTION
## Summary

- Align GFM pipe tables across repo Markdown (`docs/`, `src/doc/`, `agents/`, `README.md`) so columns read cleanly in editor/source view and still render in preview.
- Add preferred convention `agents/conventions/markdown-tables.md` (including wide-table / word-wrap guidance) and wire it into agent indexes and `docs/ezycad_doc_style.md`.
- Add `scripts/align_md_tables.py` (with `--check`) to re-align tables; listed in `agents/workflows/local-dev.md`.

Closes #192

## Test plan

- [x] `python scripts/align_md_tables.py --check`
- [x] Spot-check Markdown preview on a wide table (e.g. `src/doc/shape.md`, `docs/usage-settings.md`)
- [x] Confirm docs CI / `sphinx-build` if required by existing workflows
- [x] Squash-merge OK (branch has interim WIP commits)