### PR TITLE
Configurable sketch edge/face colors and Settings header persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Sketch appearance
 
-- **Settings -> Sketch -> Appearance:** configurable edge color, selection color, highlight (hover) color, and thickness (with alpha); face fill, selection, and highlight colors (with alpha). Persisted under `gui.sketch_edge_*` and `gui.sketch_face_*`.
+- **Settings -> Sketch -> Appearance:** configurable edge color, selection color, highlight (hover) color, and thickness (with alpha); face fill, selection, and highlight colors (with alpha). Persisted under `gui.sketch_edge_*` and `gui.sketch_face_*`. Bundled defaults match the current preferred palette (orange edge selection; mauve face fill; magenta/violet face selection/highlight).
 - **Settings pane:** Open/closed state of collapsing section headers is persisted in `gui.settings_headers`.
 
 ### UI layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Sketch appearance
+
+- **Settings -> Sketch -> Appearance:** configurable edge color, selection color, highlight (hover) color, and thickness (with alpha); face fill, selection, and highlight colors (with alpha). Persisted under `gui.sketch_edge_*` and `gui.sketch_face_*`.
+- **Settings pane:** Open/closed state of collapsing section headers is persisted in `gui.settings_headers`.
+
 ### UI layout
 
 - **ImGui docking:** Panels (Sketch List, Shape List, Options, Log, consoles, and similar) can be docked, tabbed, and split inside the main window. On desktop, panels can also be dragged into separate OS windows. The web build supports in-canvas docking only. Saved layout in settings includes dock nodes; older installs without a `[Docking]` section get a default layout on first launch.

--- a/agents/drafts/issues/active/gh-194-sketch-appearance-settings.md
+++ b/agents/drafts/issues/active/gh-194-sketch-appearance-settings.md
@@ -1,0 +1,54 @@
+---
+github_issue: 194
+github_pr: 195
+status: active
+paired_draft: ../prs/active/gh-195-sketch-appearance-settings.md
+---
+
+# Configurable sketch edge/face colors and Settings header persistence
+
+**Suggested labels:** `enhancement`, `ui`, `sketch`
+
+---
+
+## Title (GitHub)
+
+Configurable sketch edge/face colors and Settings header persistence
+
+## Body (GitHub)
+
+### Summary
+
+Make sketch edge and face appearance configurable (color, thickness, transparency), with separate colors for normal, selection, and mouse-over highlight. Persist Settings pane collapsing-header open/closed state.
+
+### Problem
+
+- Sketch edges and faces used hard-coded colors (green edges, GRAY7 faces, yellow OCCT highlight for both selection and hover).
+- Users could not tune sketch appearance or transparency from Settings.
+- Settings collapsing sections always reset to DefaultOpen / collapsed defaults on restart.
+
+### Implemented scope
+
+**Code changes:**
+
+- `src/gui.h` / `src/gui_settings.cpp` — appearance members, JSON keys, Appearance UI, `settings_headers` persistence.
+- `src/sketch_display.cpp` / `src/sketch.h` / `src/sketch.cpp` / `src/sketch_topo.cpp` — apply edge/face styles and selection vs hover drawers; `edge_face_style` refresh.
+
+**Documentation:**
+
+- `docs/usage-settings.md`, `docs/usage-sketch.md`, `CHANGELOG.md`, `src/doc/gui.md`, `src/doc/sketch.md`
+- `res/ezycad_settings.json` bundled defaults
+
+### Acceptance criteria
+
+- [ ] Settings -> Sketch -> Appearance exposes edge/face color controls with alpha.
+- [ ] Selection vs hover colors are distinct for edges and faces.
+- [ ] Settings collapsing headers persist across restarts.
+- [ ] Docs and CHANGELOG updated; Defaults restores bundled palette.
+- [ ] Native build succeeds.
+
+### Related
+
+- Issue: https://github.com/trailcode/EzyCad/issues/194
+- PR: https://github.com/trailcode/EzyCad/pull/195
+- Draft PR: `agents/drafts/prs/active/gh-195-sketch-appearance-settings.md`

--- a/agents/drafts/prs/active/gh-195-sketch-appearance-settings.md
+++ b/agents/drafts/prs/active/gh-195-sketch-appearance-settings.md
@@ -1,0 +1,37 @@
+---
+github_issue: 194
+github_pr: 195
+status: active
+paired_draft: ../issues/active/gh-194-sketch-appearance-settings.md
+---
+
+# PR - `Trailcode/sketch-colors`
+
+## Title
+
+Configurable sketch edge/face colors and Settings header persistence
+
+## Summary
+
+- **Sketch appearance:** Settings -> Sketch -> Appearance adds edge color/thickness, edge selection vs hover highlight colors, and face fill / selection fill / highlight fill (RGBA, alpha = opacity). Applied live via `Sketch_annotation_refresh::edge_face_style`.
+- **OCCT:** Separate `SetHilightAttributes` (selection) and `SetDynamicHilightAttributes` (hover); faces use shaded hilight so fill colors show.
+- **Settings UI:** Collapsing section open state persisted in `gui.settings_headers`.
+- **Defaults / docs:** Bundled palette and user/dev docs updated.
+
+## Files Changed
+
+`src/gui.h`, `src/gui_settings.cpp`, `src/sketch.h`, `src/sketch.cpp`, `src/sketch_display.cpp`, `src/sketch_topo.cpp`, `src/doc/gui.md`, `src/doc/sketch.md`, `docs/usage-settings.md`, `docs/usage-sketch.md`, `res/ezycad_settings.json`, `CHANGELOG.md`
+
+## Related
+
+- Issue: https://github.com/trailcode/EzyCad/issues/194
+- PR: https://github.com/trailcode/EzyCad/pull/195
+- Compare: https://github.com/trailcode/EzyCad/compare/main...Trailcode/sketch-colors
+
+## Test Plan
+
+- [ ] Build Release `EzyCad`.
+- [ ] Appearance colors update live; selection vs hover distinct for edges and faces.
+- [ ] Face selection/highlight tint fill (shaded), not wire-only.
+- [ ] Settings headers persist after restart; **Defaults** restores bundled palette.
+- [ ] Optional docs build for `usage-settings.md`.

--- a/docs/usage-settings.md
+++ b/docs/usage-settings.md
@@ -52,7 +52,7 @@ Between those, the pane has **six** collapsible sections. Expand a section to se
 5. **Sketch** — Expand **Appearance** (nested) for edge and face display colors. Expand **Dimensions** (nested) for length-dimension appearance and behavior (most rows have **?** help). Other sketch rows stay in the parent **Sketch** section:
    - **Edge color** / **Edge thickness** — current-sketch edge RGBA (alpha = opacity) and line width (**0.5** to **8.0**)
    - **Edge selection color** / **Edge highlight color** — selected edges vs mouse-over (dynamic) highlight (RGBA)
-   - **Face fill color** / **Face selection color** / **Face highlight color** — face fill, selected fill, and mouse-over highlight (RGBA)
+   - **Face fill color** / **Face selection fill** / **Face highlight fill** — normal fill, selected fill, and mouse-over fill (RGBA)
    - **Dimension line width** — slider **0.5** to **8.0**
    - **Dimension arrow size** — slider **1.0** to **24.0**
    - **Dimension color** — RGB for dimension lines, arrow heads, and value text
