### PR TITLE
Typed undo/redo deltas for shapes and document ops

### DIFF
--- a/agents/drafts/issues/active/gh-200-undo-redo-typed-deltas.md
+++ b/agents/drafts/issues/active/gh-200-undo-redo-typed-deltas.md
@@ -1,0 +1,67 @@
+---
+github_issue: 200
+github_pr: 201
+status: active
+paired_draft: ../prs/active/gh-201-undo-redo-typed-deltas.md
+---
+
+# Replace full-document JSON undo with typed shape/document deltas
+
+**Suggested labels:** `enhancement`
+
+---
+
+## Title (GitHub)
+
+Replace full-document JSON undo with typed shape/document deltas
+
+## Body (GitHub)
+
+### Summary
+
+Interactive undo/redo still used full-document `to_json()` snapshots for almost every non-sketch edit. Extend the existing `Delta` pattern (already used for sketch geometry) to shapes and document structure so history stores only affected objects.
+
+### Problem
+
+- Full JSON undo copies every shape BREP on each step and reloads the whole model.
+- Shapes lacked stable ids for delta resolution.
+
+### Implemented scope
+
+**Code changes:**
+
+- Stable `Shape_id` on `Shp`; `shapes[].id` in project JSON.
+- `src/shp_delta.*` — add / remove / geom / replace deltas (`TopoDS_Shape` in `Shape_rec`).
+- `src/doc_delta.*` — sketch structural + underlay deltas.
+- Wired `shp_*`, primitives, delete, extrude/revolve/import, sketch add/remove, underlay UI.
+- JSON snapshots only for mixed delete and file-open checkpoint.
+
+**Documentation:**
+
+- `src/doc/undo-redo.md`, `shape.md`, `utility.md`
+
+### Acceptance criteria
+
+- [x] Interactive edits use typed deltas (no full-document copy).
+- [x] Fuse/cut/delete/add-box undo tests; sketch delta interleave.
+- [x] Shape ids persist in JSON.
+- [x] Developer docs updated.
+
+### Files touched
+
+- `src/shp_delta.*`, `src/doc_delta.*`, `src/shp.*`, `src/gui_occt_view.*`, `src/gui.*`, `src/shp_*.cpp`
+- `tests/shp_tests.cpp`
+- `src/doc/undo-redo.md`, `shape.md`, `utility.md`
+- `agents/drafts/issues/active/gh-200-undo-redo-typed-deltas.md` (this draft)
+
+### Related
+
+- GitHub issue: https://github.com/trailcode/EzyCad/issues/200
+- Prior sketch deltas: #144 / #145
+- PR: https://github.com/trailcode/EzyCad/pull/201
+- PR draft: `agents/drafts/prs/active/gh-201-undo-redo-typed-deltas.md`
+
+### Test plan
+
+- [x] `EzyCad_tests --gtest_filter=Shp_test.Undo*:Shp_test.Shape_ids*:Sketch_test.Undo*`
+- [ ] Manual smoke: box add, fuse, new sketch, underlay slider undo

--- a/agents/drafts/prs/active/gh-201-undo-redo-typed-deltas.md
+++ b/agents/drafts/prs/active/gh-201-undo-redo-typed-deltas.md
@@ -1,0 +1,56 @@
+---
+github_issue: 200
+github_pr: 201
+status: active
+paired_draft: ../issues/active/gh-200-undo-redo-typed-deltas.md
+---
+
+# PR - Typed undo/redo deltas for shapes and document ops
+
+## Title
+
+Typed undo/redo deltas for shapes and document ops
+
+## Summary
+
+- Interactive undo no longer copies the whole document for shape/sketch/underlay edits.
+- Stable shape ids + typed deltas (`shp_delta`, `doc_delta`); `Shape_rec` holds `TopoDS_Shape`.
+- JSON snapshots remain only for mixed delete and open-file checkpoint.
+- Closes #200 (extends the sketch-delta approach from #144 / #145).
+
+## Files Changed
+
+- `src/shp_delta.h`, `src/shp_delta.cpp`
+- `src/doc_delta.h`, `src/doc_delta.cpp`
+- `src/shp.h`, `src/shp.cpp`
+- `src/gui_occt_view.h`, `src/gui_occt_view.cpp`
+- `src/gui.h`, `src/gui.cpp`
+- `src/shp_*.cpp` (fuse/cut/common/fillet/chamfer/move/rotate/scale/polar_dup/extrude)
+- `tests/shp_tests.cpp`
+- `src/doc/undo-redo.md`, `src/doc/shape.md`, `src/doc/utility.md`
+- `agents/drafts/issues/active/gh-200-undo-redo-typed-deltas.md`
+- `agents/drafts/prs/active/gh-201-undo-redo-typed-deltas.md` (this draft)
+
+## Related
+
+- Issue: https://github.com/trailcode/EzyCad/issues/200
+- PR: https://github.com/trailcode/EzyCad/pull/201
+- Prior: https://github.com/trailcode/EzyCad/issues/144 , https://github.com/trailcode/EzyCad/pull/145
+
+## Test Plan
+
+- [x] Build `EzyCad_tests` (Release).
+- [x] `EzyCad_tests.exe --gtest_filter=Shp_test.Undo*:Shp_test.Shape_ids*:Sketch_test.Undo*`
+- [ ] Manual: box add, fuse, add sketch, underlay slider undo/redo.
+- [ ] Mixed sketch-edge delete still uses snapshot path.
+
+## Notes
+
+- Branch commits include an early `WIP` squash candidate; optional follow-up to tidy history before merge.
+- Underlay pixels remain in `Ezy_asset_store` (same as before); deltas store placement/asset id JSON only.
+
+## Post-merge (checklist for the author)
+
+- [ ] Close #200 if fully addressed (Closes link should do this).
+- [ ] Move drafts to `archive/`.
+- [ ] Consider `CHANGELOG.md` `[Unreleased]` entry.

--- a/src/doc/shape.md
+++ b/src/doc/shape.md
@@ -45,7 +45,7 @@ Always go through `Occt_view::add_shp_(Shp_ptr&)` (or a wrapper that calls it):
 | 2    | Set the document-wide shape selection mode (`m_shp_selection_mode`) |
 | 3    | Redisplay and append to `m_shps`                                    |
 
-`add_shp_()` does **not** push undo; callers that mutate the document should call `view().push_undo_snapshot()` first when appropriate.
+`add_shp_()` does **not** push undo; callers that mutate the document should push a typed shape delta (or snapshot fallback) after a successful commit. New shapes receive a stable `Shape_id` from `allocate_shape_id()` when id is still 0.
 
 ### Operation selection cache (`m_shps` on `Shp_operation_base`)
 
@@ -167,15 +167,21 @@ Full GLFW -> `GUI` routing before these delegates: [`src/doc/gui.md`](gui.md).
 
 ## Undo
 
-| Mechanism                            | When                                                                                                   |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| `Occt_view::push_undo_snapshot()`    | Before booleans, fillet/chamfer, primitive add, polar dup, transform finalize, extrude commit, revolve |
-| Transform preview only               | No undo until **finalize** (not on each mouse move)                                                    |
-| `Sketch_op_delta` (sketch subsystem) | Separate from shape ops; shape list captured in view snapshots                                         |
+Shape ops use typed deltas from [`shp_delta.h`](../shp_delta.h) (see [undo-redo.md](undo-redo.md)). No full-document JSON for these paths.
+
+| Mechanism                         | When                                                          |
+| --------------------------------- | ------------------------------------------------------------- |
+| `Shape_add_delta`                 | Primitives, extrude, revolve, STEP/PLY import                 |
+| `Shape_remove_delta`              | Delete selection when only `Shp` objects are selected         |
+| `Shape_geom_delta`                | Move / rotate / scale **finalize** (not preview)              |
+| `Shape_replace_delta`             | Fuse / cut / common / fillet / chamfer / polar duplicate      |
+| `push_undo_snapshot()` (fallback) | Delete when selection also includes sketch edges / dimensions |
+
+Shapes carry a stable `Shape_id` persisted as `shapes[].id` in project JSON.
 
 ## Persistence
 
-Shape serialization is handled in **`Occt_view`** (JSON `shapes` array in project save/load), not in a dedicated `shp_json` module. Fields include name, display mode, visibility, material, and tessellated/brep payload as implemented in the view I/O path.
+Shape serialization is handled in **`Occt_view`** (JSON `shapes` array in project save/load), not in a dedicated `shp_json` module. Fields include stable `id`, name, material, and BREP payload.
 
 Import/export (STEP, IGES, STL, PLY) also flows through `Occt_view` reader/writer helpers.
 
@@ -185,24 +191,25 @@ Import/export (STEP, IGES, STL, PLY) also flows through `Occt_view` reader/write
 
 ```cpp
 Occt_view& view = ...;
-view.push_undo_snapshot();
-TopoDS_Shape box = shp_create::create_box(0, 0, 0, 10, 10, 10);
-Shp_ptr shp = new Shp(view.ctx(), box);
-shp->set_name(view.get_unique_shape_name("Box"));
-view.add_shp_(shp);  // friend access, or use view.add_box(...) wrapper
+// Prefer view.add_box(...) which registers the shape and pushes Shape_add_delta.
+view.add_box(0, 0, 0, 10, 10, 10);
 ```
 
 ### Implement a replace-style operation
 
 ```cpp
 Status My_op::run() {
-  view().push_undo_snapshot();
   CHK_RET(ensure_operation_multi_shps_());
+  std::vector<Shape_rec> removed;
+  for (const Shp_ptr& s : m_shps)
+    removed.push_back(capture_shape_rec(*s));
   // ... BRepAlgoAPI_* ...
   Shp_ptr result = new Shp(ctx(), new_topo);
   result->set_name("MyOp");
   delete_operation_shps_();
   add_shp_(result);
+  view().push_undo_delta(std::make_unique<Shape_replace_delta>(
+      std::move(removed), std::vector<Shape_rec>{capture_shape_rec(*result)}));
   return Status::ok();
 }
 ```
@@ -216,13 +223,13 @@ auto lines = shp_info::collect(shp->Shape(), &meta);
 
 ## Testing
 
-| Item         | Notes                                                                                                                            |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| GTest suite  | `tests/shp_tests.cpp` — filters `Shp_create.*`, `Shp_info.*`, `Shp_test.*`                                                       |
-| Coverage     | `shp_create` volumes/bboxes; `shp_info::collect`; `Occt_view::add_*` / unique names; fuse/cut/common via AIS selection injection |
-| Fixture      | `Shp_test` inherits `Sketch_test` (headless `Occt_view`)                                                                         |
-| Related      | Sketch-face extrude / revolve still live under `Sketch_test.*`                                                                   |
-| Build target | `EzyCad_tests` ([`agents/workflows/local-dev.md`](../../agents/workflows/local-dev.md))                                          |
+| Item         | Notes                                                                                                                        |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| GTest suite  | `tests/shp_tests.cpp` — filters `Shp_create.*`, `Shp_info.*`, `Shp_test.*`                                                   |
+| Coverage     | `shp_create` volumes/bboxes; `shp_info::collect`; `Occt_view::add_*` / unique names; fuse/cut/common; shape undo/redo deltas |
+| Fixture      | `Shp_test` inherits `Sketch_test` (headless `Occt_view`)                                                                     |
+| Related      | Sketch-face extrude / revolve still live under `Sketch_test.*`                                                               |
+| Build target | `EzyCad_tests` ([`agents/workflows/local-dev.md`](../../agents/workflows/local-dev.md))                                      |
 
 ## Related code outside `src/shp_*`
 

--- a/src/doc/undo-redo.md
+++ b/src/doc/undo-redo.md
@@ -2,9 +2,11 @@
 
 Developer reference for EzyCad's document history. Public C++ entry points:
 