@@ -185,12 +185,12 @@ If saved layout text has no `[Docking]` section (older installs), a default dock
 | `permanent_node_anno_scale`   | number             | Scale for permanent **+** markers: the sketch **Origin** and user-placed Add node points ([Sketch origin](usage-sketch.md#sketch-origin); **0.25** to **3.0**; default **1.0**).                                              |
 | `origin_marker_color`         | array of 3 numbers | RGB color for the **active** sketch's Origin marker (+ with circle; **0** to **1** per channel; default cyan **0.0**, **0.75**, **1.0**).                                                                                     |
 | `sketch_edge_color`           | array of 4 numbers | Current-sketch edge RGBA (**0** to **1**; alpha = opacity; default green **0**, **1**, **0**, **1**).                                                                                                                       |
-| `sketch_edge_selection_color` | array of 4 numbers | Selected sketch-edge RGBA (default yellow **1**, **1**, **0**, **1**). Falls back to `sketch_edge_highlight_color` when absent.                                                                                               |
+| `sketch_edge_selection_color` | array of 4 numbers | Selected sketch-edge RGBA (default orange **1**, **0.545**, **0**, **1**). Falls back to `sketch_edge_highlight_color` when absent.                                                                                           |
 | `sketch_edge_highlight_color` | array of 4 numbers | Mouse-over (dynamic) highlight RGBA for sketch edges (default yellow **1**, **1**, **0**, **1**).                                                                                                                              |
 | `sketch_edge_line_width`      | number             | Current-sketch edge line width (**0.5** to **8.0**; default **1.0**).                                                                                                                                                         |
-| `sketch_face_color`           | array of 4 numbers | Current-sketch face fill RGBA (default dark gray **0.07**, **0.07**, **0.07**, **0.5**).                                                                                                                                      |
-| `sketch_face_selection_color` | array of 4 numbers | Selected sketch-face fill RGBA (default yellow **1**, **1**, **0**, **0.5**). Falls back to `sketch_face_highlight_color` when absent.                                                                                          |
-| `sketch_face_highlight_color` | array of 4 numbers | Mouse-over (dynamic) highlight RGBA for sketch faces (default yellow **1**, **1**, **0**, **0.5**).                                                                                                                             |
+| `sketch_face_color`           | array of 4 numbers | Current-sketch face fill RGBA (default mauve **0.301**, **0.245**, **0.321**, **0.297**).                                                                                                                                      |
+| `sketch_face_selection_color` | array of 4 numbers | Selected sketch-face **fill** RGBA (default magenta **0.799**, **0.187**, **0.591**, **1**). Falls back to `sketch_face_highlight_color` when absent.                                                                         |
+| `sketch_face_highlight_color` | array of 4 numbers | Mouse-over (dynamic) sketch-face **fill** RGBA (default violet **0.823**, **0**, **1**, **1**).                                                                                                                               |
 | `snap_guide_color_node`       | array of 3 numbers | RGB for snap guides when both axes lock to the same node (float **0** to **1**; default lavender **0.82**, **0.55**, **0.95**). Legacy `snap_guide_color` loads here when `snap_guide_color_node` is absent.                  |
 | `snap_guide_color_axis`       | array of 3 numbers | RGB for snap guides when aligned on X or Y only (float **0** to **1**; default magenta **0.96**, **0.06**, **0.54**). Legacy `snap_guide_color` sets both node and axis colors.                                               |
 | `snap_guide_mode`             | integer            | **0** *Traditional* (local markers), **1** *Fullscreen* (view-spanning axis lines), **2** *Both* (default **2**).                                                                                                             |
@@ -223,7 +223,7 @@ Each **`imgui_style_dark`** / **`imgui_style_light`** object may contain:
 | `frame_padding_x`, `frame_padding_y`   | number | Padding inside frames (**0** to **24**).                                                       |
 | `item_spacing_x`, `item_spacing_y`     | number | Spacing between widgets (**0** to **24**).                                                     |
 
-Each **`settings_headers`** object may contain (default **true** for sections that used to open by default):
+Each **`settings_headers`** object may contain (default: only nested Sketch **Appearance** / **Dimensions** expanded):
 
 | Key                 | Type    | Meaning                                      |
 | ------------------- | ------- | -------------------------------------------- |

--- a/docs/usage-settings.md
+++ b/docs/usage-settings.md
@@ -39,7 +39,7 @@ Open **View -> Settings**. The window title is **Settings**.
 - **UI verbosity** — stepper at the top (default **6**). Values **5** and **6** show contextual **?** help buttons (hover for tooltip, click to open Read the Docs where linked). Lower values hide those buttons and some explanatory text.
 - At the bottom: **Defaults** — reloads bundled defaults from the app `res/` tree (including ImGui layout from that file).
 
-Between those, the pane has **six** collapsible sections. Expand a section to see its controls; when collapsed, only the section title bar is visible.
+Between those, the pane has **six** collapsible sections. Expand a section to see its controls; when collapsed, only the section title bar is visible. Which sections are expanded is remembered in settings (`gui.settings_headers`).
 
 1. **3D view navigation** — **View rotation step** (degrees per key press for <kbd>NumPad 8</kbd>/<kbd>2</kbd>/<kbd>4</kbd>/<kbd>6</kbd> orbit and <kbd>Shift</kbd>+<kbd>NumPad 4</kbd>/<kbd>6</kbd> roll; default **45**; **`?`** opens [view roll](https://ezycad.readthedocs.io/en/latest/usage.html#view-roll) on Read the Docs). **Zoom scroll scale** (multiplier for wheel and **+**/**-** zoom; default **4**). Hold <kbd>Shift</kbd> while zooming for a Blender-style finer step (multiply by **0.1**). Numpad shortcuts are documented with <kbd>Num Lock</kbd> off; with <kbd>Num Lock</kbd> on, use main-row alternatives in [usage.md -> View navigation](usage.md#view-navigation). Stored as **`gui.view_roll_step_deg`** and **`gui.view_zoom_scroll_scale`**. See **[usage-occt-view.md](usage-occt-view.md)**.
 
@@ -49,7 +49,10 @@ Between those, the pane has **six** collapsible sections. Expand a section to se
 
 4. **3D view grid** — **Show grid** (checkbox; grid is drawn on the **active sketch** plane, behind coplanar geometry). **Fine grid lines** and **Major grid lines** (dense lines vs every-tenth emphasis). **Grid step**, **Grid padding** (margin around sketch content when sizing the grid), and **Grid display Z offset** in the Settings pane use the **same length scale as sketch length dimensions** (display value = model value / internal `dimension_scale`, default **100**). Saved JSON (`occt_view`) stores padding in model units (`grid_padding`).
 
-5. **Sketch** — Expand **Dimensions** (nested, open by default) for length-dimension appearance and behavior (most rows have **?** help). Other sketch rows stay in the parent **Sketch** section:
+5. **Sketch** — Expand **Appearance** (nested) for edge and face display colors. Expand **Dimensions** (nested) for length-dimension appearance and behavior (most rows have **?** help). Other sketch rows stay in the parent **Sketch** section:
+   - **Edge color** / **Edge thickness** — current-sketch edge RGBA (alpha = opacity) and line width (**0.5** to **8.0**)
+   - **Edge selection color** / **Edge highlight color** — selected edges vs mouse-over (dynamic) highlight (RGBA)
+   - **Face fill color** / **Face selection color** / **Face highlight color** — face fill, selected fill, and mouse-over highlight (RGBA)
    - **Dimension line width** — slider **0.5** to **8.0**
    - **Dimension arrow size** — slider **1.0** to **24.0**
    - **Dimension color** — RGB for dimension lines, arrow heads, and value text
@@ -181,6 +184,13 @@ If saved layout text has no `[Docking]` section (older installs), a default dock
 | `show_sketch_dimensions`      | boolean            | When false, hides length dimensions on all sketches.                                                                                                                                                                          |
 | `permanent_node_anno_scale`   | number             | Scale for permanent **+** markers: the sketch **Origin** and user-placed Add node points ([Sketch origin](usage-sketch.md#sketch-origin); **0.25** to **3.0**; default **1.0**).                                              |
 | `origin_marker_color`         | array of 3 numbers | RGB color for the **active** sketch's Origin marker (+ with circle; **0** to **1** per channel; default cyan **0.0**, **0.75**, **1.0**).                                                                                     |
+| `sketch_edge_color`           | array of 4 numbers | Current-sketch edge RGBA (**0** to **1**; alpha = opacity; default green **0**, **1**, **0**, **1**).                                                                                                                       |
+| `sketch_edge_selection_color` | array of 4 numbers | Selected sketch-edge RGBA (default yellow **1**, **1**, **0**, **1**). Falls back to `sketch_edge_highlight_color` when absent.                                                                                               |
+| `sketch_edge_highlight_color` | array of 4 numbers | Mouse-over (dynamic) highlight RGBA for sketch edges (default yellow **1**, **1**, **0**, **1**).                                                                                                                              |
+| `sketch_edge_line_width`      | number             | Current-sketch edge line width (**0.5** to **8.0**; default **1.0**).                                                                                                                                                         |
+| `sketch_face_color`           | array of 4 numbers | Current-sketch face fill RGBA (default dark gray **0.07**, **0.07**, **0.07**, **0.5**).                                                                                                                                      |
+| `sketch_face_selection_color` | array of 4 numbers | Selected sketch-face fill RGBA (default yellow **1**, **1**, **0**, **0.5**). Falls back to `sketch_face_highlight_color` when absent.                                                                                          |
+| `sketch_face_highlight_color` | array of 4 numbers | Mouse-over (dynamic) highlight RGBA for sketch faces (default yellow **1**, **1**, **0**, **0.5**).                                                                                                                             |
 | `snap_guide_color_node`       | array of 3 numbers | RGB for snap guides when both axes lock to the same node (float **0** to **1**; default lavender **0.82**, **0.55**, **0.95**). Legacy `snap_guide_color` loads here when `snap_guide_color_node` is absent.                  |
 | `snap_guide_color_axis`       | array of 3 numbers | RGB for snap guides when aligned on X or Y only (float **0** to **1**; default magenta **0.96**, **0.06**, **0.54**). Legacy `snap_guide_color` sets both node and axis colors.                                               |
 | `snap_guide_mode`             | integer            | **0** *Traditional* (local markers), **1** *Fullscreen* (view-spanning axis lines), **2** *Both* (default **2**).                                                                                                             |
@@ -188,6 +198,7 @@ If saved layout text has no `[Docking]` section (older installs), a default dock
 | `annotate_all_coaxial_nodes`  | boolean            | When true (default), show axis guides and markers for *all* co-axial nodes (current sketch plus other visible sketches). When false, only the closest node per active axis is annotated. Also in sketch **Options**.          |
 | `imgui_style_dark`            | object             | ImGui layout for **dark mode** (see keys below).                                                                                                                                                                              |
 | `imgui_style_light`           | object             | ImGui layout for **light mode** (same keys).                                                                                                                                                                                  |
+| `settings_headers`            | object             | Which Settings pane collapsing sections are expanded (booleans; see keys below).                                                                                                                                              |
 | `imgui_rounding_general`      | number             | **Legacy:** copied into both theme objects on load when `imgui_style_*` is absent.                                                                                                                                            |
 | `imgui_rounding_scroll`       | number             | **Legacy:** same.                                                                                                                                                                                                             |
 | `imgui_rounding_tabs`         | number             | **Legacy:** same.                                                                                                                                                                                                             |
@@ -209,8 +220,21 @@ Each **`imgui_style_dark`** / **`imgui_style_light`** object may contain:
 | `window_border`                        | number | Window border thickness (**0** to **2**).                                                      |
 | `frame_border`                         | number | Widget frame border thickness (**0** to **2**).                                                |
 | `window_padding_x`, `window_padding_y` | number | Inner padding of windows (**0** to **24**).                                                    |
-| `frame_padding_x`, `frame_padding_y`   | number | Padding inside framed widgets (**0** to **24**).                                               |
+| `frame_padding_x`, `frame_padding_y`   | number | Padding inside frames (**0** to **24**).                                                       |
 | `item_spacing_x`, `item_spacing_y`     | number | Spacing between widgets (**0** to **24**).                                                     |
+
+Each **`settings_headers`** object may contain (default **true** for sections that used to open by default):
+
+| Key                 | Type    | Meaning                                      |
+| ------------------- | ------- | -------------------------------------------- |
+| `view_nav`          | boolean | **3D view navigation** section expanded.     |
+| `ui`                | boolean | **UI** section expanded.                     |
+| `view_presentation` | boolean | **View presentation** section expanded.      |
+| `grid`              | boolean | **3D view grid** section expanded.           |
+| `sketch`            | boolean | **Sketch** section expanded.                 |
+| `sketch_appearance` | boolean | Nested **Appearance** under Sketch.          |
+| `sketch_dimensions` | boolean | Nested **Dimensions** under Sketch.          |
+| `startup`           | boolean | **Startup project** section expanded.        |
 
 Scripting API **`ezy.occt_view_settings_json()`** returns a JSON string with **`occt_view`** plus selected **`gui`** keys (including dimension and snap keys above, **`gui.permanent_node_anno_scale`**, **`gui.inspection_orthographic`**, **`gui.view_roll_step_deg`**, **`gui.view_zoom_scroll_scale`** when saved). See [scripting.md](scripting.md).
 

--- a/docs/usage-sketch.md
+++ b/docs/usage-sketch.md
@@ -38,7 +38,7 @@ This guide covers all 2D sketching tools and operations in EzyCad. For the main 
    - ![Operation Axis Tool](res/icons/Sketcher_MirrorSketch.png) [Operational axis](#operation-axis-tool) - Define a reference axis, then use the **Mirror** and **Revolve** controls (in the Options panel) to mirror selected sketch edges or revolve edges/faces into 3D solids.
    - ![Create Sketch from Planar Face Tool](res/icons/Macro_FaceToSketch_48.png) [Create sketch from planar face](#create-sketch-from-planar-face-tool)
 
-See [Sketch origin](#sketch-origin) — every sketch includes one permanent reference point.
+See [Sketch origin](#sketch-origin) — every sketch includes one permanent reference point. Edge and face colors (including selection highlight and transparency) are in **Settings -> Sketch -> Appearance** (see [usage-settings.md](usage-settings.md#settings-pane)).
 
 (sketch-origin)=
 ## Sketch origin

--- a/res/ezycad_settings.json
+++ b/res/ezycad_settings.json
@@ -51,6 +51,16 @@
       "window_padding_x": 10.0,
       "window_padding_y": 10.0
     },
+    "settings_headers": {
+      "view_nav": true,
+      "ui": true,
+      "view_presentation": false,
+      "grid": false,
+      "sketch": false,
+      "sketch_appearance": true,
+      "sketch_dimensions": true,
+      "startup": false
+    },
     "inspection_orthographic": false,
     "last_opened_project_path": "",
     "load_last_opened_on_startup": false,
@@ -59,6 +69,43 @@
       0.0,
       0.75,
       1.0
+    ],
+    "sketch_edge_color": [
+      0.0,
+      1.0,
+      0.0,
+      1.0
+    ],
+    "sketch_edge_selection_color": [
+      1.0,
+      1.0,
+      0.0,
+      1.0
+    ],
+    "sketch_edge_highlight_color": [
+      1.0,
+      1.0,
+      0.0,
+      1.0
+    ],
+    "sketch_edge_line_width": 1.0,
+    "sketch_face_color": [
+      0.07,
+      0.07,
+      0.07,
+      0.5
+    ],
+    "sketch_face_selection_color": [
+      1.0,
+      1.0,
+      0.0,
+      0.5
+    ],
+    "sketch_face_highlight_color": [
+      1.0,
+      1.0,
+      0.0,
+      0.5
     ],
     "permanent_node_anno_scale": 0.30000001192092896,
     "show_dbg": false,

--- a/res/ezycad_settings.json
+++ b/res/ezycad_settings.json
@@ -31,8 +31,8 @@
       "item_spacing_y": 5.0,
       "rounding_general": 8.0,
       "rounding_scroll": 12.0,
-      "rounding_tabs": 6.0,
-      "window_alpha": 0.8199999928474426,
+      "rounding_tabs": 3.0,
+      "window_alpha": 0.8299999833106995,
       "window_border": 1.0,
       "window_padding_x": 10.0,
       "window_padding_y": 10.0
@@ -51,16 +51,6 @@
       "window_padding_x": 10.0,
       "window_padding_y": 10.0
     },
-    "settings_headers": {
-      "view_nav": true,
-      "ui": true,
-      "view_presentation": false,
-      "grid": false,
-      "sketch": false,
-      "sketch_appearance": true,
-      "sketch_dimensions": true,
-      "startup": false
-    },
     "inspection_orthographic": false,
     "last_opened_project_path": "",
     "load_last_opened_on_startup": false,
@@ -70,14 +60,27 @@
       0.75,
       1.0
     ],
+    "permanent_node_anno_scale": 0.30000001192092896,
+    "settings_headers": {
+      "grid": false,
+      "sketch": false,
+      "sketch_appearance": true,
+      "sketch_dimensions": true,
+      "startup": false,
+      "ui": false,
+      "view_nav": false,
+      "view_presentation": false
+    },
+    "show_dbg": false,
+    "show_lua_console": true,
+    "show_options": true,
+    "show_python_console": true,
+    "show_settings_dialog": false,
+    "show_shape_list": true,
+    "show_sketch_dimensions": true,
+    "show_sketch_list": true,
     "sketch_edge_color": [
       0.0,
-      1.0,
-      0.0,
-      1.0
-    ],
-    "sketch_edge_selection_color": [
-      1.0,
       1.0,
       0.0,
       1.0
@@ -89,33 +92,30 @@
       1.0
     ],
     "sketch_edge_line_width": 1.0,
-    "sketch_face_color": [
-      0.07,
-      0.07,
-      0.07,
-      0.5
-    ],
-    "sketch_face_selection_color": [
+    "sketch_edge_selection_color": [
       1.0,
-      1.0,
+      0.5454545617103577,
       0.0,
-      0.5
+      1.0
+    ],
+    "sketch_face_color": [
+      0.30079561471939087,
+      0.24541562795639038,
+      0.32057416439056396,
+      0.2966507077217102
     ],
     "sketch_face_highlight_color": [
-      1.0,
-      1.0,
+      0.8229665756225586,
       0.0,
-      0.5
+      1.0,
+      1.0
     ],
-    "permanent_node_anno_scale": 0.30000001192092896,
-    "show_dbg": false,
-    "show_lua_console": true,
-    "show_options": true,
-    "show_python_console": true,
-    "show_settings_dialog": false,
-    "show_shape_list": true,
-    "show_sketch_dimensions": true,
-    "show_sketch_list": true,
+    "sketch_face_selection_color": [
+      0.7990430593490601,
+      0.18733544647693634,
+      0.5912379622459412,
+      1.0
+    ],
     "snap_guide_color_axis": [
       0.9576271176338196,
       0.06492385268211365,
@@ -138,7 +138,7 @@
     "view_roll_step_deg": 45.0,
     "view_zoom_scroll_scale": 4.0
   },
-  "imgui_ini": "[Window][##MainMenuBar]\nPos=0,0\nSize=1920,22\nCollapsed=0\n\n[Window][Toolbar]\nPos=252,21\nSize=1190,58\nCollapsed=0\n\n[Window][Sketch List]\nPos=0,22\nSize=252,443\nCollapsed=0\nDockId=0x00000005,0\n\n[Window][Shape List]\nPos=0,467\nSize=252,551\nCollapsed=0\nDockId=0x00000006,0\n\n[Window][Options]\nPos=1443,34\nSize=345,431\nCollapsed=0\n\n[Window][Lua Console]\nPos=0,1020\nSize=1920,101\nCollapsed=0\nDockId=0x0000000E,0\n\n[Window][Python Console]\nPos=0,1020\nSize=1920,101\nCollapsed=0\nDockId=0x0000000E,1\n\n[Window][Log]\nPos=0,1020\nSize=1920,101\nCollapsed=0\nDockId=0x0000000E,2\n\n[Window][Settings]\nPos=603,99\nSize=603,701\nCollapsed=0\n\n[Window][Debug##Default]\nPos=60,60\nSize=400,400\nCollapsed=0\n\n[Window][dbg]\nPos=344,110\nSize=320,200\nCollapsed=0\n\n[Window][Sketch properties]\nPos=1060,381\nSize=701,477\nCollapsed=0\n\n[Window][About]\nPos=700,300\nSize=520,520\nCollapsed=0\n\n[Window][New sketch]\nPos=801,473\nSize=317,175\nCollapsed=0\n\n[Window][WindowOverViewport_11111111]\nPos=0,22\nSize=1920,1099\nCollapsed=0\n\n[Docking][Data]\nDockSpace       ID=0xD79204D4 Window=0x1BBC0F80 Pos=0,51 Size=1920,1099 Split=Y\n  DockNode      ID=0x0000000D Parent=0xD79204D4 SizeRef=1920,996 Split=X\n    DockNode    ID=0x00000007 Parent=0x0000000D SizeRef=252,1099 Split=Y Selected=0xCA8EA105\n      DockNode  ID=0x00000005 Parent=0x00000007 SizeRef=167,443 Selected=0xCA8EA105\n      DockNode  ID=0x00000006 Parent=0x00000007 SizeRef=167,551 Selected=0x3BE507E9\n    DockNode    ID=0x00000008 Parent=0x0000000D SizeRef=1666,1099 Split=X\n      DockNode  ID=0x00000001 Parent=0x00000008 SizeRef=168,1121\n      DockNode  ID=0x00000002 Parent=0x00000008 SizeRef=1750,1121 CentralNode=1 Selected=0x0C01D6D5\n  DockNode      ID=0x0000000E Parent=0xD79204D4 SizeRef=1920,101 Selected=0x139FDA3F\n\n",
+  "imgui_ini": "[Window][##MainMenuBar]\nSize=1920,22\nCollapsed=0\n\n[Window][Toolbar]\nPos=252,21\nSize=1190,58\nCollapsed=0\n\n[Window][Sketch List]\nPos=0,22\nSize=252,443\nCollapsed=0\nDockId=0x00000005,0\n\n[Window][Shape List]\nPos=0,467\nSize=252,551\nCollapsed=0\nDockId=0x00000006,0\n\n[Window][Options]\nPos=1443,34\nSize=345,224\nCollapsed=0\n\n[Window][Lua Console]\nPos=0,1020\nSize=1920,101\nCollapsed=0\nDockId=0x0000000E,0\n\n[Window][Python Console]\nPos=0,1020\nSize=1920,101\nCollapsed=0\nDockId=0x0000000E,1\n\n[Window][Log]\nPos=0,1020\nSize=1920,101\nCollapsed=0\nDockId=0x0000000E,2\n\n[Window][Settings]\nPos=603,99\nSize=603,701\nCollapsed=0\n\n[Window][Debug##Default]\nPos=60,60\nSize=400,400\nCollapsed=0\n\n[Window][dbg]\nPos=344,110\nSize=320,200\nCollapsed=0\n\n[Window][Sketch properties]\nPos=1060,381\nSize=701,477\nCollapsed=0\n\n[Window][About]\nPos=700,300\nSize=520,520\nCollapsed=0\n\n[Window][New sketch]\nPos=801,473\nSize=317,175\nCollapsed=0\n\n[Window][WindowOverViewport_11111111]\nPos=0,22\nSize=1920,1099\nCollapsed=0\n\n[Docking][Data]\nDockSpace       ID=0xD79204D4 Window=0x1BBC0F80 Pos=0,51 Size=1920,1099 Split=Y\n  DockNode      ID=0x0000000D Parent=0xD79204D4 SizeRef=1920,996 Split=X\n    DockNode    ID=0x00000007 Parent=0x0000000D SizeRef=252,1099 Split=Y Selected=0xCA8EA105\n      DockNode  ID=0x00000005 Parent=0x00000007 SizeRef=167,443 Selected=0xCA8EA105\n      DockNode  ID=0x00000006 Parent=0x00000007 SizeRef=167,551 Selected=0x3BE507E9\n    DockNode    ID=0x00000008 Parent=0x0000000D SizeRef=1666,1099 Split=X\n      DockNode  ID=0x00000001 Parent=0x00000008 SizeRef=168,1121\n      DockNode  ID=0x00000002 Parent=0x00000008 SizeRef=1750,1121 CentralNode=1 Selected=0x0C01D6D5\n  DockNode      ID=0x0000000E Parent=0xD79204D4 SizeRef=1920,101 Selected=0xB5DBBD78\n\n",
   "occt_view": {
     "bg_color1": [
       0.037551622837781906,
@@ -154,7 +154,7 @@
     "grid_color1": [
       0.11268295347690582,
       0.056886445730924606,
-      0.13899612426757813
+      0.13899612426757812
     ],
     "grid_color2": [
       0.11791712045669556,

--- a/src/doc/gui.md
+++ b/src/doc/gui.md
@@ -214,6 +214,8 @@ Shared sketch controls (snap, midpoint nodes, place-from-center) live in `option
 | `load_occt_view_settings_`  | Called from `GUI::init`                                             |
 | `occt_view_settings_json()` | Scripting API for settings blob                                     |
 
+Sketch edge/face display colors live under `gui.sketch_edge_*` / `gui.sketch_face_*` and are applied live via `Sketch_annotation_refresh::edge_face_style`. Settings collapsing-header open state is stored in `gui.settings_headers`.
+
 User-visible key tables: [`docs/usage-settings.md`](../../docs/usage-settings.md). When adding a Settings control, follow [agents/conventions/user-docs-sync.md](../../agents/conventions/user-docs-sync.md).
 
 ## Toolbar and one-shot commands

--- a/src/doc/sketch.md
+++ b/src/doc/sketch.md
@@ -114,14 +114,14 @@ Full GLFW -> `GUI` -> view routing: [`src/doc/gui.md`](gui.md).
 
 ### Visibility and display
 
-| Method                                                | Purpose                                                                      |          |                                         |
-| ---                                                   | ---                                                                          |          |                                         |
-| `set_visible` / `is_visible`                          | Show or hide the whole sketch in the viewer                                  |          |                                         |
-| `set_show_faces` / `set_show_edges` / `set_show_dims` | Layer toggles for faces, edges, dimensions                                   |          |                                         |
-| `set_edge_style(Full \                                | Background \                                                                 | Hidden)` | Current vs background sketch appearance |
-| `set_current()`                                       | Make this sketch current in `Occt_view`                                      |          |                                         |
-| `refresh_annotations(Sketch_annotation_refresh)`      | Rebuild length dimensions and/or permanent node marks after settings changes |          |                                         |
-| `append_list_hover_ais(out)`                          | AIS objects to highlight when the Sketch List row is hovered                 |          |                                         |
+| Method                                                | Purpose                                                                             |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `set_visible` / `is_visible`                          | Show or hide the whole sketch in the viewer                                         |
+| `set_show_faces` / `set_show_edges` / `set_show_dims` | Layer toggles for faces, edges, dimensions                                          |
+| `set_edge_style(Full / Background / Hidden)`          | Current vs background appearance (edge/face colors from Settings -> Sketch)         |
+| `set_current()`                                       | Make this sketch current in `Occt_view`                                             |
+| `refresh_annotations(Sketch_annotation_refresh)`      | Rebuild dims, node marks, and/or edge-face styles after settings changes            |
+| `append_list_hover_ais(out)`                          | AIS objects to highlight when the Sketch List row is hovered                        |
 
 ### Geometry queries and inspector
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -86,6 +86,21 @@ inline constexpr float k_gui_permanent_node_anno_scale_max     = 3.0f;
 inline constexpr float k_gui_permanent_node_anno_scale_default = 1.0f;
 
 inline constexpr float k_gui_origin_marker_color_default[3] = {0.0f, 0.75f, 1.0f};
+/// Current-sketch edge RGBA (`gui.sketch_edge_color`); alpha maps to OCCT opacity (1 - transparency).
+inline constexpr float k_gui_sketch_edge_color_default[4] = {0.0f, 1.0f, 0.0f, 1.0f};
+/// Selected sketch-edge RGBA (`gui.sketch_edge_selection_color`).
+inline constexpr float k_gui_sketch_edge_selection_color_default[4] = {1.0f, 1.0f, 0.0f, 1.0f};
+/// Dynamic (hover) highlight RGBA for sketch edges (`gui.sketch_edge_highlight_color`).
+inline constexpr float k_gui_sketch_edge_highlight_color_default[4] = {1.0f, 1.0f, 0.0f, 1.0f};
+inline constexpr float k_gui_sketch_edge_line_width_default         = 1.0f;
+inline constexpr float k_gui_sketch_edge_line_width_min             = 0.5f;
+inline constexpr float k_gui_sketch_edge_line_width_max             = 8.0f;
+/// Current-sketch face fill RGBA (`gui.sketch_face_color`); matches former Quantity_NOC_GRAY7 @ 50%.
+inline constexpr float k_gui_sketch_face_color_default[4] = {0.07f, 0.07f, 0.07f, 0.5f};
+/// Selected sketch-face fill RGBA (`gui.sketch_face_selection_color`).
+inline constexpr float k_gui_sketch_face_selection_color_default[4] = {1.0f, 1.0f, 0.0f, 0.5f};
+/// Dynamic (hover) highlight RGBA for sketch faces (`gui.sketch_face_highlight_color`).
+inline constexpr float k_gui_sketch_face_highlight_color_default[4] = {1.0f, 1.0f, 0.0f, 0.5f};
 /// Allowed range and default for `gui.view_roll_step_deg` (view roll and numpad orbit steps; must match Settings slider).
 inline constexpr double k_gui_view_roll_step_deg_min     = 0.1;
 inline constexpr double k_gui_view_roll_step_deg_max     = 180.0;
@@ -109,7 +124,7 @@ inline constexpr float k_gui_imgui_border_slider_max   = 2.f;
 inline constexpr float k_gui_imgui_padding_slider_max  = 24.f;
 inline constexpr float k_gui_imgui_spacing_slider_max  = 24.f;
 
-/// Per-theme ImGui layout values (Settings -> UI; persisted under gui.imgui_style_dark / gui.imgui_style_light).
+/// ImGui layout for **dark mode** / **light mode** (Settings -> UI; persisted under gui.imgui_style_dark / gui.imgui_style_light).
 /// The Settings pane edits whichever theme matches the current Dark mode checkbox.
 struct Gui_imgui_style_settings
 {
@@ -125,6 +140,20 @@ struct Gui_imgui_style_settings
   float frame_padding_y{3.f};
   float item_spacing_x{8.f};
   float item_spacing_y{4.f};
+};
+
+/// Open/closed state for Settings pane collapsing headers (`gui.settings_headers`).
+/// Defaults match the former ImGuiTreeNodeFlags_DefaultOpen choices.
+struct Gui_settings_headers
+{
+  bool view_nav{true};
+  bool ui{true};
+  bool view_presentation{false};
+  bool grid{false};
+  bool sketch{false};
+  bool sketch_appearance{true};
+  bool sketch_dimensions{true};
+  bool startup{false};
 };
 
 namespace doc_urls
@@ -199,6 +228,19 @@ public:
   float permanent_node_anno_scale() const { return m_permanent_node_anno_scale; }
   /// RGB color for the active sketch's origin marker (0-1 per channel).
   const float* origin_marker_color_rgb() const { return m_origin_marker_color; }
+  /// Current-sketch edge RGBA (0-1; alpha = opacity).
+  const float* sketch_edge_color_rgba() const { return m_sketch_edge_color; }
+  /// Sketch-edge selected-state RGBA (0-1; alpha = opacity).
+  const float* sketch_edge_selection_color_rgba() const { return m_sketch_edge_selection_color; }
+  /// Sketch-edge dynamic (hover) highlight RGBA (0-1; alpha = opacity).
+  const float* sketch_edge_highlight_color_rgba() const { return m_sketch_edge_highlight_color; }
+  float        sketch_edge_line_width() const { return m_sketch_edge_line_width; }
+  /// Current-sketch face fill RGBA (0-1; alpha = opacity).
+  const float* sketch_face_color_rgba() const { return m_sketch_face_color; }
+  /// Sketch-face selected-state RGBA (0-1; alpha = opacity).
+  const float* sketch_face_selection_color_rgba() const { return m_sketch_face_selection_color; }
+  /// Sketch-face dynamic (hover) highlight RGBA (0-1; alpha = opacity).
+  const float* sketch_face_highlight_color_rgba() const { return m_sketch_face_highlight_color; }
   bool         get_add_mid_pt_line_edges() const { return m_add_mid_pt_line_edges; }
   bool         get_add_mid_pt_rect_edges() const { return m_add_mid_pt_rect_edges; }
   bool         get_add_mid_pt_slot_edges() const { return m_add_mid_pt_slot_edges; }
@@ -432,6 +474,8 @@ private:
   void imgui_style_defaults_from_theme_(bool dark, Gui_imgui_style_settings& out) const;
   [[nodiscard]] const Gui_imgui_style_settings& imgui_style_active_() const;
   Gui_imgui_style_settings&                     imgui_style_active_();
+  /// CollapsingHeader that keeps `open_state` and saves settings when the user toggles it.
+  bool settings_collapsing_header_(const char* label, bool& open_state);
 
   Occt_view::uptr m_view;
   GLFWwindow*     m_glfw_window{nullptr};
@@ -472,6 +516,23 @@ private:
   float        m_permanent_node_anno_scale  = k_gui_permanent_node_anno_scale_default;
   float        m_origin_marker_color[3]     = {k_gui_origin_marker_color_default[0], k_gui_origin_marker_color_default[1],
                                                k_gui_origin_marker_color_default[2]};
+  float        m_sketch_edge_color[4] = {k_gui_sketch_edge_color_default[0], k_gui_sketch_edge_color_default[1],
+                                         k_gui_sketch_edge_color_default[2], k_gui_sketch_edge_color_default[3]};
+  float        m_sketch_edge_selection_color[4] = {
+      k_gui_sketch_edge_selection_color_default[0], k_gui_sketch_edge_selection_color_default[1],
+      k_gui_sketch_edge_selection_color_default[2], k_gui_sketch_edge_selection_color_default[3]};
+  float m_sketch_edge_highlight_color[4] = {
+      k_gui_sketch_edge_highlight_color_default[0], k_gui_sketch_edge_highlight_color_default[1],
+      k_gui_sketch_edge_highlight_color_default[2], k_gui_sketch_edge_highlight_color_default[3]};
+  float m_sketch_edge_line_width = k_gui_sketch_edge_line_width_default;
+  float m_sketch_face_color[4]   = {k_gui_sketch_face_color_default[0], k_gui_sketch_face_color_default[1],
+                                    k_gui_sketch_face_color_default[2], k_gui_sketch_face_color_default[3]};
+  float m_sketch_face_selection_color[4] = {
+      k_gui_sketch_face_selection_color_default[0], k_gui_sketch_face_selection_color_default[1],
+      k_gui_sketch_face_selection_color_default[2], k_gui_sketch_face_selection_color_default[3]};
+  float m_sketch_face_highlight_color[4] = {
+      k_gui_sketch_face_highlight_color_default[0], k_gui_sketch_face_highlight_color_default[1],
+      k_gui_sketch_face_highlight_color_default[2], k_gui_sketch_face_highlight_color_default[3]};
   bool         m_add_mid_pt_line_edges      = false;
   bool         m_add_mid_pt_rect_edges      = true;
   bool         m_add_mid_pt_slot_edges      = false;
@@ -554,6 +615,7 @@ private:
   bool                     m_show_lua_console{true}; // Lua Console pane; hidden if false in settings
   Gui_imgui_style_settings m_imgui_style_dark{};
   Gui_imgui_style_settings m_imgui_style_light{};
+  Gui_settings_headers     m_settings_headers{};
   bool                     m_sketch_properties_open{false};
   std::weak_ptr<Sketch>    m_sketch_properties_sketch;
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -89,18 +89,18 @@ inline constexpr float k_gui_origin_marker_color_default[3] = {0.0f, 0.75f, 1.0f
 /// Current-sketch edge RGBA (`gui.sketch_edge_color`); alpha maps to OCCT opacity (1 - transparency).
 inline constexpr float k_gui_sketch_edge_color_default[4] = {0.0f, 1.0f, 0.0f, 1.0f};
 /// Selected sketch-edge RGBA (`gui.sketch_edge_selection_color`).
-inline constexpr float k_gui_sketch_edge_selection_color_default[4] = {1.0f, 1.0f, 0.0f, 1.0f};
+inline constexpr float k_gui_sketch_edge_selection_color_default[4] = {1.0f, 0.545455f, 0.0f, 1.0f};
 /// Dynamic (hover) highlight RGBA for sketch edges (`gui.sketch_edge_highlight_color`).
 inline constexpr float k_gui_sketch_edge_highlight_color_default[4] = {1.0f, 1.0f, 0.0f, 1.0f};
 inline constexpr float k_gui_sketch_edge_line_width_default         = 1.0f;
 inline constexpr float k_gui_sketch_edge_line_width_min             = 0.5f;
 inline constexpr float k_gui_sketch_edge_line_width_max             = 8.0f;
-/// Current-sketch face fill RGBA (`gui.sketch_face_color`); matches former Quantity_NOC_GRAY7 @ 50%.
-inline constexpr float k_gui_sketch_face_color_default[4] = {0.07f, 0.07f, 0.07f, 0.5f};
+/// Current-sketch face fill RGBA (`gui.sketch_face_color`).
+inline constexpr float k_gui_sketch_face_color_default[4] = {0.300796f, 0.245416f, 0.320574f, 0.296651f};
 /// Selected sketch-face fill RGBA (`gui.sketch_face_selection_color`).
-inline constexpr float k_gui_sketch_face_selection_color_default[4] = {1.0f, 1.0f, 0.0f, 0.5f};
+inline constexpr float k_gui_sketch_face_selection_color_default[4] = {0.799043f, 0.187335f, 0.591238f, 1.0f};
 /// Dynamic (hover) highlight RGBA for sketch faces (`gui.sketch_face_highlight_color`).
-inline constexpr float k_gui_sketch_face_highlight_color_default[4] = {1.0f, 1.0f, 0.0f, 0.5f};
+inline constexpr float k_gui_sketch_face_highlight_color_default[4] = {0.822967f, 0.0f, 1.0f, 1.0f};
 /// Allowed range and default for `gui.view_roll_step_deg` (view roll and numpad orbit steps; must match Settings slider).
 inline constexpr double k_gui_view_roll_step_deg_min     = 0.1;
 inline constexpr double k_gui_view_roll_step_deg_max     = 180.0;
@@ -143,11 +143,10 @@ struct Gui_imgui_style_settings
 };
 
 /// Open/closed state for Settings pane collapsing headers (`gui.settings_headers`).
-/// Defaults match the former ImGuiTreeNodeFlags_DefaultOpen choices.
 struct Gui_settings_headers
 {
-  bool view_nav{true};
-  bool ui{true};
+  bool view_nav{false};
+  bool ui{false};
   bool view_presentation{false};
   bool grid{false};
   bool sketch{false};

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -1192,7 +1192,7 @@ void GUI::settings_()
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex(0);
         ImGui::AlignTextToFramePadding();
-        ImGui::TextUnformatted("Face selection color");
+        ImGui::TextUnformatted("Face selection fill");
         ImGui::TableSetColumnIndex(1);
         if (ImGui::ColorEdit4("##sketch_face_sel_color", m_sketch_face_selection_color,
                               ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
@@ -1203,7 +1203,7 @@ void GUI::settings_()
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex(0);
         ImGui::AlignTextToFramePadding();
-        ImGui::TextUnformatted("Face highlight color");
+        ImGui::TextUnformatted("Face highlight fill");
         ImGui::TableSetColumnIndex(1);
         if (ImGui::ColorEdit4("##sketch_face_hl_color", m_sketch_face_highlight_color,
                               ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -30,6 +30,37 @@ nlohmann::json imgui_style_to_json(const Gui_imgui_style_settings& s)
                         {"item_spacing_x", s.item_spacing_x},     {"item_spacing_y", s.item_spacing_y}};
 }
 
+nlohmann::json settings_headers_to_json(const Gui_settings_headers& h)
+{
+  return nlohmann::json{{"view_nav", h.view_nav},
+                        {"ui", h.ui},
+                        {"view_presentation", h.view_presentation},
+                        {"grid", h.grid},
+                        {"sketch", h.sketch},
+                        {"sketch_appearance", h.sketch_appearance},
+                        {"sketch_dimensions", h.sketch_dimensions},
+                        {"startup", h.startup}};
+}
+
+void parse_settings_headers_json(const nlohmann::json& obj, Gui_settings_headers& out)
+{
+  Gui_settings_headers defaults{};
+  auto                 b = [&obj](const char* key, bool fallback) -> bool
+  {
+    if (obj.contains(key) && obj[key].is_boolean())
+      return obj[key].get<bool>();
+    return fallback;
+  };
+  out.view_nav           = b("view_nav", defaults.view_nav);
+  out.ui                 = b("ui", defaults.ui);
+  out.view_presentation  = b("view_presentation", defaults.view_presentation);
+  out.grid               = b("grid", defaults.grid);
+  out.sketch             = b("sketch", defaults.sketch);
+  out.sketch_appearance  = b("sketch_appearance", defaults.sketch_appearance);
+  out.sketch_dimensions  = b("sketch_dimensions", defaults.sketch_dimensions);
+  out.startup            = b("startup", defaults.startup);
+}
+
 void parse_imgui_style_json(const nlohmann::json& obj, const Gui_imgui_style_settings& defaults, Gui_imgui_style_settings& out)
 {
   auto f = [&obj](const char* key, float fallback) -> float
@@ -133,6 +164,23 @@ std::string GUI::occt_view_settings_json() const
       {"show_sketch_dimensions", m_show_sketch_dimensions},
       {k_gui_key_permanent_node_anno_scale, m_permanent_node_anno_scale},
       {"origin_marker_color", {m_origin_marker_color[0], m_origin_marker_color[1], m_origin_marker_color[2]}},
+      {"sketch_edge_color",
+       {m_sketch_edge_color[0], m_sketch_edge_color[1], m_sketch_edge_color[2], m_sketch_edge_color[3]}},
+      {"sketch_edge_selection_color",
+       {m_sketch_edge_selection_color[0], m_sketch_edge_selection_color[1], m_sketch_edge_selection_color[2],
+        m_sketch_edge_selection_color[3]}},
+      {"sketch_edge_highlight_color",
+       {m_sketch_edge_highlight_color[0], m_sketch_edge_highlight_color[1], m_sketch_edge_highlight_color[2],
+        m_sketch_edge_highlight_color[3]}},
+      {"sketch_edge_line_width", m_sketch_edge_line_width},
+      {"sketch_face_color",
+       {m_sketch_face_color[0], m_sketch_face_color[1], m_sketch_face_color[2], m_sketch_face_color[3]}},
+      {"sketch_face_selection_color",
+       {m_sketch_face_selection_color[0], m_sketch_face_selection_color[1], m_sketch_face_selection_color[2],
+        m_sketch_face_selection_color[3]}},
+      {"sketch_face_highlight_color",
+       {m_sketch_face_highlight_color[0], m_sketch_face_highlight_color[1], m_sketch_face_highlight_color[2],
+        m_sketch_face_highlight_color[3]}},
       {"add_mid_pt_edges", m_add_mid_pt_line_edges},
       {"add_mid_pt_rect_edges", m_add_mid_pt_rect_edges},
       {"add_mid_pt_slot_edges", m_add_mid_pt_slot_edges},
@@ -199,6 +247,23 @@ void GUI::save_occt_view_settings()
       {"show_sketch_dimensions", m_show_sketch_dimensions},
       {k_gui_key_permanent_node_anno_scale, m_permanent_node_anno_scale},
       {"origin_marker_color", {m_origin_marker_color[0], m_origin_marker_color[1], m_origin_marker_color[2]}},
+      {"sketch_edge_color",
+       {m_sketch_edge_color[0], m_sketch_edge_color[1], m_sketch_edge_color[2], m_sketch_edge_color[3]}},
+      {"sketch_edge_selection_color",
+       {m_sketch_edge_selection_color[0], m_sketch_edge_selection_color[1], m_sketch_edge_selection_color[2],
+        m_sketch_edge_selection_color[3]}},
+      {"sketch_edge_highlight_color",
+       {m_sketch_edge_highlight_color[0], m_sketch_edge_highlight_color[1], m_sketch_edge_highlight_color[2],
+        m_sketch_edge_highlight_color[3]}},
+      {"sketch_edge_line_width", m_sketch_edge_line_width},
+      {"sketch_face_color",
+       {m_sketch_face_color[0], m_sketch_face_color[1], m_sketch_face_color[2], m_sketch_face_color[3]}},
+      {"sketch_face_selection_color",
+       {m_sketch_face_selection_color[0], m_sketch_face_selection_color[1], m_sketch_face_selection_color[2],
+        m_sketch_face_selection_color[3]}},
+      {"sketch_face_highlight_color",
+       {m_sketch_face_highlight_color[0], m_sketch_face_highlight_color[1], m_sketch_face_highlight_color[2],
+        m_sketch_face_highlight_color[3]}},
       {"add_mid_pt_edges", m_add_mid_pt_line_edges},
       {"add_mid_pt_rect_edges", m_add_mid_pt_rect_edges},
       {"add_mid_pt_slot_edges", m_add_mid_pt_slot_edges},
@@ -206,6 +271,7 @@ void GUI::save_occt_view_settings()
       {"last_opened_project_path", m_last_opened_project_path},
       {"imgui_style_dark", imgui_style_to_json(m_imgui_style_dark)},
       {"imgui_style_light", imgui_style_to_json(m_imgui_style_light)},
+      {"settings_headers", settings_headers_to_json(m_settings_headers)},
       {"view_roll_step_deg", m_view_roll_step_deg},
       {"view_zoom_scroll_scale", m_view_zoom_scroll_scale},
       {"inspection_orthographic", m_inspection_orthographic},
@@ -415,6 +481,33 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
           m_origin_marker_color[i] = std::clamp(a[i].get<float>(), 0.f, 1.f);
     }
 
+    auto parse_rgba4 = [&g](const char* key, float* out, const float* defaults)
+    {
+      for (int i = 0; i < 4; ++i)
+        out[i] = defaults[i];
+      if (!g.contains(key) || !g[key].is_array())
+        return;
+      const json& a = g[key];
+      for (int i = 0; i < 4; ++i)
+        if (i < static_cast<int>(a.size()) && a[i].is_number())
+          out[i] = std::clamp(a[i].get<float>(), 0.f, 1.f);
+    };
+    parse_rgba4("sketch_edge_color", m_sketch_edge_color, k_gui_sketch_edge_color_default);
+    parse_rgba4("sketch_edge_highlight_color", m_sketch_edge_highlight_color, k_gui_sketch_edge_highlight_color_default);
+    parse_rgba4("sketch_face_color", m_sketch_face_color, k_gui_sketch_face_color_default);
+    parse_rgba4("sketch_face_highlight_color", m_sketch_face_highlight_color, k_gui_sketch_face_highlight_color_default);
+    // Selection colors: fall back to highlight when absent (pre-split settings files).
+    parse_rgba4("sketch_edge_selection_color", m_sketch_edge_selection_color,
+                g.contains("sketch_edge_selection_color") ? k_gui_sketch_edge_selection_color_default
+                                                          : m_sketch_edge_highlight_color);
+    parse_rgba4("sketch_face_selection_color", m_sketch_face_selection_color,
+                g.contains("sketch_face_selection_color") ? k_gui_sketch_face_selection_color_default
+                                                          : m_sketch_face_highlight_color);
+
+    m_sketch_edge_line_width =
+        parse_bounded_float("sketch_edge_line_width", k_gui_sketch_edge_line_width_min, k_gui_sketch_edge_line_width_max,
+                            k_gui_sketch_edge_line_width_default);
+
     if (g.contains("edge_dim_arrow_style") && g["edge_dim_arrow_style"].is_number_integer())
     {
       const int v = g["edge_dim_arrow_style"].get<int>();
@@ -460,6 +553,10 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
 
     if (g.contains("imgui_style_light") && g["imgui_style_light"].is_object())
       parse_imgui_style_json(g["imgui_style_light"], light_defaults, m_imgui_style_light);
+
+    m_settings_headers = Gui_settings_headers{};
+    if (g.contains("settings_headers") && g["settings_headers"].is_object())
+      parse_settings_headers_json(g["settings_headers"], m_settings_headers);
 
     const bool has_nested_imgui_style = (g.contains("imgui_style_dark") && g["imgui_style_dark"].is_object()) ||
                                         (g.contains("imgui_style_light") && g["imgui_style_light"].is_object());
@@ -695,6 +792,18 @@ void GUI::load_occt_view_settings_()
   log_message("Settings: loaded.");
 }
 
+bool GUI::settings_collapsing_header_(const char* label, bool& open_state)
+{
+  ImGui::SetNextItemOpen(open_state);
+  const bool open = ImGui::CollapsingHeader(label);
+  if (open != open_state)
+  {
+    open_state = open;
+    save_occt_view_settings();
+  }
+  return open;
+}
+
 void GUI::settings_()
 {
   if (!m_show_settings_dialog)
@@ -754,7 +863,7 @@ void GUI::settings_()
     ImGui::TextWrapped("0 = minimal UI. Odd values add more controls and panes; even values add more help (tooltips and "
                        "hints). Higher values are reserved for future tiers.");
 
-  if (ImGui::CollapsingHeader("3D view navigation", ImGuiTreeNodeFlags_DefaultOpen))
+  if (settings_collapsing_header_("3D view navigation", m_settings_headers.view_nav))
   {
     if (ImGui::BeginTable("settings_view_nav", 2, ImGuiTableFlags_SizingStretchProp))
     {
@@ -816,7 +925,7 @@ void GUI::settings_()
           "Hold Shift while scrolling or pressing +/- for finer zoom.");
   }
 
-  if (ImGui::CollapsingHeader("UI", ImGuiTreeNodeFlags_DefaultOpen))
+  if (settings_collapsing_header_("UI", m_settings_headers.ui))
   {
     bool ui_changed = false;
     if (ImGui::Checkbox("Dark mode", &m_dark_mode))
@@ -828,7 +937,7 @@ void GUI::settings_()
       save_occt_view_settings();
   }
 
-  if (ImGui::CollapsingHeader("View presentation"))
+  if (settings_collapsing_header_("View presentation", m_settings_headers.view_presentation))
   {
     float bg1[3], bg2[3];
     m_view->get_bg_gradient_colors(bg1, bg2);
@@ -902,7 +1011,7 @@ void GUI::settings_()
     }
   }
 
-  if (ui_show_feature(3) && ImGui::CollapsingHeader("3D view grid"))
+  if (ui_show_feature(3) && settings_collapsing_header_("3D view grid", m_settings_headers.grid))
   {
     float g1[3], g2[3];
     m_view->get_grid_colors(g1, g2);
@@ -1009,14 +1118,103 @@ void GUI::settings_()
       save_occt_view_settings();
   }
 
-  if (ImGui::CollapsingHeader("Sketch"))
+  if (settings_collapsing_header_("Sketch", m_settings_headers.sketch))
   {
     bool ul_changed        = false;
     bool dim_changed       = false;
     bool node_anno_changed = false;
+    bool appear_changed    = false;
 
     ImGui::Indent(ImGui::GetStyle().IndentSpacing);
-    if (ImGui::CollapsingHeader("Dimensions", ImGuiTreeNodeFlags_DefaultOpen))
+    if (settings_collapsing_header_("Appearance", m_settings_headers.sketch_appearance))
+      if (ImGui::BeginTable("settings_sketch_appear", 2, ImGuiTableFlags_SizingStretchProp))
+      {
+        ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, k_label_col_w);
+        ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Edge color");
+        ImGui::TableSetColumnIndex(1);
+        if (ImGui::ColorEdit4("##sketch_edge_color", m_sketch_edge_color, ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
+          appear_changed = true;
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+        GUI_DOC_HELP_("Color and opacity of edges on the current sketch (alpha = opacity).", nullptr);
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Edge thickness");
+        ImGui::TableSetColumnIndex(1);
+        {
+          float lw = m_sketch_edge_line_width;
+          if (ImGui::SliderFloat("##sketch_edge_lw", &lw, k_gui_sketch_edge_line_width_min,
+                                 k_gui_sketch_edge_line_width_max, "%.2f"))
+          {
+            m_sketch_edge_line_width = lw;
+            appear_changed           = true;
+          }
+        }
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Edge selection color");
+        ImGui::TableSetColumnIndex(1);
+        if (ImGui::ColorEdit4("##sketch_edge_sel_color", m_sketch_edge_selection_color,
+                              ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
+          appear_changed = true;
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+        GUI_DOC_HELP_("Color and opacity for selected sketch edges.", nullptr);
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Edge highlight color");
+        ImGui::TableSetColumnIndex(1);
+        if (ImGui::ColorEdit4("##sketch_edge_hl_color", m_sketch_edge_highlight_color,
+                              ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
+          appear_changed = true;
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+        GUI_DOC_HELP_("Color and opacity for mouse-over (dynamic) highlight on sketch edges.", nullptr);
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Face fill color");
+        ImGui::TableSetColumnIndex(1);
+        if (ImGui::ColorEdit4("##sketch_face_color", m_sketch_face_color, ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
+          appear_changed = true;
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+        GUI_DOC_HELP_("Fill color and opacity of closed faces on the current sketch.", nullptr);
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Face selection color");
+        ImGui::TableSetColumnIndex(1);
+        if (ImGui::ColorEdit4("##sketch_face_sel_color", m_sketch_face_selection_color,
+                              ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
+          appear_changed = true;
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+        GUI_DOC_HELP_("Fill color and opacity for selected sketch faces.", nullptr);
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Face highlight color");
+        ImGui::TableSetColumnIndex(1);
+        if (ImGui::ColorEdit4("##sketch_face_hl_color", m_sketch_face_highlight_color,
+                              ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
+          appear_changed = true;
+        ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+        GUI_DOC_HELP_("Fill color and opacity for mouse-over (dynamic) highlight on sketch faces.", nullptr);
+
+        ImGui::EndTable();
+      }
+
+    if (settings_collapsing_header_("Dimensions", m_settings_headers.sketch_dimensions))
       if (ImGui::BeginTable("settings_sketch_dims", 2, ImGuiTableFlags_SizingStretchProp))
       {
         ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, k_label_col_w);
@@ -1438,6 +1636,13 @@ void GUI::settings_()
         m_view->refresh_sketch_annotations({.permanent_node_marks = true});
     }
 
+    if (appear_changed)
+    {
+      save_occt_view_settings();
+      if (m_view)
+        m_view->refresh_sketch_annotations({.edge_face_style = true});
+    }
+
     if (ul_changed)
     {
       uint8_t hr, hg, hb, ha;
@@ -1458,7 +1663,7 @@ void GUI::settings_()
     }
   }
 
-  if (ui_show_feature(3) && ImGui::CollapsingHeader("Startup project"))
+  if (ui_show_feature(3) && settings_collapsing_header_("Startup project", m_settings_headers.startup))
   {
 #ifndef __EMSCRIPTEN__
     if (ImGui::BeginTable("settings_startup_native", 2, ImGuiTableFlags_SizingStretchProp))
@@ -1525,6 +1730,9 @@ void GUI::settings_()
         }
 
         show_message("Default settings applied.");
+        if (m_view)
+          m_view->refresh_sketch_annotations(
+              {.length_dimensions = true, .permanent_node_marks = true, .edge_face_style = true});
       }
       catch (...)
       {

--- a/src/sketch.cpp
+++ b/src/sketch.cpp
@@ -221,6 +221,12 @@ void Sketch::refresh_annotations(const Sketch_annotation_refresh& refresh)
 
   if (refresh.permanent_node_marks)
     m_node_marks.sync();
+
+  if (refresh.edge_face_style)
+  {
+    set_edge_style(m_edge_style);
+    m_ctx.UpdateCurrentViewer();
+  }
 }
 
 size_t Sketch::length_dimension_count() const { return m_dims.length_dimension_count(); }

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -32,6 +32,8 @@ struct Sketch_annotation_refresh
 {
   bool length_dimensions    = false;
   bool permanent_node_marks = false;
+  /// Reapply edge/face display colors, widths, and selection highlight drawers from GUI settings.
+  bool edge_face_style = false;
 };
 
 // The Sketch class provides a comprehensive set of methods for creating and manipulating 2D sketches in a 3D environment.
@@ -203,7 +205,9 @@ private:
   void get_originating_face_snp_pts_3d_(std::vector<gp_Pnt>& out);
 
   // Style related
-  void                  update_edge_style_(AIS_Shape_ptr& shp);
+  void                  update_edge_style_(const AIS_Shape_ptr& shp);
+  void                  update_face_style_(const AIS_Shape_ptr& shp);
+  void                  update_all_face_styles_();
   void                  sync_operation_axis_display_();
   bool                  show_operation_axis_() const;
   bool                  operation_axis_suppresses_sketch_snap_() const;

--- a/src/sketch_display.cpp
+++ b/src/sketch_display.cpp
@@ -2,6 +2,8 @@
 #include "sketch.h"
 
 #include <Aspect_TypeOfLine.hxx>
+#include <Aspect_InteriorStyle.hxx>
+#include <AIS_DisplayMode.hxx>
 #include <Graphic3d_AspectFillArea3d.hxx>
 #include <Graphic3d_NameOfMaterial.hxx>
 #include <Prs3d_Drawer.hxx>
@@ -59,6 +61,7 @@ Handle(Prs3d_Drawer) make_edge_hilight_drawer_(const float* rgba, float line_wid
 Handle(Prs3d_Drawer) make_face_hilight_drawer_(const float* rgba)
 {
   Handle(Prs3d_Drawer) drawer = new Prs3d_Drawer();
+  drawer->SetupOwnDefaults();
   const Quantity_Color qc     = rgb_from_rgba_(rgba);
   const float          transp = transparency_from_rgba_(rgba);
   drawer->SetColor(qc);
@@ -71,6 +74,8 @@ Handle(Prs3d_Drawer) make_face_hilight_drawer_(const float* rgba)
 
   Handle(Graphic3d_AspectFillArea3d) fill = new Graphic3d_AspectFillArea3d();
   fill->SetAlphaMode(Graphic3d_AlphaMode_Blend);
+  fill->SetInteriorStyle(Aspect_IS_SOLID);
+  fill->SetInteriorColor(qc);
   fill->SetColor(qc);
   drawer->SetBasicFillAreaAspect(fill);
 
@@ -92,6 +97,8 @@ void apply_edge_hilight_(AIS_Shape& shp, const GUI& gui)
 
 void apply_face_hilight_(AIS_Shape& shp, const GUI& gui)
 {
+  // Use shaded hilight so selection/hover tint the face fill, not only a wire outline.
+  shp.SetHilightMode(AIS_Shaded);
   Handle(Prs3d_Drawer) selected = make_face_hilight_drawer_(gui.sketch_face_selection_color_rgba());
   Handle(Prs3d_Drawer) hover    = make_face_hilight_drawer_(gui.sketch_face_highlight_color_rgba());
   shp.SetHilightAttributes(selected);

--- a/src/sketch_display.cpp
+++ b/src/sketch_display.cpp
@@ -1,30 +1,158 @@
 // Sketch viewer display: visibility, edge styling, sketch switching, list hover.
 #include "sketch.h"
 
+#include <Aspect_TypeOfLine.hxx>
+#include <Graphic3d_AspectFillArea3d.hxx>
+#include <Graphic3d_NameOfMaterial.hxx>
+#include <Prs3d_Drawer.hxx>
+#include <Prs3d_LineAspect.hxx>
+#include <Prs3d_ShadingAspect.hxx>
 #include <Quantity_Color.hxx>
 #include <V3d_Viewer.hxx>
+#include <algorithm>
 
+#include "gui.h"
 #include "gui_occt_view.h"
 #include "utl.h"
 
-void Sketch::update_edge_style_(AIS_Shape_ptr& shp)
+namespace
 {
+constexpr float k_originating_face_full_rgba[4] = {0.3f, 0.0f, 0.0f, 1.0f};
+/// Fixed style for non-current sketches (not user-configurable).
+constexpr float k_background_edge_rgba[4] = {0.3f, 0.3f, 0.3f, 0.3f};
+constexpr float k_background_face_rgba[4] = {0.3f, 0.3f, 0.3f, 0.2f};
+constexpr float k_edge_highlight_line_width = 2.0f;
+
+Quantity_Color rgb_from_rgba_(const float* rgba)
+{
+  return Quantity_Color(static_cast<double>(rgba[0]), static_cast<double>(rgba[1]), static_cast<double>(rgba[2]),
+                        Quantity_TOC_RGB);
+}
+
+float transparency_from_rgba_(const float* rgba)
+{
+  return std::clamp(1.f - rgba[3], 0.f, 1.f);
+}
+
+void apply_rgba_style_(AIS_Shape& shp, const float* rgba, float line_width)
+{
+  shp.SetWidth(static_cast<double>(line_width));
+  shp.SetColor(rgb_from_rgba_(rgba));
+  shp.SetTransparency(static_cast<double>(transparency_from_rgba_(rgba)));
+}
+
+Handle(Prs3d_Drawer) make_edge_hilight_drawer_(const float* rgba, float line_width)
+{
+  Handle(Prs3d_Drawer) drawer = new Prs3d_Drawer();
+  const Quantity_Color qc     = rgb_from_rgba_(rgba);
+  drawer->SetColor(qc);
+  drawer->SetTransparency(transparency_from_rgba_(rgba));
+  Handle(Prs3d_LineAspect) line =
+      new Prs3d_LineAspect(qc, Aspect_TOL_SOLID, static_cast<double>(line_width));
+  drawer->SetLineAspect(line);
+  drawer->SetWireAspect(line);
+  drawer->SetSeenLineAspect(line);
+  drawer->SetFaceBoundaryAspect(line);
+  return drawer;
+}
+
+Handle(Prs3d_Drawer) make_face_hilight_drawer_(const float* rgba)
+{
+  Handle(Prs3d_Drawer) drawer = new Prs3d_Drawer();
+  const Quantity_Color qc     = rgb_from_rgba_(rgba);
+  const float          transp = transparency_from_rgba_(rgba);
+  drawer->SetColor(qc);
+  drawer->SetTransparency(transp);
+
+  Handle(Prs3d_ShadingAspect) shading = new Prs3d_ShadingAspect();
+  shading->SetColor(qc);
+  shading->SetTransparency(static_cast<double>(transp));
+  drawer->SetShadingAspect(shading);
+
+  Handle(Graphic3d_AspectFillArea3d) fill = new Graphic3d_AspectFillArea3d();
+  fill->SetAlphaMode(Graphic3d_AlphaMode_Blend);
+  fill->SetColor(qc);
+  drawer->SetBasicFillAreaAspect(fill);
+
+  Handle(Prs3d_LineAspect) line = new Prs3d_LineAspect(qc, Aspect_TOL_SOLID, 2.0);
+  drawer->SetWireAspect(line);
+  drawer->SetFaceBoundaryAspect(line);
+  return drawer;
+}
+
+void apply_edge_hilight_(AIS_Shape& shp, const GUI& gui)
+{
+  Handle(Prs3d_Drawer) selected =
+      make_edge_hilight_drawer_(gui.sketch_edge_selection_color_rgba(), k_edge_highlight_line_width);
+  Handle(Prs3d_Drawer) hover =
+      make_edge_hilight_drawer_(gui.sketch_edge_highlight_color_rgba(), k_edge_highlight_line_width);
+  shp.SetHilightAttributes(selected);
+  shp.SetDynamicHilightAttributes(hover);
+}
+
+void apply_face_hilight_(AIS_Shape& shp, const GUI& gui)
+{
+  Handle(Prs3d_Drawer) selected = make_face_hilight_drawer_(gui.sketch_face_selection_color_rgba());
+  Handle(Prs3d_Drawer) hover    = make_face_hilight_drawer_(gui.sketch_face_highlight_color_rgba());
+  shp.SetHilightAttributes(selected);
+  shp.SetDynamicHilightAttributes(hover);
+}
+} // namespace
+
+void Sketch::update_edge_style_(const AIS_Shape_ptr& shp)
+{
+  if (shp.IsNull())
+    return;
+
+  const GUI& gui = m_view.gui();
   switch (m_edge_style)
   {
   case Edge_style::Full:
-    shp->SetWidth(1.0);
-    shp->SetColor(Quantity_Color(0.0, 1.0, 0.0, Quantity_TOC_RGB));
-    shp->SetTransparency(0.0);
+    apply_rgba_style_(*shp, gui.sketch_edge_color_rgba(), gui.sketch_edge_line_width());
     break;
 
   case Edge_style::Background:
-    shp->SetWidth(1.0);
-    shp->SetColor(Quantity_Color(0.3, 0.3, 0.3, Quantity_TOC_RGB));
-    shp->SetTransparency(0.7);
+    apply_rgba_style_(*shp, k_background_edge_rgba, gui.sketch_edge_line_width());
     break;
 
   default:
     EZY_ASSERT(false);
+  }
+
+  apply_edge_hilight_(*shp, gui);
+}
+
+void Sketch::update_face_style_(const AIS_Shape_ptr& shp)
+{
+  if (shp.IsNull())
+    return;
+
+  const GUI& gui = m_view.gui();
+  switch (m_edge_style)
+  {
+  case Edge_style::Full:
+    apply_rgba_style_(*shp, gui.sketch_face_color_rgba(), 1.0f);
+    break;
+
+  case Edge_style::Background:
+    apply_rgba_style_(*shp, k_background_face_rgba, 1.0f);
+    break;
+
+  default:
+    EZY_ASSERT(false);
+  }
+
+  shp->SetMaterial(Graphic3d_NOM_PLASTIC);
+  apply_face_hilight_(*shp, gui);
+}
+
+void Sketch::update_all_face_styles_()
+{
+  for (const Sketch_face_shp_ptr& face : m_topo.faces())
+  {
+    update_face_style_(face);
+    if (!face.IsNull())
+      m_ctx.Redisplay(face, false);
   }
 }
 
@@ -33,24 +161,23 @@ void Sketch::update_originating_face_style()
   if (!m_originating_face)
     return;
 
+  const GUI& gui = m_view.gui();
   switch (m_edge_style)
   {
   case Edge_style::Full:
-    m_originating_face->SetWidth(1.0);
-    m_originating_face->SetColor(Quantity_Color(0.3, 0.0, 0.0, Quantity_TOC_RGB));
-    m_originating_face->SetTransparency(0.0);
+    // Originating face wire stays a distinct dark-red cue for "from face" sketches.
+    apply_rgba_style_(*m_originating_face, k_originating_face_full_rgba, gui.sketch_edge_line_width());
     break;
 
   case Edge_style::Background:
-    m_originating_face->SetWidth(1.0);
-    m_originating_face->SetColor(Quantity_Color(0.3, 0.3, 0.3, Quantity_TOC_RGB));
-    m_originating_face->SetTransparency(0.7);
+    apply_rgba_style_(*m_originating_face, k_background_edge_rgba, gui.sketch_edge_line_width());
     break;
 
   default:
     EZY_ASSERT(false);
   }
 
+  apply_edge_hilight_(*m_originating_face, gui);
   m_ctx.Redisplay(m_originating_face, true);
 }
 
@@ -197,7 +324,12 @@ void Sketch::set_edge_style(Edge_style style)
   m_edge_style = style;
 
   for (Edge& e : m_edges.edges())
+  {
     update_edge_style_(e.shp);
+    if (!e.shp.IsNull())
+      m_ctx.Redisplay(e.shp, false);
+  }
 
+  update_all_face_styles_();
   update_originating_face_style();
 }

--- a/src/sketch_topo.cpp
+++ b/src/sketch_topo.cpp
@@ -5,9 +5,7 @@
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepTools.hxx>
-#include <Graphic3d_AspectFillArea3d.hxx>
 #include <Precision.hxx>
-#include <Quantity_Color.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Wire.hxx>
 #include <algorithm>
@@ -542,9 +540,7 @@ void Sketch_topo::update_faces()
         continue;
 
       Sketch_face_shp_ptr f = create_face_shape_(face);
-      f->SetColor(Quantity_NOC_GRAY7);       // Base color
-      f->SetTransparency(0.5);               // 0.5 = 50% transparent (0.0 = opaque, 1.0 = invisible)
-      f->SetMaterial(Graphic3d_NOM_PLASTIC); // Optional: material for shading
+      m_sketch.update_face_style_(f);
 
       m_sketch.m_ctx.Display(f, AIS_Shaded, AIS_Shape::SelectionMode(TopAbs_FACE), true);
       m_sketch.m_ctx.Activate(f, AIS_Shape::SelectionMode(TopAbs_FACE));


### PR DESCRIPTION
## Summary
- **Sketch appearance:** Settings -> Sketch -> Appearance adds edge color/thickness, edge selection vs hover highlight colors, and face fill / selection fill / highlight fill (RGBA, alpha = opacity). Applied live via `Sketch_annotation_refresh::edge_face_style`.
- **OCCT:** Separate `SetHilightAttributes` (selection) and `SetDynamicHilightAttributes` (hover); faces use shaded hilight so fill colors show.
- **Settings UI:** Collapsing section open state persisted in `gui.settings_headers`.
- **Defaults / docs:** Bundled `res/ezycad_settings.json` and C++ fallbacks updated to the preferred palette; `usage-settings.md`, `usage-sketch.md`, `CHANGELOG.md`, and `src/doc/{gui,sketch}.md` updated.

## Test plan
- [x] Build Release `EzyCad`.
- [x] Settings -> Sketch -> Appearance: change edge/face colors and alpha; verify live update on current sketch.
- [x] Select edge vs hover edge: distinct selection vs highlight colors.
- [x] Select face vs hover face: fill tints match selection/highlight fills (not wire-only).
- [x] Collapse/expand Settings sections; restart app — open state restored.
- [x] Settings **Defaults** restores bundled palette.
- [x] Optional: docs build / review `usage-settings.md` JSON keys.

## Related
- Fixes #194