-- [`delta.h`](../delta.h) — abstract undo step
-- [`sketch_op_recorder.h`](../sketch_op_recorder.h) — sketch operation recorder (public API)
-- [`gui_occt_view.h`](../gui_occt_view.h) — stack storage and `undo()` / `redo()`
+- [`delta.h`](../delta.h) -- abstract undo step
+- [`sketch_op_recorder.h`](../sketch_op_recorder.h) -- sketch operation recorder (public API)
+- [`shp_delta.h`](../shp_delta.h) -- shape add / remove / geom / replace deltas
+- [`doc_delta.h`](../doc_delta.h) -- sketch structural and underlay deltas
+- [`gui_occt_view.h`](../gui_occt_view.h) -- stack storage and `undo()` / `redo()`
 
 Maintainers: update this file when undo stack layout, delta types, or push/pop contracts change (see [agents/conventions/token-lean.md](../../agents/conventions/token-lean.md#developer-docs-in-srcdoc)). User-facing shortcuts are documented in [`docs/usage.md`](../../docs/usage.md).
 
@@ -12,14 +14,12 @@ Maintainers: update this file when undo stack layout, delta types, or push/pop c
 
 EzyCad keeps a bounded history of user edits so **Ctrl+Z** / **Ctrl+Y** (and Edit menu items) can step backward and forward through the session. History is owned by `Occt_view` and spans both 2D sketch geometry and the wider 3D document (shapes, sketches, underlays, imports).
 
-The implementation uses **two strategies** on one stack:
+Interactive edits use **typed element deltas** that store only affected objects. Full-document JSON snapshots remain only for a few fallback cases (mixed selection delete, optimistic file-open checkpoint).
 
-| Strategy               | When used             | Stored payload                                                           |
-| ---------------------- | --------------------- | ------------------------------------------------------------------------ |
-| **Element delta**      | Sketch geometry edits | `std::unique_ptr<Delta>` (`Sketch_op_delta` in `sketch_op_recorder.cpp`) |
-| **Full JSON snapshot** | Everything else       | `to_json()` string of the whole document                                 |
-
-Sketch deltas are cheaper and precise; JSON snapshots are simple and cover arbitrary document changes (shape booleans, sketch add/remove, file load, etc.).
+| Strategy               | When used                                       | Stored payload                           |
+| ---------------------- | ----------------------------------------------- | ---------------------------------------- |
+| **Element delta**      | Sketch, shape, underlay, sketch add/remove      | `std::unique_ptr<Delta>`                 |
+| **Full JSON snapshot** | Mixed delete (sketch edges + shapes); file open | `to_json()` string of the whole document |
 
 ## Requirements and invariants
 
@@ -33,11 +33,11 @@ Sketch deltas are cheaper and precise; JSON snapshots are simple and cover arbit
 
 Each stack frame stores:
 
-| Field   | Role                                                              |
-| ------- | ----------------------------------------------------------------- |
-| `delta` | Non-null for sketch element steps; mutually exclusive with `json` |
-| `json`  | Full-document snapshot when `delta` is null                       |
-| `mode`  | `Mode` active when the operation ran; restored on undo/redo       |
+| Field   | Role                                                        |
+| ------- | ----------------------------------------------------------- |
+| `delta` | Non-null for typed steps; mutually exclusive with `json`    |
+| `json`  | Full-document snapshot when `delta` is null                 |
+| `mode`  | `Mode` active when the operation ran; restored on undo/redo |
 
 ### `m_restoring` guard
 
@@ -54,37 +54,41 @@ After applying a delta or reloading a snapshot, `Occt_view` calls `GUI::set_mode
 
 ### View camera
 
-Snapshot undo/redo calls `load(state.json, false)` so **camera pan/zoom/rotate are preserved** across JSON-based steps. Delta steps mutate sketch data in place and do not touch the view matrix.
+Snapshot undo/redo calls `load(state.json, false)` so **camera pan/zoom/rotate are preserved** across JSON-based steps. Delta steps mutate data in place and do not touch the view matrix.
 
-### Stable sketch identity
+### Stable identities
 
-`Sketch_op_delta` keys sketches by stable `sketch_id` (not display name or list index). Node indices are never compacted; undo tombstones nodes created during an operation. See [sketch.md](sketch.md#requirements-and-invariants).
+- Sketches: stable `sketch_id` (see [sketch.md](sketch.md#requirements-and-invariants)).
+- Shapes: stable `Shape_id` on `Shp`, allocated by `Occt_view::allocate_shape_id()`, persisted as `shapes[].id` in project JSON. Deltas resolve shapes by id, not list index.
+
+Booleans and fillets are lossy: undo must retain the **pre-op BREP of affected shapes** (not the whole document).
 
 ## Architecture
 
 ```
-GUI (menus, hotkeys, some UI-driven snapshots)
+GUI (menus, hotkeys, underlay UI)
   |
   +-- Occt_view::undo() / redo()
   |     m_undo_stack / m_redo_stack (Undo_entry)
   |
-  +-- push_undo_snapshot()  -->  entry.json = to_json()
-  +-- push_undo_delta()     -->  entry.delta = Sketch_op_delta
+  +-- push_undo_delta()     -->  typed Delta subclass
+  +-- push_undo_snapshot()  -->  entry.json = to_json() (fallback only)
   +-- pop_undo_snapshot()   -->  drop last entry (failed/aborted edit)
 
 Sketch edits
-  Sketch_op_recorder (RAII)
-    note_prev_* / note_curr_* during mutation
-    commit() --> push_undo_delta(Sketch_op_delta)
-    cancel() --> discard (destructor auto-cancels if not committed)
+  Sketch_op_recorder --> Sketch_op_delta
+
+Shape edits
+  Shape_add_delta / Shape_remove_delta / Shape_geom_delta / Shape_replace_delta
+
+Document structure
+  Sketch_struct_delta / Underlay_delta / Composite_delta
 
 Delta (abstract)
   apply_forward(view)   redo
   apply_reverse(view)   undo
   clone()               copy for opposite stack
 ```
-
-`Sketch_op_delta` is currently the only `Delta` subclass (defined in [`sketch_op_recorder.cpp`](../sketch_op_recorder.cpp), not the public header).
 
 ## Core types
 
@@ -98,39 +102,30 @@ class Delta {
 };
 ```
 
-Subclasses record the **forward** change. Undo applies `apply_reverse`; redo reapplies `apply_forward`.
+### Sketch deltas
 
-### `Sketch_op_recorder` ([`sketch_op_recorder.h`](../sketch_op_recorder.h))
+See [`Sketch_op_recorder`](../sketch_op_recorder.h) / `Sketch_op_delta` (unchanged element prev/curr lists).
 
-RAII scope around one sketch edit:
+### Shape deltas ([`shp_delta.h`](../shp_delta.h))
 
-1. **Construction** — captures live node positions and linear edges at operation start; initializes `Sketch_op_data` for the sketch's `get_id()`.
-2. **Mutation** — sketch code calls `note_*` helpers as it changes geometry.
-3. **`commit()`** — if any notes were recorded, pushes the delta via `Occt_view::push_undo_delta()`.
-4. **`cancel()`** or scope exit without commit — nothing is pushed (used for no-op mirror, failed tools, etc.).
+| Type                  | Stores                                       | Used for                                       |
+| --------------------- | -------------------------------------------- | ---------------------------------------------- |
+| `Shape_add_delta`     | Added `Shape_rec` list (id, name, mat, BREP) | Primitives, extrude, revolve, STEP/PLY import  |
+| `Shape_remove_delta`  | Removed `Shape_rec` list                     | Delete selection (shapes only)                 |
+| `Shape_geom_delta`    | Per-id before/after BREP                     | Move / rotate / scale finalize                 |
+| `Shape_replace_delta` | Removed + added `Shape_rec` lists            | Fuse / cut / common / fillet / chamfer / polar |
 
-Recorder notes (deduplicated by geometry):
+`Shape_rec` is BREP text plus attrs for one shape. Helpers: `capture_shape_rec`, `Occt_view::insert_shape_rec` / `remove_shape_by_id` / `set_shape_geom_by_id`.
 
-| Method                                                  | Meaning                                                     |
-| ------------------------------------------------------- | ----------------------------------------------------------- |
-| `note_prev_linear_edge`                                 | Edge removed or split away (must have existed at op start)  |
-| `note_curr_linear_edge`                                 | New linear segment added                                    |
-| `note_prev_arc_edge` / `note_curr_arc_edge`             | Arc circle segment removed / added                          |
-| `note_curr_node`                                        | New node not live at op start (stores `permanent` for redo) |
-| `note_prev_length_dim` / `note_curr_length_dim`         | Dimension removed / added                                   |
-| `note_prev_operation_axis` / `note_curr_operation_axis` | Operation axis before / after                               |
+### Document deltas ([`doc_delta.h`](../doc_delta.h))
 
-`note_prev_linear_edge` only records edges that were present when the recorder opened (`linear_edge_at_op_start_`), so incidental splits of pre-existing geometry are not mistaken for undoable removals of the user's new work.
+| Type                  | Stores                                                 | Used for                            |
+| --------------------- | ------------------------------------------------------ | ----------------------------------- |
+| `Sketch_struct_delta` | One sketch JSON (add or remove); optional auto-default | Add/remove sketch, sketch-from-face |
+| `Underlay_delta`      | Sketch id + before/after underlay JSON                 | Underlay import/remove/calib/UI     |
+| `Composite_delta`     | Ordered child deltas                                   | Multi-part edits if needed          |
 
-### `Sketch_op_delta` apply logic ([`sketch_op_recorder.cpp`](../sketch_op_recorder.cpp))
-
-**Forward (redo):** add `curr_*` linear edges and arcs, restore `curr_*` dimensions and operation axis, refresh faces.
-
-**Reverse (undo):** clear curr operation axis; remove curr dimensions, arcs, and linear segments; restore `prev_*` linear edges and arcs; restore prev operation axis and dimensions; tombstone `curr_node_pts`; refresh faces.
-
-Geometry is matched by **2D coordinates** (`Precision::SquareConfusion()`), not raw node indices, so deltas survive sketch list reordering as long as the sketch id resolves.
-
-`resolve_sketch_()` finds the target sketch in `Occt_view::get_sketches()` by id, with a fallback raw pointer for headless tests.
+Underlay pixels stay in `Ezy_asset_store`; undo restores placement / asset id references only.
 
 ## Undo / redo navigation
 
@@ -142,82 +137,86 @@ Geometry is matched by **2D coordinates** (`Precision::SquareConfusion()`), not 
 4. Push redo entry; restore `mode`.
 5. Clear `m_restoring`.
 
-`redo()` is symmetric: pop redo, capture current state for undo, `apply_forward` or `load`, push undo.
+`redo()` is symmetric.
 
 ## What pushes history
 
 ### Sketch deltas (`Sketch_op_recorder` + `commit()`)
 
-| Area                           | Trigger                                                           |
-| ------------------------------ | ----------------------------------------------------------------- |
-| `Sketch_tools::finalize`       | Line, multi-edge, rectangle, square, circle, slot, operation axis |
-| `Sketch_dims`                  | Add/remove length dimension; dimension tool finalize              |
-| `Sketch_tools` / `Sketch_dims` | Add-node tool (split at interior node)                            |
-| `sketch_operations.cpp`        | Mirror selected edges                                             |
-| `Sketch_edges` / `Sketch_topo` | Splits during edge add (via recorder passed into add/split paths) |
+Same as before: tool finalize, dims, splits, mirror (see prior sections / [sketch.md](sketch.md)).
 
-Interactive tools create the recorder internally. Direct `add_edge_(..., rec)` calls are for tests and delta replay.
+### Shape deltas
+
+| Area        | Operation                                                                          |
+| ----------- | ---------------------------------------------------------------------------------- |
+| `Occt_view` | Primitives, revolve, STEP/PLY import, shape-only delete                            |
+| `shp_*`     | Fuse, cut, common, fillet, chamfer, move/rotate/scale finalize, polar dup, extrude |
+
+Push **after** a successful mutation (capture result ids/BREPs). Failed booleans/fillets do not push.
+
+### Sketch / underlay deltas
+
+| Area        | Operation                                                                            |
+| ----------- | ------------------------------------------------------------------------------------ |
+| `Occt_view` | `add_sketch`, `remove_sketch`, sketch-from-face                                      |
+| `GUI`       | Underlay import/remove/calib/orthogonalize; transform sliders on activate/deactivate |
 
 ### JSON snapshots (`push_undo_snapshot()`)
 
-| Area        | Operation                                                                                                                                               |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Occt_view` | New file, add/remove sketch, sketch from face, sketch extrude finalize, revolve, delete shapes/sketches, primitives (box, sphere, ...), STEP/PLY import |
-| `shp_*`     | Fuse, cut, common, fillet, chamfer, move, rotate, scale, polar duplicate, extrude finalize                                                              |
-| `GUI`       | Open project, underlay import/remove/calibration/transform sliders, underlay orthogonalize                                                              |
-| `GUI`       | Underlay panel edits push on `IsItemActivated` so one snapshot covers a drag                                                                            |
+| Area        | Operation                                                             |
+| ----------- | --------------------------------------------------------------------- |
+| `Occt_view` | Delete when selection includes non-shape AIS (sketch edges / dims)    |
+| `GUI`       | Open project (optimistic push; cleared by `load` or `pop` on failure) |
 
-### `pop_undo_snapshot()` (abort without restoring)
+### `pop_undo_snapshot()`
 
-Used when a snapshot was pushed optimistically but the operation failed or made no change:
-
-- Invalid project open (`GUI::on_file`)
-- Underlay calibration rescale failure
-- Other guarded UI paths in `gui.cpp`
+Used when a snapshot was pushed optimistically but the operation failed (invalid project open).
 
 ## User interface
 
-| Input                  | Action                                  |                   |
-| ---                    | ---                                     |                   |
-| Ctrl+Z                 | Undo                                    |                   |
-| Ctrl+Shift+Z or Ctrl+Y | Redo                                    |                   |
-| Edit menu              | Undo / Redo (disabled when stack empty) |                   |
-| Settings pane          | Shows stack sizes: `Undo: N             | Redo: M [max 50]` |
+| Input                  | Action                                  |
+| ---------------------- | --------------------------------------- |
+| Ctrl+Z                 | Undo                                    |
+| Ctrl+Shift+Z or Ctrl+Y | Redo                                    |
+| Edit menu              | Undo / Redo (disabled when stack empty) |
+| Settings pane          | Shows stack sizes: Undo N / Redo M      |
 
 Hotkeys are handled in `GUI::on_key` (`gui_mode.cpp`) when dist/angle edit popups are not active.
 
 ## Document load and new file
 
-- **Open `.ezy`:** `GUI::on_file` pushes a snapshot of the current document, then `load(manifest)`. A failed parse calls `pop_undo_snapshot()`.
-- **`Occt_view::load`:** clears shapes and sketches from JSON; clears undo/redo stacks unless `m_restoring`.
-- **`Occt_view::new_file`:** pushes snapshot, then clears document and creates the default sketch.
+- **Open `.ezy`:** `GUI::on_file` pushes a snapshot of the current document, then `load(manifest)`. A failed parse calls `pop_undo_snapshot()`. Successful `load` clears both stacks.
+- **`Occt_view::new_file`:** clears undo/redo stacks, resets sketch and shape id allocators, creates the default sketch.
 
 ## Adding undo for new behavior
 
 ### Sketch geometry change
 
 1. Open a `Sketch_op_recorder` around the mutation.
-2. Call `note_prev_*` before removing or splitting existing geometry; `note_curr_*` after adding.
+2. Call `note_prev_*` / `note_curr_*` as appropriate.
 3. `commit()` at success; `cancel()` on no-op or error.
-4. If redo/undo needs logic not covered by existing note types, extend `Sketch_op_data` and both `apply_forward_` / `apply_reverse_` in `sketch_op_recorder.cpp`.
 
-### Non-sketch document change
+### Shape change
 
-Call `Occt_view::push_undo_snapshot()` **before** mutating sketches, shapes, or assets. Use `pop_undo_snapshot()` if the mutation does not commit.
+1. Capture affected `Shape_rec` / geom strings **before** mutating when needed for reverse.
+2. Mutate; capture results.
+3. `push_undo_delta(std::make_unique<Shape_*_delta>(...))` on success only.
 
-Prefer pushing only when work will actually happen (see `create_sketch_from_planar_face_` guard).
+### Sketch add/remove or underlay
+
+Use `Sketch_struct_delta` or `Underlay_delta` (see GUI underlay helpers `begin_underlay_undo_` / `commit_underlay_undo_` / `push_underlay_change_`).
 
 ### New delta subclass
 
 1. Subclass `Delta` in a dedicated header/source pair.
 2. Implement `apply_forward`, `apply_reverse`, and `clone`.
-3. Push via `push_undo_delta(std::make_unique<Your_delta>(...))`.
+3. Push via `push_undo_delta`.
 4. Document the new type here and in the owning module doc.
 
-Today only sketch edits justify a delta; shape booleans and transforms remain JSON snapshots.
+Prefer typed deltas over `push_undo_snapshot()` for interactive edits.
 
 ## Related docs
 
-- [sketch.md](sketch.md) — sketch coordinator, stable ids, recorder usage in tools
-- [shape.md](shape.md) — shape operations that push JSON snapshots
-- [gui.md](gui.md) — input routing, mode switching restored on undo
+- [sketch.md](sketch.md) -- sketch coordinator, stable ids, recorder usage
+- [shape.md](shape.md) -- shape operations and shape-id undo
+- [gui.md](gui.md) -- input routing, mode switching restored on undo

--- a/src/doc/undo-redo.md
+++ b/src/doc/undo-redo.md
@@ -110,12 +110,12 @@ See [`Sketch_op_recorder`](../sketch_op_recorder.h) / `Sketch_op_delta` (unchang
 
 | Type                  | Stores                                       | Used for                                       |
 | --------------------- | -------------------------------------------- | ---------------------------------------------- |
-| `Shape_add_delta`     | Added `Shape_rec` list (id, name, mat, BREP) | Primitives, extrude, revolve, STEP/PLY import  |
+| `Shape_add_delta`     | Added `Shape_rec` list (id, name, mat, geom) | Primitives, extrude, revolve, STEP/PLY import  |
 | `Shape_remove_delta`  | Removed `Shape_rec` list                     | Delete selection (shapes only)                 |
-| `Shape_geom_delta`    | Per-id before/after BREP                     | Move / rotate / scale finalize                 |
+| `Shape_geom_delta`    | Per-id before/after `TopoDS_Shape`           | Move / rotate / scale finalize                 |
 | `Shape_replace_delta` | Removed + added `Shape_rec` lists            | Fuse / cut / common / fillet / chamfer / polar |
 
-`Shape_rec` is BREP text plus attrs for one shape. Helpers: `capture_shape_rec`, `Occt_view::insert_shape_rec` / `remove_shape_by_id` / `set_shape_geom_by_id`.
+`Shape_rec` holds a shared `TopoDS_Shape` plus attrs (not BREP text). File I/O still serializes BREP in project JSON. Helpers: `capture_shape_rec`, `Occt_view::insert_shape_rec` / `remove_shape_by_id` / `set_shape_geom_by_id`.
 
 ### Document deltas ([`doc_delta.h`](../doc_delta.h))
 
@@ -198,7 +198,7 @@ Hotkeys are handled in `GUI::on_key` (`gui_mode.cpp`) when dist/angle edit popup
 
 ### Shape change
 
-1. Capture affected `Shape_rec` / geom strings **before** mutating when needed for reverse.
+1. Capture affected `Shape_rec` / `TopoDS_Shape` **before** mutating when needed for reverse.
 2. Mutate; capture results.
 3. `push_undo_delta(std::make_unique<Shape_*_delta>(...))` on success only.
 

--- a/src/doc/utility.md
+++ b/src/doc/utility.md
@@ -133,9 +133,8 @@ Symmetric `to_json` / `from_json_*` for `gp_Pnt2d`, `gp_Pnt`, `gp_Dir`, `gp_Pln`
 
 ```cpp
 Status Shp_fuse::selected_fuse() {
-  view().push_undo_snapshot();
   CHK_RET(ensure_operation_multi_shps_());
-  // ...
+  // ... mutate, then push Shape_replace_delta on success (see undo-redo.md)
   return Status::ok();
 }
 ```

--- a/src/doc_delta.cpp
+++ b/src/doc_delta.cpp
@@ -1,0 +1,128 @@
+#include "doc_delta.h"
+
+#include "gui_occt_view.h"
+#include "sketch.h"
+#include "sketch_json.h"
+#include "utl.h"
+
+Sketch_struct_delta::Sketch_struct_delta(Kind kind, nlohmann::json sketch_json, bool was_current,
+                                         std::optional<nlohmann::json> auto_created_default_json)
+    : m_kind(kind)
+    , m_sketch_json(std::move(sketch_json))
+    , m_was_current(was_current)
+    , m_auto_created_default_json(std::move(auto_created_default_json))
+{
+}
+
+void Sketch_struct_delta::add_sketch_(Occt_view& view, const nlohmann::json& sketch_json, bool make_current) const
+{
+  view.undo_insert_sketch(sketch_json, make_current);
+}
+
+void Sketch_struct_delta::remove_sketch_by_id_(Occt_view& view, size_t sketch_id) const
+{
+  view.undo_remove_sketch(sketch_id);
+}
+
+void Sketch_struct_delta::apply_forward(Occt_view& view)
+{
+  if (m_kind == Kind::Add)
+  {
+    add_sketch_(view, m_sketch_json, m_was_current);
+    return;
+  }
+
+  const size_t id = m_sketch_json["id"].get<size_t>();
+  remove_sketch_by_id_(view, id);
+  if (m_auto_created_default_json)
+    add_sketch_(view, *m_auto_created_default_json, true);
+}
+
+void Sketch_struct_delta::apply_reverse(Occt_view& view)
+{
+  if (m_kind == Kind::Add)
+  {
+    const size_t id = m_sketch_json["id"].get<size_t>();
+    remove_sketch_by_id_(view, id);
+    if (view.get_sketches().empty())
+      view.ensure_current_sketch_for_undo();
+
+    return;
+  }
+
+  if (m_auto_created_default_json)
+    remove_sketch_by_id_(view, (*m_auto_created_default_json)["id"].get<size_t>());
+
+  add_sketch_(view, m_sketch_json, m_was_current);
+}
+
+std::unique_ptr<Delta> Sketch_struct_delta::clone() const
+{
+  return std::make_unique<Sketch_struct_delta>(m_kind, m_sketch_json, m_was_current, m_auto_created_default_json);
+}
+
+Underlay_delta::Underlay_delta(size_t sketch_id, nlohmann::json before, nlohmann::json after)
+    : m_sketch_id(sketch_id)
+    , m_before(std::move(before))
+    , m_after(std::move(after))
+{
+}
+
+void Underlay_delta::apply_json_(Occt_view& view, const nlohmann::json& j) const
+{
+  for (const auto& sketch : view.get_sketches())
+  {
+    if (sketch->get_id() != m_sketch_id)
+      continue;
+
+    Sketch_underlay& ul = sketch->underlay();
+    if (j.is_null() || (j.is_object() && j.empty()))
+    {
+      ul.clear_and_update();
+      return;
+    }
+
+    if (!ul.from_json(j, view.asset_store()))
+      ul.clear_and_update();
+    else
+      ul.rebuild_display(sketch->get_plane(), sketch->is_visible());
+
+    return;
+  }
+}
+
+void Underlay_delta::apply_forward(Occt_view& view) { apply_json_(view, m_after); }
+
+void Underlay_delta::apply_reverse(Occt_view& view) { apply_json_(view, m_before); }
+
+std::unique_ptr<Delta> Underlay_delta::clone() const
+{
+  return std::make_unique<Underlay_delta>(m_sketch_id, m_before, m_after);
+}
+
+Composite_delta::Composite_delta(std::vector<std::unique_ptr<Delta>> parts)
+    : m_parts(std::move(parts))
+{
+}
+
+void Composite_delta::apply_forward(Occt_view& view)
+{
+  for (std::unique_ptr<Delta>& part : m_parts)
+    part->apply_forward(view);
+}
+
+void Composite_delta::apply_reverse(Occt_view& view)
+{
+  for (auto it = m_parts.rbegin(); it != m_parts.rend(); ++it)
+    (*it)->apply_reverse(view);
+}
+
+std::unique_ptr<Delta> Composite_delta::clone() const
+{
+  std::vector<std::unique_ptr<Delta>> copies;
+  copies.reserve(m_parts.size());
+  for (const std::unique_ptr<Delta>& part : m_parts)
+    copies.push_back(part->clone());
+
+  return std::make_unique<Composite_delta>(std::move(copies));
+}

--- a/src/doc_delta.h
+++ b/src/doc_delta.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "delta.h"
+
+#include <cstdint>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+/// Add or remove one sketch (full per-sketch JSON), without copying the whole document.
+class Sketch_struct_delta : public Delta
+{
+public:
+  enum class Kind
+  {
+    Add,
+    Remove
+  };
+
+  Sketch_struct_delta(Kind kind, nlohmann::json sketch_json, bool was_current,
+                      std::optional<nlohmann::json> auto_created_default_json = std::nullopt);
+
+  void                   apply_forward(Occt_view& view) override;
+  void                   apply_reverse(Occt_view& view) override;
+  std::unique_ptr<Delta> clone() const override;
+
+private:
+  void add_sketch_(Occt_view& view, const nlohmann::json& sketch_json, bool make_current) const;
+  void remove_sketch_by_id_(Occt_view& view, size_t sketch_id) const;
+
+  Kind                          m_kind;
+  nlohmann::json                m_sketch_json;
+  bool                          m_was_current{false};
+  std::optional<nlohmann::json> m_auto_created_default_json;
+};
+
+/// Underlay placement / image change on one sketch (asset pixels stay in the store).
+class Underlay_delta : public Delta
+{
+public:
+  Underlay_delta(size_t sketch_id, nlohmann::json before, nlohmann::json after);
+
+  void                   apply_forward(Occt_view& view) override;
+  void                   apply_reverse(Occt_view& view) override;
+  std::unique_ptr<Delta> clone() const override;
+
+private:
+  void apply_json_(Occt_view& view, const nlohmann::json& j) const;
+
+  size_t         m_sketch_id{0};
+  nlohmann::json m_before;
+  nlohmann::json m_after;
+};
+
+/// Runs child deltas in order (forward) / reverse order (reverse).
+class Composite_delta : public Delta
+{
+public:
+  explicit Composite_delta(std::vector<std::unique_ptr<Delta>> parts);
+
+  void                   apply_forward(Occt_view& view) override;
+  void                   apply_reverse(Occt_view& view) override;
+  std::unique_ptr<Delta> clone() const override;
+
+private:
+  std::vector<std::unique_ptr<Delta>> m_parts;
+};

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -27,6 +27,7 @@
 #include "utl_log.h"
 #include "scr_lua_console.h"
 #include "gui_occt_view.h"
+#include "doc_delta.h"
 #include "utl_io.h"
 #include "scr_python_console.h"
 #include "shp_info.h"
@@ -1622,8 +1623,9 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
   if (ImGui::Button("Remove underlay"))
     if (ul.has_image())
     {
-      m_view->push_undo_snapshot();
+      const nlohmann::json before = ul.to_json(m_view->asset_store());
       ul.clear_and_update();
+      push_underlay_change_(*sk, before);
       m_underlay_panel_sketch = nullptr;
     }
 
@@ -1805,7 +1807,9 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
       {
         const bool changed = ImGui::SliderScalar(label, type, p_data, p_min, p_max, format, flags);
         if (ImGui::IsItemActivated())
-          m_view->push_undo_snapshot();
+          begin_underlay_undo_(*sk);
+        if (ImGui::IsItemDeactivatedAfterEdit())
+          commit_underlay_undo_(*sk);
 
         if (changed)
           apply_ul_xform();
@@ -1815,7 +1819,9 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
       {
         const bool changed = ImGui::InputDouble(label, p_data, 0.0, 0.0, format);
         if (ImGui::IsItemActivated())
-          m_view->push_undo_snapshot();
+          begin_underlay_undo_(*sk);
+        if (ImGui::IsItemDeactivatedAfterEdit())
+          commit_underlay_undo_(*sk);
 
         if (changed)
         {
@@ -1897,7 +1903,9 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
         const bool changed = ImGui::SliderScalar("Base X", ImGuiDataType_Double, &m_underlay_base.x, &min_u, &max_u, "%.4f",
                                                  ImGuiSliderFlags_ClampOnInput);
         if (ImGui::IsItemActivated())
-          m_view->push_undo_snapshot();
+          begin_underlay_undo_(*sk);
+        if (ImGui::IsItemDeactivatedAfterEdit())
+          commit_underlay_undo_(*sk);
         if (changed)
           apply_affine();
       }
@@ -1906,7 +1914,9 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
         const bool changed = ImGui::SliderScalar("Base Y", ImGuiDataType_Double, &m_underlay_base.y, &min_v, &max_v, "%.4f",
                                                  ImGuiSliderFlags_ClampOnInput);
         if (ImGui::IsItemActivated())
-          m_view->push_undo_snapshot();
+          begin_underlay_undo_(*sk);
+        if (ImGui::IsItemDeactivatedAfterEdit())
+          commit_underlay_undo_(*sk);
         if (changed)
           apply_affine();
       }
@@ -1915,7 +1925,9 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
       {
         const bool changed = ImGui::InputDouble(label, p_data, 0.0, 0.0, "%.4f");
         if (ImGui::IsItemActivated())
-          m_view->push_undo_snapshot();
+          begin_underlay_undo_(*sk);
+        if (ImGui::IsItemDeactivatedAfterEdit())
+          commit_underlay_undo_(*sk);
 
         if (changed)
           apply_affine();
@@ -1954,8 +1966,9 @@ void GUI::sketch_underlay_panel_settings_(const Sketch::sptr& sk)
 
       if (ImGui::Button("Make orthogonal (keep lengths + U direction)"))
       {
-        m_view->push_undo_snapshot();
+        const nlohmann::json before = sk->underlay().to_json(m_view->asset_store());
         force_underlay_orthogonal_(sk);
+        push_underlay_change_(*sk, before);
       }
 
       if (ui_show_contextual_help() && ImGui::IsItemHovered())
@@ -1972,8 +1985,8 @@ void GUI::on_sketch_underlay_file(const std::string& file_path, const std::strin
   if (!sk)
     sk = m_view->curr_sketch_shared();
 
-  m_view->push_undo_snapshot();
-  uint8_t hr, hg, hb, ha;
+  const nlohmann::json before = sk->underlay().to_json(m_view->asset_store());
+  uint8_t              hr, hg, hb, ha;
   underlay_highlight_color_rgba(hr, hg, hb, ha);
   if (!sk->underlay().load_from_file_bytes(file_bytes, m_view->asset_store(), hr, hg, hb, ha, sk->get_plane(),
                                            sk->is_visible()))
@@ -1982,6 +1995,7 @@ void GUI::on_sketch_underlay_file(const std::string& file_path, const std::strin
     return;
   }
 
+  push_underlay_change_(*sk, before);
   m_underlay_calib_x_done = false;
   m_underlay_calib_y_done = false;
   m_underlay_panel_sketch = nullptr;
@@ -1994,6 +2008,37 @@ void GUI::cancel_underlay_calib_()
   m_underlay_calib_phase = Underlay_calib_phase::None;
 
   m_underlay_calib_sketch_wk.reset();
+}
+
+void GUI::begin_underlay_undo_(Sketch& sk)
+{
+  m_underlay_undo_before     = sk.underlay().to_json(m_view->asset_store());
+  m_underlay_undo_sketch_id  = sk.get_id();
+}
+
+void GUI::commit_underlay_undo_(Sketch& sk)
+{
+  if (!m_underlay_undo_before)
+    return;
+
+  const nlohmann::json after = sk.underlay().to_json(m_view->asset_store());
+  if (after == *m_underlay_undo_before)
+  {
+    m_underlay_undo_before.reset();
+    return;
+  }
+
+  m_view->push_undo_delta(std::make_unique<Underlay_delta>(m_underlay_undo_sketch_id, *m_underlay_undo_before, after));
+  m_underlay_undo_before.reset();
+}
+
+void GUI::push_underlay_change_(Sketch& sk, const nlohmann::json& before)
+{
+  const nlohmann::json after = sk.underlay().to_json(m_view->asset_store());
+  if (after == before)
+    return;
+
+  m_view->push_undo_delta(std::make_unique<Underlay_delta>(sk.get_id(), before, after));
 }
 
 void GUI::force_underlay_orthogonal_(const Sketch::sptr& sk)
@@ -2098,11 +2143,10 @@ void GUI::underlay_calib_prompt_x_distance_(const Sketch::sptr& sk)
       return;
     }
 
-    m_view->push_undo_snapshot();
+    const nlohmann::json before = s->underlay().to_json(m_view->asset_store());
     if (!s->underlay().rescale_uv_chord_to_length(m_underlay_calib_x0, m_underlay_calib_x1, Dx, s->get_plane(),
                                                   s->is_visible()))
     {
-      m_view->pop_undo_snapshot();
       show_message("Could not calibrate X (underlay axes degenerate or segment too short).");
       return;
     }
@@ -2115,6 +2159,8 @@ void GUI::underlay_calib_prompt_x_distance_(const Sketch::sptr& sk)
 
     if (m_underlay_calib_x_done && m_underlay_calib_y_done)
       force_underlay_orthogonal_(s);
+
+    push_underlay_change_(*s, before);
 
     m_dist_callback        = nullptr;
     m_underlay_calib_phase = Underlay_calib_phase::None;
@@ -2156,10 +2202,9 @@ void GUI::underlay_calib_prompt_y_distance_(const Sketch::sptr& sk)
       return;
     }
 
-    m_view->push_undo_snapshot();
+    const nlohmann::json before = s->underlay().to_json(m_view->asset_store());
     if (!s->underlay().rescale_v_chord_to_length(m_underlay_calib_y0, m_underlay_calib_y1, Dy, s->get_plane(), s->is_visible()))
     {
-      m_view->pop_undo_snapshot();
       show_message("Set Y: picks need a clear span along image height (not along the same edge as X only). Try two points "
                    "further apart in V.");
       return;
@@ -2173,6 +2218,8 @@ void GUI::underlay_calib_prompt_y_distance_(const Sketch::sptr& sk)
 
     if (m_underlay_calib_x_done && m_underlay_calib_y_done)
       force_underlay_orthogonal_(s);
+
+    push_underlay_change_(*s, before);
 
     m_dist_callback = nullptr;
     cancel_underlay_calib_();

--- a/src/gui.h
+++ b/src/gui.h
@@ -25,6 +25,8 @@
 #include "shp_info.h"
 #include "utl_types.h"
 
+#include <nlohmann/json.hpp>
+
 class Lua_console;
 class Python_console;
 class Sketch;
@@ -661,6 +663,13 @@ private:
   glm::vec4  m_underlay_tint_col{1.f, 220.f / 255.f, 0.f, 1.f};
   /// Default underlay tint for new imports (0-1, persisted in ezycad_settings.json).
   glm::vec4 m_underlay_highlight_color{0.639830f, 0.561988f, 0.311782f, 1.f};
+
+  /// Stash underlay JSON before a slider drag; commit on deactivate.
+  std::optional<nlohmann::json> m_underlay_undo_before;
+  size_t                        m_underlay_undo_sketch_id{0};
+  void                          begin_underlay_undo_(Sketch& sk);
+  void                          commit_underlay_undo_(Sketch& sk);
+  void                          push_underlay_change_(Sketch& sk, const nlohmann::json& before);
   /// Shape List hover highlight in the OCCT view (0-1, persisted in ezycad_settings.json).
   glm::vec4 m_elm_list_hover_color{0.402064f, 0.102557f, 0.474576f, 1.f};
 

--- a/src/gui_occt_view.cpp
+++ b/src/gui_occt_view.cpp
@@ -945,8 +945,7 @@ Shp_ptr Occt_view::find_shape_by_id(Shape_id id) const
 
 void Occt_view::insert_shape_rec(const Shape_rec& rec)
 {
-  TopoDS_Shape shape = shape_from_brep_string(rec.geom);
-  Shp_ptr      shp   = new Shp(*m_ctx, shape);
+  Shp_ptr shp = new Shp(*m_ctx, rec.geom);
   shp->set_id(rec.id);
   adopt_shape_id(rec.id);
   shp->set_name(rec.name);

--- a/src/gui_occt_view.cpp
+++ b/src/gui_occt_view.cpp
@@ -45,11 +45,13 @@
 
 #include "utl_dbg.h"
 #include "delta.h"
+#include "doc_delta.h"
 #include "utl_geom.h"
 #include "gui.h"
 #include "utl_ply_io.h"
 #include "shp.h"
 #include "shp_create.h"
+#include "shp_delta.h"
 #include "sketch.h"
 #include "sketch_ais.h"
 #include "sketch_json.h"
@@ -554,11 +556,11 @@ void Occt_view::cancel(Set_parent_mode set_parent_mode)
 // Revolve related
 void Occt_view::revolve_selected(const double angle)
 {
-  push_undo_snapshot();
   Shp_rslt revolved = curr_sketch().revolve_selected(angle);
   if (revolved.has_value())
   {
     add_shp_(*revolved);
+    push_undo_delta(std::make_unique<Shape_add_delta>(std::vector<Shape_rec>{capture_shape_rec(**revolved)}));
     // Switch to none mode because displaying shapes in sketch modes is disabled.
     gui().set_mode(Mode::Normal);
   }
@@ -576,8 +578,6 @@ void Occt_view::create_sketch_from_planar_face_(const ScreenCoords& screen_coord
   {
     if (auto pln = plane_from_face(*face); pln)
     {
-      // Push only when we will create a sketch (avoids no-op undo on misclick).
-      push_undo_snapshot();
       // Get the outer wire of the face
       TopoDS_Wire outer_wire = BRepTools::OuterWire(*face);
       EZY_ASSERT(!outer_wire.IsNull());
@@ -585,6 +585,8 @@ void Occt_view::create_sketch_from_planar_face_(const ScreenCoords& screen_coord
       m_sketches.push_back(m_cur_sketch);
       m_cur_sketch->set_current();
       refresh_viewer_grid_();
+      push_undo_delta(std::make_unique<Sketch_struct_delta>(
+          Sketch_struct_delta::Kind::Add, Sketch_json::to_json(*m_cur_sketch, m_assets), true));
       // fit_face_in_view(*face);
       m_gui.set_mode(Mode::Sketch_inspection_mode);
     }
@@ -597,7 +599,7 @@ void Occt_view::create_sketch_from_planar_face_(const ScreenCoords& screen_coord
 
 void Occt_view::finalize_sketch_extrude_()
 {
-  push_undo_snapshot();
+  // Extrude finalize pushes Shape_add_delta after the solid is registered.
   m_shp_extrude.finalize();
 }
 
@@ -636,7 +638,6 @@ void Occt_view::ensure_current_sketch_()
 
 void Occt_view::add_sketch(const gp_Pln& pln, const std::string& base_name)
 {
-  push_undo_snapshot();
   std::vector<std::string> existing;
   existing.reserve(m_sketches.size());
   for (const Sketch_ptr& s : m_sketches)
@@ -647,6 +648,8 @@ void Occt_view::add_sketch(const gp_Pln& pln, const std::string& base_name)
   m_sketches.push_back(m_cur_sketch);
   m_cur_sketch->set_current();
   refresh_viewer_grid_();
+  push_undo_delta(std::make_unique<Sketch_struct_delta>(Sketch_struct_delta::Kind::Add,
+                                                         Sketch_json::to_json(*m_cur_sketch, m_assets), true));
   m_gui.set_mode(Mode::Sketch_inspection_mode);
 }
 
@@ -912,6 +915,9 @@ void Occt_view::refresh_shape_shading_(const Shp_ptr& shp)
 
 void Occt_view::add_shp_(Shp_ptr& shp)
 {
+  if (shp->get_id() == 0)
+    shp->set_id(allocate_shape_id());
+
   shp->SetMaterial(m_default_material);
   refresh_shape_shading_(shp);
   shp->set_selection_mode(m_shp_selection_mode);
@@ -919,6 +925,119 @@ void Occt_view::add_shp_(Shp_ptr& shp)
   m_ctx->UpdateCurrentViewer();
   m_shps.push_back(shp);
 }
+
+Shape_id Occt_view::allocate_shape_id() { return m_next_shape_id++; }
+
+void Occt_view::adopt_shape_id(Shape_id id)
+{
+  if (id >= m_next_shape_id)
+    m_next_shape_id = id + 1;
+}
+
+Shp_ptr Occt_view::find_shape_by_id(Shape_id id) const
+{
+  for (const Shp_ptr& s : m_shps)
+    if (!s.IsNull() && s->get_id() == id)
+      return s;
+
+  return Shp_ptr();
+}
+
+void Occt_view::insert_shape_rec(const Shape_rec& rec)
+{
+  TopoDS_Shape shape = shape_from_brep_string(rec.geom);
+  Shp_ptr      shp   = new Shp(*m_ctx, shape);
+  shp->set_id(rec.id);
+  adopt_shape_id(rec.id);
+  shp->set_name(rec.name);
+
+  const int nmat    = Graphic3d_MaterialAspect::NumberOfMaterials();
+  int       mat_idx = rec.material;
+  if (mat_idx < 0 || mat_idx >= nmat)
+    mat_idx = static_cast<int>(m_default_material.Name());
+
+  shp->SetMaterial(Graphic3d_MaterialAspect(static_cast<Graphic3d_NameOfMaterial>(mat_idx)));
+  refresh_shape_shading_(shp);
+  shp->set_selection_mode(m_shp_selection_mode);
+  m_shps.push_back(shp);
+  m_ctx->Display(shp, shp->get_disp_mode(), AIS_Shape::SelectionMode(m_shp_selection_mode), true);
+  m_ctx->Redisplay(shp, true);
+  m_ctx->UpdateCurrentViewer();
+}
+
+void Occt_view::remove_shape_by_id(Shape_id id)
+{
+  for (auto it = m_shps.begin(); it != m_shps.end(); ++it)
+  {
+    if ((*it).IsNull() || (*it)->get_id() != id)
+      continue;
+
+    Shp_ptr shp = *it;
+    if (m_shape_list_hover == shp)
+      set_shape_list_hover(nullptr);
+
+    m_ctx->Remove(shp, false);
+    m_shps.erase(it);
+    m_ctx->UpdateCurrentViewer();
+    return;
+  }
+}
+
+void Occt_view::set_shape_geom_by_id(Shape_id id, const TopoDS_Shape& geom)
+{
+  Shp_ptr shp = find_shape_by_id(id);
+  if (shp.IsNull())
+    return;
+
+  shp->Set(geom);
+  gp_Trsf identity;
+  shp->SetLocalTransformation(identity);
+  m_ctx->Redisplay(shp, true);
+  m_ctx->UpdateCurrentViewer();
+}
+
+void Occt_view::undo_insert_sketch(const nlohmann::json& sketch_json, bool make_current)
+{
+  Sketch_ptr sketch = Sketch_json::from_json(*this, sketch_json);
+  m_sketches.push_back(sketch);
+  if (make_current)
+  {
+    m_cur_sketch = sketch;
+    m_cur_sketch->set_current();
+  }
+
+  refresh_viewer_grid_();
+}
+
+void Occt_view::undo_remove_sketch(size_t sketch_id)
+{
+  for (auto it = m_sketches.begin(); it != m_sketches.end(); ++it)
+  {
+    if ((*it)->get_id() != sketch_id)
+      continue;
+
+    const Sketch_ptr sketch = *it;
+    if (m_sketch_list_hover == sketch)
+      set_sketch_list_hover(nullptr);
+
+    m_sketches.erase(it);
+    if (m_cur_sketch == sketch)
+    {
+      if (m_sketches.empty())
+        m_cur_sketch = nullptr;
+      else
+      {
+        m_cur_sketch = m_sketches.front();
+        m_cur_sketch->set_current();
+      }
+    }
+
+    refresh_viewer_grid_();
+    return;
+  }
+}
+
+void Occt_view::ensure_current_sketch_for_undo() { ensure_current_sketch_(); }
 
 std::string Occt_view::unique_shape_name_(const char* base_name) const
 {
@@ -934,18 +1053,17 @@ std::string Occt_view::get_unique_shape_name(const char* base_name) const { retu
 
 void Occt_view::add_box(double ox, double oy, double oz, double width, double length, double height)
 {
-  push_undo_snapshot();
   TopoDS_Shape box = shp_create::create_box(ox, oy, oz, width, length, height);
   Shp_ptr      shp = new Shp(*m_ctx, box);
   shp->set_name(unique_shape_name_("Box"));
   add_shp_(shp);
   m_ctx->Display(shp, shp->get_disp_mode(), AIS_Shape::SelectionMode(m_shp_selection_mode), true);
   m_view->Redraw();
+  push_undo_delta(std::make_unique<Shape_add_delta>(std::vector<Shape_rec>{capture_shape_rec(*shp)}));
 }
 
 void Occt_view::add_pyramid(double ox, double oy, double oz, double side)
 {
-  push_undo_snapshot();
   TopoDS_Shape pyramid = shp_create::create_pyramid(side);
   if (pyramid.IsNull())
     return;
@@ -961,12 +1079,18 @@ void Occt_view::add_pyramid(double ox, double oy, double oz, double side)
 
   add_shp_(shp);
   m_ctx->Display(shp, shp->get_disp_mode(), AIS_Shape::SelectionMode(m_shp_selection_mode), true);
+  if (ox != 0 || oy != 0 || oz != 0)
+  {
+    AIS_Shape_ptr ais = shp;
+    bake_transform_into_geometry(ais);
+  }
+
   m_view->Redraw();
+  push_undo_delta(std::make_unique<Shape_add_delta>(std::vector<Shape_rec>{capture_shape_rec(*shp)}));
 }
 
 void Occt_view::add_sphere(double ox, double oy, double oz, double radius)
 {
-  push_undo_snapshot();
   TopoDS_Shape sphere = shp_create::create_sphere(radius);
   Shp_ptr      shp    = new Shp(*m_ctx, sphere);
   shp->set_name(unique_shape_name_("Sphere"));
@@ -979,12 +1103,18 @@ void Occt_view::add_sphere(double ox, double oy, double oz, double radius)
 
   add_shp_(shp);
   m_ctx->Display(shp, shp->get_disp_mode(), AIS_Shape::SelectionMode(m_shp_selection_mode), true);
+  if (ox != 0 || oy != 0 || oz != 0)
+  {
+    AIS_Shape_ptr ais = shp;
+    bake_transform_into_geometry(ais);
+  }
+
   m_view->Redraw();
+  push_undo_delta(std::make_unique<Shape_add_delta>(std::vector<Shape_rec>{capture_shape_rec(*shp)}));
 }
 
 void Occt_view::add_cylinder(double ox, double oy, double oz, double radius, double height)
 {
-  push_undo_snapshot();
   TopoDS_Shape shape = shp_create::create_cylinder(radius, height);
   Shp_ptr      shp   = new Shp(*m_ctx, shape);
   shp->set_name(unique_shape_name_("Cylinder"));
@@ -997,12 +1127,18 @@ void Occt_view::add_cylinder(double ox, double oy, double oz, double radius, dou
 
   add_shp_(shp);
   m_ctx->Display(shp, shp->get_disp_mode(), AIS_Shape::SelectionMode(m_shp_selection_mode), true);
+  if (ox != 0 || oy != 0 || oz != 0)
+  {
+    AIS_Shape_ptr ais = shp;
+    bake_transform_into_geometry(ais);
+  }
+
   m_view->Redraw();
+  push_undo_delta(std::make_unique<Shape_add_delta>(std::vector<Shape_rec>{capture_shape_rec(*shp)}));
 }
 
 void Occt_view::add_cone(double ox, double oy, double oz, double R1, double R2, double height)
 {
-  push_undo_snapshot();
   TopoDS_Shape shape = shp_create::create_cone(R1, R2, height);
   Shp_ptr      shp   = new Shp(*m_ctx, shape);
   shp->set_name(unique_shape_name_("Cone"));
@@ -1015,12 +1151,18 @@ void Occt_view::add_cone(double ox, double oy, double oz, double R1, double R2, 
 
   add_shp_(shp);
   m_ctx->Display(shp, shp->get_disp_mode(), AIS_Shape::SelectionMode(m_shp_selection_mode), true);
+  if (ox != 0 || oy != 0 || oz != 0)
+  {
+    AIS_Shape_ptr ais = shp;
+    bake_transform_into_geometry(ais);
+  }
+
   m_view->Redraw();
+  push_undo_delta(std::make_unique<Shape_add_delta>(std::vector<Shape_rec>{capture_shape_rec(*shp)}));
 }
 
 void Occt_view::add_torus(double ox, double oy, double oz, double R1, double R2)
 {
-  push_undo_snapshot();
   TopoDS_Shape shape = shp_create::create_torus(R1, R2);
   Shp_ptr      shp   = new Shp(*m_ctx, shape);
   shp->set_name(unique_shape_name_("Torus"));
@@ -1033,7 +1175,14 @@ void Occt_view::add_torus(double ox, double oy, double oz, double R1, double R2)
 
   add_shp_(shp);
   m_ctx->Display(shp, shp->get_disp_mode(), AIS_Shape::SelectionMode(m_shp_selection_mode), true);
+  if (ox != 0 || oy != 0 || oz != 0)
+  {
+    AIS_Shape_ptr ais = shp;
+    bake_transform_into_geometry(ais);
+  }
+
   m_view->Redraw();
+  push_undo_delta(std::make_unique<Shape_add_delta>(std::vector<Shape_rec>{capture_shape_rec(*shp)}));
 }
 
 bool Occt_view::fit_face_in_view(const TopoDS_Face& face)
@@ -1162,7 +1311,21 @@ void Occt_view::delete_shapes(std::vector<AIS_Shape_ptr> to_delete)
   if (to_delete.empty())
     return;
 
-  push_undo_snapshot();
+  std::vector<Shape_rec> removed_shapes;
+  bool                   has_non_shape = false;
+  for (const AIS_Shape_ptr& obj : to_delete)
+  {
+    if (Shp_ptr shp = Shp_ptr::DownCast(obj); !shp.IsNull())
+      removed_shapes.push_back(capture_shape_rec(*shp));
+    else
+      has_non_shape = true;
+  }
+
+  if (has_non_shape)
+    push_undo_snapshot();
+  else if (!removed_shapes.empty())
+    push_undo_delta(std::make_unique<Shape_remove_delta>(std::move(removed_shapes)));
+
   remove_selected_length_dimensions_from_sketches_();
   delete_(to_delete);
   cancel(Set_parent_mode::No); // In case we are in the middle of a operation.
@@ -2149,18 +2312,26 @@ void Occt_view::remove_sketch(const Sketch_ptr& sketch)
   if (m_sketch_list_hover == sketch)
     set_sketch_list_hover(nullptr);
 
-  push_undo_snapshot();
+  const bool           was_current = (m_cur_sketch == sketch);
+  const nlohmann::json removed_json = Sketch_json::to_json(*sketch, m_assets);
+
   m_sketches.remove(sketch);
+  std::optional<nlohmann::json> auto_default;
   if (m_cur_sketch == sketch)
   {
     if (m_sketches.empty())
     {
       m_cur_sketch = nullptr;
       create_default_sketch_();
+      auto_default = Sketch_json::to_json(*m_cur_sketch, m_assets);
     }
     else
       m_cur_sketch = m_sketches.front();
   }
+
+  push_undo_delta(std::make_unique<Sketch_struct_delta>(Sketch_struct_delta::Kind::Remove, removed_json, was_current,
+                                                         std::move(auto_default)));
+  refresh_viewer_grid_();
 }
 
 Sketch& Occt_view::curr_sketch()
@@ -2216,7 +2387,7 @@ Shp_extrude&   Occt_view::shp_extrude()   { return m_shp_extrude;    }
 // clang-format on
 
 // ---------------------------------------------------------------------------
-// Undo / redo: sketch edits use element deltas; other operations use full JSON snapshots.
+// Undo / redo: interactive edits use typed deltas; JSON snapshots for mixed delete / file open.
 void Occt_view::push_undo_snapshot()
 {
   if (m_restoring)
@@ -2355,6 +2526,7 @@ std::string Occt_view::to_json() const
     std::ostringstream  oss;
     BRepTools::Write(shape, oss, false, false, TopTools_FormatVersion_CURRENT); // Write BREP data to the stream
     json shp_json;
+    shp_json["id"]       = s->get_id();
     shp_json["name"]     = s->get_name();
     shp_json["material"] = s->Material();
     shp_json["geom"]     = oss.str();
@@ -2406,6 +2578,8 @@ void Occt_view::load(const std::string& json_str, bool restore_view)
     m_redo_stack.clear();
   }
 
+  m_next_shape_id = 1;
+
   const json j = json::parse(json_str);
   (void)j.value("ezyFormat", 1); // Reserved for future migrations; sketch JSON migrates per-edge dim flags in Sketch_json.
   EZY_ASSERT(j.contains("sketches") && j["sketches"].is_array());
@@ -2430,6 +2604,14 @@ void Occt_view::load(const std::string& json_str, bool restore_view)
     iss.str(s["geom"]);
     BRepTools::Read(shape, iss, BRep_Builder());
     Shp_ptr shp = new Shp(*m_ctx, shape);
+    if (s.contains("id") && s["id"].is_number_unsigned())
+    {
+      shp->set_id(s["id"].get<Shape_id>());
+      adopt_shape_id(shp->get_id());
+    }
+    else
+      shp->set_id(allocate_shape_id());
+
     shp->set_name(s["name"]);
     int mat_idx = static_cast<int>(m_default_material.Name());
     if (s.contains("material") && s["material"].is_number_integer())
@@ -2632,19 +2814,21 @@ Status Occt_view::import_step(const std::string& step_data)
   if (to_add.empty())
     return Status::user_error("STEP: no valid shapes in file.");
 
-  push_undo_snapshot();
+  std::vector<Shape_rec> added;
+  added.reserve(to_add.size());
   for (const TopoDS_Shape& shape : to_add)
   {
     Shp_ptr shp = new Shp(*m_ctx, shape);
     add_shp_(shp);
+    added.push_back(capture_shape_rec(*shp));
   }
 
+  push_undo_delta(std::make_unique<Shape_add_delta>(std::move(added)));
   return Status::ok();
 }
 
 bool Occt_view::import_ply(const std::string& ply_bytes)
 {
-  push_undo_snapshot();
   TopoDS_Shape shape;
   if (Status st = import_ply_shape(ply_bytes, shape); !st.is_ok())
   {
@@ -2656,6 +2840,7 @@ bool Occt_view::import_ply(const std::string& ply_bytes)
 
   Shp_ptr shp = new Shp(*m_ctx, shape);
   add_shp_(shp);
+  push_undo_delta(std::make_unique<Shape_add_delta>(std::vector<Shape_rec>{capture_shape_rec(*shp)}));
   return true;
 }
 
@@ -2671,6 +2856,7 @@ void Occt_view::new_file()
   clear_all(m_shps, m_sketches, m_cur_sketch);
   m_assets.clear();
   m_next_sketch_id = 1;
+  m_next_shape_id  = 1;
 
   create_default_sketch_();
   refresh_viewer_grid_();

--- a/src/gui_occt_view.h
+++ b/src/gui_occt_view.h
@@ -29,9 +29,12 @@
 #include "utl_asset_store.h"
 #include "utl_geom.h"
 
+#include <nlohmann/json.hpp>
+
 class Delta;
 class GUI;
 class Sketch;
+struct Shape_rec;
 struct Sketch_annotation_refresh;
 struct Length_dimension_style;
 class Prs3d_Drawer;
@@ -94,10 +97,10 @@ public:
   /// Writes STEP, IGES, binary STL, or PLY to \a file_path. Uses selected shapes if any, else all shapes.
   [[nodiscard]] Status export_document(Export_format fmt, const std::string& file_path);
 
-  // Undo / redo (delta steps for sketch edits; full JSON snapshot for other operations).
-  /// Saves current document (full JSON) and mode.
+  // Undo / redo (element deltas for edits; full JSON only for file-open checkpoint).
+  /// Saves current document (full JSON) and mode. Prefer typed deltas for interactive edits.
   void push_undo_snapshot();
-  /// Records a sketch element delta (added/removed nodes and edges).
+  /// Records an element/document delta (sketch, shape, underlay, etc.).
   void push_undo_delta(std::unique_ptr<Delta> delta);
   /// Removes the last snapshot without restoring (e.g. aborted edit that did not change the document).
   void   pop_undo_snapshot();
@@ -107,6 +110,23 @@ public:
   bool   can_redo() const;
   size_t undo_stack_size() const;
   size_t redo_stack_size() const;
+
+  Shape_id allocate_shape_id();
+  void     adopt_shape_id(Shape_id id);
+  Shp_ptr  find_shape_by_id(Shape_id id) const;
+  /// Insert a shape from an undo snapshot (keeps \a rec.id). Displays in the viewer.
+  void insert_shape_rec(const Shape_rec& rec);
+  /// Remove a shape by stable id (viewer + document list).
+  void remove_shape_by_id(Shape_id id);
+  /// Replace BREP of an existing shape (identity local transform).
+  void set_shape_geom_by_id(Shape_id id, const TopoDS_Shape& geom);
+
+  /// Insert a sketch from JSON for undo/redo (adopts sketch id from JSON).
+  void undo_insert_sketch(const nlohmann::json& sketch_json, bool make_current);
+  /// Remove a sketch by id for undo/redo (does not auto-create a default sketch).
+  void undo_remove_sketch(size_t sketch_id);
+  /// Ensure there is a current sketch after undo left the list empty.
+  void ensure_current_sketch_for_undo();
 
   void do_frame();
   /// Apply pending navigation (pan/zoom/rotate) to the camera before UI uses view projection (e.g. underlay slider bounds).
@@ -354,6 +374,7 @@ private:
   std::vector<Undo_entry> m_redo_stack;
   bool                    m_restoring{false};
   size_t                  m_next_sketch_id{1};
+  Shape_id                m_next_shape_id{1};
   Ezy_asset_store         m_assets;
 
   // --------------------------------------------------------------------

--- a/src/shp.cpp
+++ b/src/shp.cpp
@@ -5,6 +5,7 @@
 Shp::Shp(AIS_InteractiveContext& ctx, const TopoDS_Shape& shp)
     : AIS_Shape(shp)
     , m_ctx(ctx)
+    , m_id(0)
     , m_name("Shape")
     , m_disp_mode(AIS_Shaded)
     , m_visible(true)
@@ -13,6 +14,10 @@ Shp::Shp(AIS_InteractiveContext& ctx, const TopoDS_Shape& shp)
 }
 
 Shp::~Shp() {}
+
+Shape_id Shp::get_id() const { return m_id; }
+
+void Shp::set_id(Shape_id id) { m_id = id; }
 
 const std::string& Shp::get_name() const { return m_name; }
 

--- a/src/shp.h
+++ b/src/shp.h
@@ -2,10 +2,13 @@
 
 #include <AIS_Shape.hxx>
 #include <AIS_DisplayMode.hxx>
+#include <cstdint>
 
 #include "utl.h"
 
 class AIS_InteractiveContext;
+
+using Shape_id = uint64_t;
 
 class Shp : public AIS_Shape
 {
@@ -13,6 +16,8 @@ public:
   Shp(AIS_InteractiveContext& ctx, const TopoDS_Shape& shp);
   virtual ~Shp();
 
+  Shape_id           get_id() const;
+  void               set_id(Shape_id id);
   const std::string& get_name() const;
   void               set_name(const std::string& name);
   AIS_DisplayMode    get_disp_mode() const;
@@ -25,6 +30,7 @@ protected:
   void update_display_();
 
   AIS_InteractiveContext& m_ctx;
+  Shape_id                m_id{0};
   std::string             m_name;
   AIS_DisplayMode         m_disp_mode;
   bool                    m_visible;

--- a/src/shp_chamfer.cpp
+++ b/src/shp_chamfer.cpp
@@ -9,6 +9,7 @@
 
 #include "mode.h"
 #include "gui_occt_view.h"
+#include "shp_delta.h"
 #include "utl_occt.h"
 
 Shp_chamfer::Shp_chamfer(Occt_view& view)
@@ -18,10 +19,11 @@ Shp_chamfer::Shp_chamfer(Occt_view& view)
 
 Status Shp_chamfer::add_chamfer(const ScreenCoords& screen_coords, const Chamfer_mode chamfer_mode)
 {
-  view().push_undo_snapshot();
   Shp_ptr chamfer_src_shp = Shp_ptr::DownCast(get_shape_(screen_coords));
   if (chamfer_src_shp.IsNull())
     return Status::user_error("Click on a shape.");
+
+  const Shape_rec removed = capture_shape_rec(*chamfer_src_shp);
 
   BRepFilletAPI_MakeChamfer chamfer_maker(chamfer_src_shp->Shape());
 
@@ -97,6 +99,8 @@ Status Shp_chamfer::add_chamfer(const ScreenCoords& screen_coords, const Chamfer
     chamfer_maker.Build();
     Shp_ptr chamfer_shp = new Shp(ctx(), chamfer_maker.Shape());
     replace_picked_shape_(chamfer_src_shp, chamfer_shp, "Chamfered shape");
+    view().push_undo_delta(std::make_unique<Shape_replace_delta>(std::vector<Shape_rec>{removed},
+                                                                  std::vector<Shape_rec>{capture_shape_rec(*chamfer_shp)}));
   }
   catch (const Standard_Failure& e)
   {

--- a/src/shp_common.cpp
+++ b/src/shp_common.cpp
@@ -3,6 +3,7 @@
 #include <BRepAlgoAPI_Common.hxx>
 
 #include "gui_occt_view.h"
+#include "shp_delta.h"
 #include "utl.h"
 
 Shp_common::Shp_common(Occt_view& view)
@@ -19,8 +20,12 @@ Shp_rslt Shp_common::common(std::vector<Shp_ptr> shps)
     if (shp.IsNull())
       return Shp_rslt(Result_status::User_error, "common: null shape");
 
-  view().push_undo_snapshot();
   m_shps = std::move(shps);
+
+  std::vector<Shape_rec> removed;
+  removed.reserve(m_shps.size());
+  for (const Shp_ptr& shp : m_shps)
+    removed.push_back(capture_shape_rec(*shp));
 
   std::vector<Shp_ptr>::iterator itr = m_shps.begin();
 
@@ -48,6 +53,7 @@ Shp_rslt Shp_common::common(std::vector<Shp_ptr> shps)
   shp->set_name("Common");
   delete_operation_shps_();
   add_shp_(shp);
+  view().push_undo_delta(std::make_unique<Shape_replace_delta>(std::move(removed), std::vector<Shape_rec>{capture_shape_rec(*shp)}));
   return Shp_rslt(shp);
 }
 

--- a/src/shp_cut.cpp
+++ b/src/shp_cut.cpp
@@ -4,6 +4,7 @@
 #include <NCollection_List.hxx>
 
 #include "gui_occt_view.h"
+#include "shp_delta.h"
 #include "utl.h"
 
 Shp_cut::Shp_cut(Occt_view& view)
@@ -20,8 +21,12 @@ Shp_rslt Shp_cut::cut(std::vector<Shp_ptr> shps)
     if (shp.IsNull())
       return Shp_rslt(Result_status::User_error, "cut: null shape");
 
-  view().push_undo_snapshot();
   m_shps = std::move(shps);
+
+  std::vector<Shape_rec> removed;
+  removed.reserve(m_shps.size());
+  for (const Shp_ptr& shp : m_shps)
+    removed.push_back(capture_shape_rec(*shp));
 
   std::vector<Shp_ptr>::iterator itr = m_shps.begin();
 
@@ -48,6 +53,7 @@ Shp_rslt Shp_cut::cut(std::vector<Shp_ptr> shps)
   shp->set_name("Cut");
   delete_operation_shps_();
   add_shp_(shp);
+  view().push_undo_delta(std::make_unique<Shape_replace_delta>(std::move(removed), std::vector<Shape_rec>{capture_shape_rec(*shp)}));
   return Shp_rslt(shp);
 }
 

--- a/src/shp_delta.cpp
+++ b/src/shp_delta.cpp
@@ -1,28 +1,6 @@
 #include "shp_delta.h"
 
-#include <BRepTools.hxx>
-#include <BRep_Builder.hxx>
-#include <Graphic3d_MaterialAspect.hxx>
-#include <TopTools_FormatVersion.hxx>
-
-#include <sstream>
-
 #include "gui_occt_view.h"
-
-std::string shape_brep_string(const TopoDS_Shape& shape)
-{
-  std::ostringstream oss;
-  BRepTools::Write(shape, oss, false, false, TopTools_FormatVersion_CURRENT);
-  return oss.str();
-}
-
-TopoDS_Shape shape_from_brep_string(const std::string& geom)
-{
-  TopoDS_Shape       shape;
-  std::istringstream iss(geom);
-  BRepTools::Read(shape, iss, BRep_Builder());
-  return shape;
-}
 
 Shape_rec capture_shape_rec(const Shp& shp)
 {
@@ -30,7 +8,7 @@ Shape_rec capture_shape_rec(const Shp& shp)
   rec.id       = shp.get_id();
   rec.name     = shp.get_name();
   rec.material = shp.Material();
-  rec.geom     = shape_brep_string(shp.Shape());
+  rec.geom     = shp.Shape();
   return rec;
 }
 
@@ -81,13 +59,13 @@ Shape_geom_delta::Shape_geom_delta(std::vector<Geom_change> changes)
 void Shape_geom_delta::apply_forward(Occt_view& view)
 {
   for (const Geom_change& ch : m_changes)
-    view.set_shape_geom_by_id(ch.id, shape_from_brep_string(ch.after_geom));
+    view.set_shape_geom_by_id(ch.id, ch.after_geom);
 }
 
 void Shape_geom_delta::apply_reverse(Occt_view& view)
 {
   for (const Geom_change& ch : m_changes)
-    view.set_shape_geom_by_id(ch.id, shape_from_brep_string(ch.before_geom));
+    view.set_shape_geom_by_id(ch.id, ch.before_geom);
 }
 
 std::unique_ptr<Delta> Shape_geom_delta::clone() const { return std::make_unique<Shape_geom_delta>(m_changes); }

--- a/src/shp_delta.cpp
+++ b/src/shp_delta.cpp
@@ -1,0 +1,116 @@
+#include "shp_delta.h"
+
+#include <BRepTools.hxx>
+#include <BRep_Builder.hxx>
+#include <Graphic3d_MaterialAspect.hxx>
+#include <TopTools_FormatVersion.hxx>
+
+#include <sstream>
+
+#include "gui_occt_view.h"
+
+std::string shape_brep_string(const TopoDS_Shape& shape)
+{
+  std::ostringstream oss;
+  BRepTools::Write(shape, oss, false, false, TopTools_FormatVersion_CURRENT);
+  return oss.str();
+}
+
+TopoDS_Shape shape_from_brep_string(const std::string& geom)
+{
+  TopoDS_Shape       shape;
+  std::istringstream iss(geom);
+  BRepTools::Read(shape, iss, BRep_Builder());
+  return shape;
+}
+
+Shape_rec capture_shape_rec(const Shp& shp)
+{
+  Shape_rec rec;
+  rec.id       = shp.get_id();
+  rec.name     = shp.get_name();
+  rec.material = shp.Material();
+  rec.geom     = shape_brep_string(shp.Shape());
+  return rec;
+}
+
+namespace
+{
+
+void remove_recs_(Occt_view& view, const std::vector<Shape_rec>& recs)
+{
+  for (const Shape_rec& rec : recs)
+    view.remove_shape_by_id(rec.id);
+}
+
+void insert_recs_(Occt_view& view, const std::vector<Shape_rec>& recs)
+{
+  for (const Shape_rec& rec : recs)
+    view.insert_shape_rec(rec);
+}
+
+} // namespace
+
+Shape_add_delta::Shape_add_delta(std::vector<Shape_rec> added)
+    : m_added(std::move(added))
+{
+}
+
+void Shape_add_delta::apply_forward(Occt_view& view) { insert_recs_(view, m_added); }
+
+void Shape_add_delta::apply_reverse(Occt_view& view) { remove_recs_(view, m_added); }
+
+std::unique_ptr<Delta> Shape_add_delta::clone() const { return std::make_unique<Shape_add_delta>(m_added); }
+
+Shape_remove_delta::Shape_remove_delta(std::vector<Shape_rec> removed)
+    : m_removed(std::move(removed))
+{
+}
+
+void Shape_remove_delta::apply_forward(Occt_view& view) { remove_recs_(view, m_removed); }
+
+void Shape_remove_delta::apply_reverse(Occt_view& view) { insert_recs_(view, m_removed); }
+
+std::unique_ptr<Delta> Shape_remove_delta::clone() const { return std::make_unique<Shape_remove_delta>(m_removed); }
+
+Shape_geom_delta::Shape_geom_delta(std::vector<Geom_change> changes)
+    : m_changes(std::move(changes))
+{
+}
+
+void Shape_geom_delta::apply_forward(Occt_view& view)
+{
+  for (const Geom_change& ch : m_changes)
+    view.set_shape_geom_by_id(ch.id, shape_from_brep_string(ch.after_geom));
+}
+
+void Shape_geom_delta::apply_reverse(Occt_view& view)
+{
+  for (const Geom_change& ch : m_changes)
+    view.set_shape_geom_by_id(ch.id, shape_from_brep_string(ch.before_geom));
+}
+
+std::unique_ptr<Delta> Shape_geom_delta::clone() const { return std::make_unique<Shape_geom_delta>(m_changes); }
+
+Shape_replace_delta::Shape_replace_delta(std::vector<Shape_rec> removed, std::vector<Shape_rec> added)
+    : m_removed(std::move(removed))
+    , m_added(std::move(added))
+{
+}
+
+void Shape_replace_delta::apply_forward(Occt_view& view)
+{
+  remove_recs_(view, m_removed);
+  insert_recs_(view, m_added);
+}
+
+void Shape_replace_delta::apply_reverse(Occt_view& view)
+{
+  remove_recs_(view, m_added);
+  insert_recs_(view, m_removed);
+}
+
+std::unique_ptr<Delta> Shape_replace_delta::clone() const
+{
+  return std::make_unique<Shape_replace_delta>(m_removed, m_added);
+}

--- a/src/shp_delta.h
+++ b/src/shp_delta.h
@@ -9,18 +9,16 @@
 #include <string>
 #include <vector>
 
-/// Serializable snapshot of one document shape for undo/redo (BREP text + attrs).
+/// In-memory snapshot of one document shape for undo/redo (shared TopoDS_Shape + attrs).
 struct Shape_rec
 {
-  Shape_id    id{0};
-  std::string name;
-  int         material{0};
-  std::string geom;
+  Shape_id     id{0};
+  std::string  name;
+  int          material{0};
+  TopoDS_Shape geom;
 };
 
-Shape_rec    capture_shape_rec(const Shp& shp);
-std::string  shape_brep_string(const TopoDS_Shape& shape);
-TopoDS_Shape shape_from_brep_string(const std::string& geom);
+Shape_rec capture_shape_rec(const Shp& shp);
 
 /// Adds shapes on forward; removes them on reverse.
 class Shape_add_delta : public Delta
@@ -56,9 +54,9 @@ class Shape_geom_delta : public Delta
 public:
   struct Geom_change
   {
-    Shape_id    id{0};
-    std::string before_geom;
-    std::string after_geom;
+    Shape_id     id{0};
+    TopoDS_Shape before_geom;
+    TopoDS_Shape after_geom;
   };
 
   explicit Shape_geom_delta(std::vector<Geom_change> changes);

--- a/src/shp_delta.h
+++ b/src/shp_delta.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "delta.h"
+#include "shp.h"
+
+#include <TopoDS_Shape.hxx>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+/// Serializable snapshot of one document shape for undo/redo (BREP text + attrs).
+struct Shape_rec
+{
+  Shape_id    id{0};
+  std::string name;
+  int         material{0};
+  std::string geom;
+};
+
+Shape_rec    capture_shape_rec(const Shp& shp);
+std::string  shape_brep_string(const TopoDS_Shape& shape);
+TopoDS_Shape shape_from_brep_string(const std::string& geom);
+
+/// Adds shapes on forward; removes them on reverse.
+class Shape_add_delta : public Delta
+{
+public:
+  explicit Shape_add_delta(std::vector<Shape_rec> added);
+
+  void                   apply_forward(Occt_view& view) override;
+  void                   apply_reverse(Occt_view& view) override;
+  std::unique_ptr<Delta> clone() const override;
+
+private:
+  std::vector<Shape_rec> m_added;
+};
+
+/// Removes shapes on forward; restores them on reverse.
+class Shape_remove_delta : public Delta
+{
+public:
+  explicit Shape_remove_delta(std::vector<Shape_rec> removed);
+
+  void                   apply_forward(Occt_view& view) override;
+  void                   apply_reverse(Occt_view& view) override;
+  std::unique_ptr<Delta> clone() const override;
+
+private:
+  std::vector<Shape_rec> m_removed;
+};
+
+/// Replaces geometry of existing shapes in place (same ids).
+class Shape_geom_delta : public Delta
+{
+public:
+  struct Geom_change
+  {
+    Shape_id    id{0};
+    std::string before_geom;
+    std::string after_geom;
+  };
+
+  explicit Shape_geom_delta(std::vector<Geom_change> changes);
+
+  void                   apply_forward(Occt_view& view) override;
+  void                   apply_reverse(Occt_view& view) override;
+  std::unique_ptr<Delta> clone() const override;
+
+private:
+  std::vector<Geom_change> m_changes;
+};
+
+/// Removes inputs and adds results (booleans, fillet/chamfer replace, polar combine).
+class Shape_replace_delta : public Delta
+{
+public:
+  Shape_replace_delta(std::vector<Shape_rec> removed, std::vector<Shape_rec> added);
+
+  void                   apply_forward(Occt_view& view) override;
+  void                   apply_reverse(Occt_view& view) override;
+  std::unique_ptr<Delta> clone() const override;
+
+private:
+  std::vector<Shape_rec> m_removed;
+  std::vector<Shape_rec> m_added;
+};

--- a/src/shp_extrude.cpp
+++ b/src/shp_extrude.cpp
@@ -10,6 +10,7 @@
 #include "gui.h"
 #include "gui_occt_view.h"
 #include "sketch.h"
+#include "shp_delta.h"
 #include "utl.h"
 
 Shp_extrude::Shp_extrude(Occt_view& view)
@@ -63,6 +64,7 @@ void Shp_extrude::finalize()
   EZY_ASSERT(m_extruded);
   m_extruded->set_name(view().get_unique_shape_name("Shape"));
   add_shp_(m_extruded);
+  view().push_undo_delta(std::make_unique<Shape_add_delta>(std::vector<Shape_rec>{capture_shape_rec(*m_extruded)}));
   ctx().Remove(m_tmp_dim, false);
   clear_all(m_to_extrude_pt, m_to_extrude, m_extruded, m_tmp_dim);
   view().set_show_dim_input(false);
@@ -119,7 +121,6 @@ void Shp_extrude::_update_extrude(const ScreenCoords& screen_coords)
         {
           view().set_show_dim_input(false);
           update_extrude_preview_(entered_dist, m_extrude_side);
-          view().push_undo_snapshot();
           finalize();
         }
       };

--- a/src/shp_fillet.cpp
+++ b/src/shp_fillet.cpp
@@ -8,6 +8,7 @@
 
 #include "mode.h"
 #include "gui_occt_view.h"
+#include "shp_delta.h"
 #include "utl_occt.h"
 
 Shp_fillet::Shp_fillet(Occt_view& view)
@@ -17,10 +18,11 @@ Shp_fillet::Shp_fillet(Occt_view& view)
 
 Status Shp_fillet::add_fillet(const ScreenCoords& screen_coords, const Fillet_mode fillet_mode)
 {
-  view().push_undo_snapshot();
   Shp_ptr fillet_src_shp = Shp_ptr::DownCast(get_shape_(screen_coords));
   if (fillet_src_shp.IsNull())
     return Status::user_error("Click on a shape.");
+
+  const Shape_rec removed = capture_shape_rec(*fillet_src_shp);
 
   BRepFilletAPI_MakeFillet fillet_maker(fillet_src_shp->Shape());
 
@@ -93,6 +95,8 @@ Status Shp_fillet::add_fillet(const ScreenCoords& screen_coords, const Fillet_mo
     fillet_maker.Build();
     Shp_ptr fillet_shp = new Shp(ctx(), fillet_maker.Shape());
     replace_picked_shape_(fillet_src_shp, fillet_shp, "Filleted shape");
+    view().push_undo_delta(
+        std::make_unique<Shape_replace_delta>(std::vector<Shape_rec>{removed}, std::vector<Shape_rec>{capture_shape_rec(*fillet_shp)}));
   }
   catch (const Standard_Failure& e)
   {

--- a/src/shp_fuse.cpp
+++ b/src/shp_fuse.cpp
@@ -3,6 +3,7 @@
 #include <BRepAlgoAPI_Fuse.hxx>
 
 #include "gui_occt_view.h"
+#include "shp_delta.h"
 #include "utl.h"
 
 Shp_fuse::Shp_fuse(Occt_view& view)
@@ -19,8 +20,12 @@ Shp_rslt Shp_fuse::fuse(std::vector<Shp_ptr> shps)
     if (shp.IsNull())
       return Shp_rslt(Result_status::User_error, "fuse: null shape");
 
-  view().push_undo_snapshot();
   m_shps = std::move(shps);
+
+  std::vector<Shape_rec> removed;
+  removed.reserve(m_shps.size());
+  for (const Shp_ptr& shp : m_shps)
+    removed.push_back(capture_shape_rec(*shp));
 
   std::vector<Shp_ptr>::iterator itr = m_shps.begin();
 
@@ -48,6 +53,7 @@ Shp_rslt Shp_fuse::fuse(std::vector<Shp_ptr> shps)
   shp->set_name("Fused");
   delete_operation_shps_();
   add_shp_(shp);
+  view().push_undo_delta(std::make_unique<Shape_replace_delta>(std::move(removed), std::vector<Shape_rec>{capture_shape_rec(*shp)}));
   return Shp_rslt(shp);
 }
 

--- a/src/shp_move.cpp
+++ b/src/shp_move.cpp
@@ -3,6 +3,7 @@
 #include "utl_geom.h"
 #include "gui.h"
 #include "gui_occt_view.h"
+#include "shp_delta.h"
 #include "utl.h"
 
 Shp_move::Shp_move(Occt_view& view)
@@ -123,8 +124,21 @@ void Shp_move::finalize()
     // be selected while in move mode.
     return;
 
-  view().push_undo_snapshot();
+  std::vector<Shape_geom_delta::Geom_change> changes;
+  changes.reserve(m_shps.size());
+  for (const Shp_ptr& shape : m_shps)
+    changes.push_back(Shape_geom_delta::Geom_change{shape->get_id(), shape_brep_string(shape->Shape()), {}});
+
   operation_shps_finalize_();
+
+  for (Shape_geom_delta::Geom_change& ch : changes)
+  {
+    Shp_ptr shp = view().find_shape_by_id(ch.id);
+    if (!shp.IsNull())
+      ch.after_geom = shape_brep_string(shp->Shape());
+  }
+
+  view().push_undo_delta(std::make_unique<Shape_geom_delta>(std::move(changes)));
   reset();
 }
 

--- a/src/shp_move.cpp
+++ b/src/shp_move.cpp
@@ -127,7 +127,7 @@ void Shp_move::finalize()
   std::vector<Shape_geom_delta::Geom_change> changes;
   changes.reserve(m_shps.size());
   for (const Shp_ptr& shape : m_shps)
-    changes.push_back(Shape_geom_delta::Geom_change{shape->get_id(), shape_brep_string(shape->Shape()), {}});
+    changes.push_back(Shape_geom_delta::Geom_change{shape->get_id(), shape->Shape(), {}});
 
   operation_shps_finalize_();
 
@@ -135,7 +135,7 @@ void Shp_move::finalize()
   {
     Shp_ptr shp = view().find_shape_by_id(ch.id);
     if (!shp.IsNull())
-      ch.after_geom = shape_brep_string(shp->Shape());
+      ch.after_geom = shp->Shape();
   }
 
   view().push_undo_delta(std::make_unique<Shape_geom_delta>(std::move(changes)));

--- a/src/shp_polar_dup.cpp
+++ b/src/shp_polar_dup.cpp
@@ -13,6 +13,7 @@
 #include "gui_occt_view.h"
 #include "sketch.h"
 #include "sketch_nodes.h"
+#include "shp_delta.h"
 
 Shp_polar_dup::Shp_polar_dup(Occt_view& view)
     : Shp_operation_base(view)
@@ -82,7 +83,10 @@ Status Shp_polar_dup::dup()
   if (!m_polar_arm_end.has_value())
     return Status::user_error("Polar arm not set.");
 
-  view().push_undo_snapshot();
+  std::vector<Shape_rec> removed;
+  removed.reserve(m_shps.size());
+  for (const Shp_ptr& shp : m_shps)
+    removed.push_back(capture_shape_rec(*shp));
 
   const double  step_angle = m_polar_angle / double(m_num_elms);
   const gp_Pln& sketch_pln = view().curr_sketch().get_plane();
@@ -92,6 +96,7 @@ Status Shp_polar_dup::dup()
 
   // Vector to store all transformed shapes if combining
   std::vector<TopoDS_Shape> transformed_shapes;
+  std::vector<Shape_rec>    added;
 
   // Create copies and rotate them
   for (size_t i = 0; i < m_num_elms; ++i)
@@ -142,6 +147,7 @@ Status Shp_polar_dup::dup()
         Shp_ptr new_shape = new Shp(ctx(), transformed_shape);
         new_shape->set_name("Polar duplicate");
         add_shp_(new_shape);
+        added.push_back(capture_shape_rec(*new_shape));
       }
     }
   }
@@ -161,9 +167,11 @@ Status Shp_polar_dup::dup()
     Shp_ptr new_shape = new Shp(ctx(), combined_shape);
     new_shape->set_name("Combined polar duplicate");
     add_shp_(new_shape);
+    added.push_back(capture_shape_rec(*new_shape));
   }
 
   delete_operation_shps_();
+  view().push_undo_delta(std::make_unique<Shape_replace_delta>(std::move(removed), std::move(added)));
   gui().set_mode(Mode::Normal); // Will call reset()
   return Status::ok();
 }

--- a/src/shp_rotate.cpp
+++ b/src/shp_rotate.cpp
@@ -8,6 +8,7 @@
 #include "utl_geom.h"
 #include "gui.h"
 #include "gui_occt_view.h"
+#include "shp_delta.h"
 #include "utl.h"
 
 Shp_rotate::Shp_rotate(Occt_view& view)
@@ -198,8 +199,21 @@ void Shp_rotate::finalize()
   if (m_shps.empty())
     return;
 
-  view().push_undo_snapshot();
+  std::vector<Shape_geom_delta::Geom_change> changes;
+  changes.reserve(m_shps.size());
+  for (const Shp_ptr& shape : m_shps)
+    changes.push_back(Shape_geom_delta::Geom_change{shape->get_id(), shape_brep_string(shape->Shape()), {}});
+
   operation_shps_finalize_();
+
+  for (Shape_geom_delta::Geom_change& ch : changes)
+  {
+    Shp_ptr shp = view().find_shape_by_id(ch.id);
+    if (!shp.IsNull())
+      ch.after_geom = shape_brep_string(shp->Shape());
+  }
+
+  view().push_undo_delta(std::make_unique<Shape_geom_delta>(std::move(changes)));
   reset();
 }
 

--- a/src/shp_rotate.cpp
+++ b/src/shp_rotate.cpp
@@ -202,7 +202,7 @@ void Shp_rotate::finalize()
   std::vector<Shape_geom_delta::Geom_change> changes;
   changes.reserve(m_shps.size());
   for (const Shp_ptr& shape : m_shps)
-    changes.push_back(Shape_geom_delta::Geom_change{shape->get_id(), shape_brep_string(shape->Shape()), {}});
+    changes.push_back(Shape_geom_delta::Geom_change{shape->get_id(), shape->Shape(), {}});
 
   operation_shps_finalize_();
 
@@ -210,7 +210,7 @@ void Shp_rotate::finalize()
   {
     Shp_ptr shp = view().find_shape_by_id(ch.id);
     if (!shp.IsNull())
-      ch.after_geom = shape_brep_string(shp->Shape());
+      ch.after_geom = shp->Shape();
   }
 
   view().push_undo_delta(std::make_unique<Shape_geom_delta>(std::move(changes)));

--- a/src/shp_scale.cpp
+++ b/src/shp_scale.cpp
@@ -4,6 +4,7 @@
 #include "gui.h"
 #include "mode.h"
 #include "gui_occt_view.h"
+#include "shp_delta.h"
 #include "utl.h"
 
 Shp_scale::Shp_scale(Occt_view& view)
@@ -69,8 +70,21 @@ void Shp_scale::finalize()
   if (m_shps.empty())
     return;
 
-  view().push_undo_snapshot();
+  std::vector<Shape_geom_delta::Geom_change> changes;
+  changes.reserve(m_shps.size());
+  for (const Shp_ptr& shape : m_shps)
+    changes.push_back(Shape_geom_delta::Geom_change{shape->get_id(), shape_brep_string(shape->Shape()), {}});
+
   operation_shps_finalize_();
+
+  for (Shape_geom_delta::Geom_change& ch : changes)
+  {
+    Shp_ptr shp = view().find_shape_by_id(ch.id);
+    if (!shp.IsNull())
+      ch.after_geom = shape_brep_string(shp->Shape());
+  }
+
+  view().push_undo_delta(std::make_unique<Shape_geom_delta>(std::move(changes)));
   reset();
 }
 

--- a/src/shp_scale.cpp
+++ b/src/shp_scale.cpp
@@ -73,7 +73,7 @@ void Shp_scale::finalize()
   std::vector<Shape_geom_delta::Geom_change> changes;
   changes.reserve(m_shps.size());
   for (const Shp_ptr& shape : m_shps)
-    changes.push_back(Shape_geom_delta::Geom_change{shape->get_id(), shape_brep_string(shape->Shape()), {}});
+    changes.push_back(Shape_geom_delta::Geom_change{shape->get_id(), shape->Shape(), {}});
 
   operation_shps_finalize_();
 
@@ -81,7 +81,7 @@ void Shp_scale::finalize()
   {
     Shp_ptr shp = view().find_shape_by_id(ch.id);
     if (!shp.IsNull())
-      ch.after_geom = shape_brep_string(shp->Shape());
+      ch.after_geom = shp->Shape();
   }
 
   view().push_undo_delta(std::make_unique<Shape_geom_delta>(std::move(changes)));

--- a/tests/shp_tests.cpp
+++ b/tests/shp_tests.cpp
@@ -12,6 +12,7 @@
 #include "shp.h"
 #include "shp_create.h"
 #include "shp_info.h"
+#include "sketch_op_recorder.h"
 #include "utl.h"
 
 namespace
@@ -321,4 +322,108 @@ TEST_F(Shp_test, Fuse_requires_two_shapes)
   Status st = view().shp_fuse().selected_fuse();
   EXPECT_FALSE(st.is_ok());
   EXPECT_EQ(view().get_shapes().size(), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Shape undo / redo (typed deltas, no full-document snapshot)
+// ---------------------------------------------------------------------------
+
+TEST_F(Shp_test, Undo_add_box_removes_shape)
+{
+  EXPECT_EQ(view().get_shapes().size(), 0u);
+  view().add_box(0, 0, 0, 10, 10, 10);
+  ASSERT_EQ(view().get_shapes().size(), 1u);
+  const Shape_id id = view().get_shapes().back()->get_id();
+  EXPECT_NE(id, 0u);
+
+  EXPECT_TRUE(view().undo());
+  EXPECT_EQ(view().get_shapes().size(), 0u);
+
+  EXPECT_TRUE(view().redo());
+  ASSERT_EQ(view().get_shapes().size(), 1u);
+  EXPECT_EQ(view().get_shapes().back()->get_id(), id);
+  EXPECT_NEAR(volume_of(view().get_shapes().back()->Shape()), 1000.0, 1e-6);
+}
+
+TEST_F(Shp_test, Undo_delete_shape_restores_brep)
+{
+  view().add_box(0, 0, 0, 10, 10, 10);
+  ASSERT_EQ(view().get_shapes().size(), 1u);
+  const Shape_id id = view().get_shapes().back()->get_id();
+
+  std::vector<AIS_Shape_ptr> to_delete;
+  to_delete.push_back(view().get_shapes().back());
+  view().delete_shapes(to_delete);
+  EXPECT_EQ(view().get_shapes().size(), 0u);
+
+  EXPECT_TRUE(view().undo());
+  ASSERT_EQ(view().get_shapes().size(), 1u);
+  EXPECT_EQ(view().get_shapes().back()->get_id(), id);
+  EXPECT_NEAR(volume_of(view().get_shapes().back()->Shape()), 1000.0, 1e-6);
+}
+
+TEST_F(Shp_test, Undo_fuse_restores_inputs)
+{
+  view().add_box(0, 0, 0, 10, 10, 10);
+  view().add_box(5, 0, 0, 10, 10, 10);
+  ASSERT_EQ(view().get_shapes().size(), 2u);
+  const Shape_id id_a = view().get_shapes().front()->get_id();
+  const Shape_id id_b = view().get_shapes().back()->get_id();
+
+  std::vector<Shp_ptr> to_select(view().get_shapes().begin(), view().get_shapes().end());
+  select_shapes(view(), to_select);
+  ASSERT_TRUE(view().shp_fuse().selected_fuse().is_ok());
+  ASSERT_EQ(view().get_shapes().size(), 1u);
+
+  EXPECT_TRUE(view().undo());
+  ASSERT_EQ(view().get_shapes().size(), 2u);
+  EXPECT_FALSE(view().find_shape_by_id(id_a).IsNull());
+  EXPECT_FALSE(view().find_shape_by_id(id_b).IsNull());
+
+  EXPECT_TRUE(view().redo());
+  ASSERT_EQ(view().get_shapes().size(), 1u);
+  EXPECT_NEAR(volume_of(view().get_shapes().back()->Shape()), 1500.0, 1e-3);
+}
+
+TEST_F(Shp_test, Undo_interleaves_sketch_delta_and_shape_add)
+{
+  gp_Pln default_plane(gp::Origin(), gp::DZ());
+  Sketch sketch("TestSketch", view(), default_plane);
+
+  {
+    Sketch_op_recorder rec(view(), sketch);
+    Sketch_access::add_edge_(sketch, gp_Pnt2d(0.0, 0.0), gp_Pnt2d(10.0, 0.0), rec);
+    rec.commit();
+  }
+
+  view().add_box(0, 0, 0, 2, 2, 2);
+  EXPECT_EQ(view().get_shapes().size(), 1u);
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 1u);
+
+  EXPECT_TRUE(view().undo()); // undo box
+  EXPECT_EQ(view().get_shapes().size(), 0u);
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 1u);
+
+  EXPECT_TRUE(view().undo()); // undo edge
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 0u);
+
+  EXPECT_TRUE(view().redo());
+  EXPECT_EQ(Sketch_access::get_linear_edge_count(sketch), 1u);
+  EXPECT_TRUE(view().redo());
+  EXPECT_EQ(view().get_shapes().size(), 1u);
+}
+
+TEST_F(Shp_test, Shape_ids_persist_in_json)
+{
+  view().add_box(0, 0, 0, 3, 4, 5);
+  ASSERT_EQ(view().get_shapes().size(), 1u);
+  const Shape_id id = view().get_shapes().back()->get_id();
+
+  const std::string json = view().to_json();
+  view().new_file();
+  EXPECT_EQ(view().get_shapes().size(), 0u);
+
+  view().load(json, false);
+  ASSERT_EQ(view().get_shapes().size(), 1u);
+  EXPECT_EQ(view().get_shapes().back()->get_id(), id);
 }


### PR DESCRIPTION
## Summary

- Replace full-document JSON undo snapshots for interactive edits with typed `Delta` subclasses (shape add/remove/geom/replace, sketch structural, underlay).
- Add stable `Shape_id` on `Shp` (persisted in project JSON); undo stores shared `TopoDS_Shape` in `Shape_rec`, not BREP text.
- Keep JSON snapshots only for mixed sketch-edge delete and file-open checkpoint.

Closes #200

## Test plan

- [x] Build `EzyCad_tests` (Release)
- [x] `EzyCad_tests.exe --gtest_filter=Shp_test.Undo*:Shp_test.Shape_ids*:Sketch_test.Undo*`
- [x] Manual: add box undo/redo; fuse two boxes undo/redo; add sketch undo/redo; underlay transform undo
- [x] Spot-check file open still clears history; mixed delete of sketch edge still undoes via snapshot

Made with [Cursor](https://cursor.com)