### PR TITLE
Document tabular layout and apply presentation nitpicks

### DIFF
--- a/docs/ezycad_code_style.md
+++ b/docs/ezycad_code_style.md
@@ -53,7 +53,7 @@ Use **`// clang-format off`** / **`// clang-format on`** only around regions whe
 
 ### Tabular layout (clang-format off)
 
-When a block is naturally a **table** (parallel keys/values, assignments, or call arguments), align columns by hand and wrap **only that block**:
+When a block is naturally a **table** (parallel keys/values, assignments, call arguments, or short `switch` cases), align columns by hand and wrap **only that block**:
 
 ```cpp
 // clang-format off
@@ -71,8 +71,22 @@ return nlohmann::json{
 // clang-format on
 ```
 
+```cpp
+// clang-format off
+switch (curve.GetType())
+{
+case GeomAbs_Line:         ++result.line_count;        break;
+case GeomAbs_Circle:       ++result.circle_count;      break;
+case GeomAbs_Ellipse:      ++result.ellipse_count;     break;
+case GeomAbs_BSplineCurve: ++result.bspline_count;     break;
+default:                   ++result.other_curve_count; break;
+}
+// clang-format on
+```
+
 - Put the comma **immediately after** the key (`{"key",  value}`), then pad spaces so the value column lines up.
 - Use one entry per line for object/map-like initializers when aligning.
+- For a **`switch` of short, parallel cases**, put each `case`/`default` on **one line** and align the label, statement(s), and trailing `break;` into columns. Keep `IndentCaseLabels: false` (labels align with `switch`), and prefer this only when every case is a simple one-liner.
 - Keep `off`/`on` tight to the table; leave surrounding code under normal clang-format.
 
 `AlignConsecutiveDeclarations` / `AlignConsecutiveAssignments` already help many declaration and assignment runs; use explicit `off`/`on` when clang-format would still break a hand-aligned key/value or argument table.

--- a/docs/ezycad_code_style.md
+++ b/docs/ezycad_code_style.md
@@ -49,9 +49,68 @@ Run **`scripts/format-src.ps1`** (or `clang-format -i` on individual files) befo
 - **`IndentCaseLabels: false`** — `case` / `default` labels align with the surrounding `switch`, not extra-indented under it.
 - **`SortIncludes: false`** — clang-format does **not** reorder `#include` lines. Follow **Headers** above manually (own header first in `.cpp`, project `"..."` before `<...>`).
 
-Use **`// clang-format off`** / **`// clang-format on`** only where layout must be preserved (e.g. macro-like tables). Prefer formatting the file normally.
+Use **`// clang-format off`** / **`// clang-format on`** only around regions where layout must be preserved. Prefer formatting the file normally; do **not** wrap an entire translation unit.
 
-**Not enforced by clang-format** (project convention): brace-initialize members (`bool ok {false};`); declare locals close to first use; omit braces on single-statement `if`/`for`/`while` bodies when clear; put a **blank line between consecutive `if` statements** that have no `else` (treat each as its own block).
+### Tabular layout (clang-format off)
+
+When a block is naturally a **table** (parallel keys/values, assignments, or call arguments), align columns by hand and wrap **only that block**:
+
+```cpp
+// clang-format off
+out.view_nav          = b("view_nav",          defaults.view_nav);
+out.view_presentation = b("view_presentation", defaults.view_presentation);
+// clang-format on
+```
+
+```cpp
+// clang-format off
+return nlohmann::json{
+    {"rounding_scroll",  s.rounding_scroll},
+    {"window_padding_x", s.window_padding_x},
+};
+// clang-format on
+```
+
+- Put the comma **immediately after** the key (`{"key",  value}`), then pad spaces so the value column lines up.
+- Use one entry per line for object/map-like initializers when aligning.
+- Keep `off`/`on` tight to the table; leave surrounding code under normal clang-format.
+
+`AlignConsecutiveDeclarations` / `AlignConsecutiveAssignments` already help many declaration and assignment runs; use explicit `off`/`on` when clang-format would still break a hand-aligned key/value or argument table.
+
+### Vertical rhythm (blank lines)
+
+Not enforced by clang-format. Treat each **logical beat** as its own short paragraph:
+
+- Put a **blank line between consecutive `if` statements** that have no `else` (each is its own block).
+- After a **local lambda or helper** closes (`};`), put a blank line before the first use or following statement.
+- Inside a short helper, separate **setup**, **early return**, and **main body** with blank lines when each is a distinct step.
+- After a multi-statement `if { ... }` (or single-statement `if` that mutates state), put a blank line before trailing same-row UI such as `ImGui::SameLine`, unit labels, or `GUI_DOC_HELP_`.
+- After a **lookup table / constexpr array**, put a blank line before the locals or code that use it.
+- Before a final **`return`**, put a blank line when the function already performed a side effect (e.g. save) above.
+- Between sequential but distinct ImGui actions (e.g. `TextWrapped` / `TextDisabled`, then `Spacing`; or one `Button` then `SameLine` / next `Button`), prefer a blank line so the chain does not read as one run-on block.
+
+Do not sprinkle blank lines inside a tight expression or a one-line `if` body; the goal is readable beats, not sparse files.
+
+### Control flow polarity
+
+When both branches are short and one is the normal success path, prefer **happy-path first**:
+
+```cpp
+if (!content.empty())
+{
+  // apply / succeed
+}
+else
+  show_message("Failed...");
+```
+
+rather than leading with the failure `if` and putting the main work in `else`, unless an early-return failure keeps the success path flatter.
+
+### Other conventions (not enforced by clang-format)
+
+- Brace-initialize members (`bool ok {false};`).
+- Declare locals close to first use.
+- Omit braces on single-statement `if`/`for`/`while` bodies when clear.
 
 ## Documentation
 

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -22,28 +22,32 @@ nlohmann::json build_occt_view_settings_object_(const Occt_view& view);
 
 nlohmann::json imgui_style_to_json(const Gui_imgui_style_settings& s)
 {
-  return nlohmann::json{{"rounding_general", s.rounding_general}, {"rounding_scroll", s.rounding_scroll},
-                        {"rounding_tabs", s.rounding_tabs},       {"window_alpha", s.window_alpha},
-                        {"window_border", s.window_border},       {"frame_border", s.frame_border},
-                        {"window_padding_x", s.window_padding_x}, {"window_padding_y", s.window_padding_y},
-                        {"frame_padding_x", s.frame_padding_x},   {"frame_padding_y", s.frame_padding_y},
-                        {"item_spacing_x", s.item_spacing_x},     {"item_spacing_y", s.item_spacing_y}};
+  // clang-format off
+  return nlohmann::json{{"rounding_general",  s.rounding_general}, {"rounding_scroll",  s.rounding_scroll},
+                        {"rounding_tabs",     s.rounding_tabs},    {"window_alpha",     s.window_alpha},
+                        {"window_border",     s.window_border},    {"frame_border",     s.frame_border},
+                        {"window_padding_x",  s.window_padding_x}, {"window_padding_y", s.window_padding_y},
+                        {"frame_padding_x",   s.frame_padding_x},  {"frame_padding_y",  s.frame_padding_y},
+                        {"item_spacing_x",    s.item_spacing_x},   {"item_spacing_y",   s.item_spacing_y}};
+  // clang-format on
 }
 
 nlohmann::json settings_headers_to_json(const Gui_settings_headers& h)
 {
-  return nlohmann::json{{"view_nav", h.view_nav},
-                        {"new_project", h.new_project},
-                        {"ui", h.ui},
+  // clang-format off
+  return nlohmann::json{{"view_nav",          h.view_nav},
+                        {"new_project",       h.new_project},
+                        {"ui",                h.ui},
                         {"view_presentation", h.view_presentation},
-                        {"grid", h.grid},
-                        {"sketch", h.sketch},
+                        {"grid",              h.grid},
+                        {"sketch",            h.sketch},
                         {"sketch_appearance", h.sketch_appearance},
                         {"sketch_dimensions", h.sketch_dimensions},
-                        {"sketch_nodes", h.sketch_nodes},
-                        {"sketch_snap", h.sketch_snap},
-                        {"sketch_underlay", h.sketch_underlay},
-                        {"startup", h.startup}};
+                        {"sketch_nodes",      h.sketch_nodes},
+                        {"sketch_snap",       h.sketch_snap},
+                        {"sketch_underlay",   h.sketch_underlay},
+                        {"startup",           h.startup}};
+  // clang-format on
 }
 
 void parse_settings_headers_json(const nlohmann::json& obj, Gui_settings_headers& out)
@@ -55,18 +59,21 @@ void parse_settings_headers_json(const nlohmann::json& obj, Gui_settings_headers
       return obj[key].get<bool>();
     return fallback;
   };
-  out.view_nav          = b("view_nav", defaults.view_nav);
-  out.new_project       = b("new_project", defaults.new_project);
-  out.ui                = b("ui", defaults.ui);
-  out.view_presentation = b("view_presentation", defaults.view_presentation);
-  out.grid              = b("grid", defaults.grid);
-  out.sketch            = b("sketch", defaults.sketch);
-  out.sketch_appearance = b("sketch_appearance", defaults.sketch_appearance);
-  out.sketch_dimensions = b("sketch_dimensions", defaults.sketch_dimensions);
-  out.sketch_nodes      = b("sketch_nodes", defaults.sketch_nodes);
-  out.sketch_snap       = b("sketch_snap", defaults.sketch_snap);
-  out.sketch_underlay   = b("sketch_underlay", defaults.sketch_underlay);
-  out.startup           = b("startup", defaults.startup);
+
+  // clang-format off
+  out.view_nav          = b("view_nav",           defaults.view_nav);
+  out.new_project       = b("new_project",        defaults.new_project);
+  out.ui                = b("ui",                 defaults.ui);
+  out.view_presentation = b("view_presentation",  defaults.view_presentation);
+  out.grid              = b("grid",               defaults.grid);
+  out.sketch            = b("sketch",             defaults.sketch);
+  out.sketch_appearance = b("sketch_appearance",  defaults.sketch_appearance);
+  out.sketch_dimensions = b("sketch_dimensions",  defaults.sketch_dimensions);
+  out.sketch_nodes      = b("sketch_nodes",       defaults.sketch_nodes);
+  out.sketch_snap       = b("sketch_snap",        defaults.sketch_snap);
+  out.sketch_underlay   = b("sketch_underlay",    defaults.sketch_underlay);
+  out.startup           = b("startup",            defaults.startup);
+  // clang-format on
 }
 
 void parse_imgui_style_json(const nlohmann::json& obj, const Gui_imgui_style_settings& defaults, Gui_imgui_style_settings& out)
@@ -1518,6 +1525,7 @@ void GUI::settings_()
               appear_changed                        = true;
             }
           }
+
           ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
           GUI_DOC_HELP_("Faces with more edges than this use the fast face-copy drag preview "
                         "(default 24). Boxes and circles stay under the threshold.",

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -23,30 +23,40 @@ nlohmann::json build_occt_view_settings_object_(const Occt_view& view);
 nlohmann::json imgui_style_to_json(const Gui_imgui_style_settings& s)
 {
   // clang-format off
-  return nlohmann::json{{"rounding_general",  s.rounding_general}, {"rounding_scroll",  s.rounding_scroll},
-                        {"rounding_tabs",     s.rounding_tabs},    {"window_alpha",     s.window_alpha},
-                        {"window_border",     s.window_border},    {"frame_border",     s.frame_border},
-                        {"window_padding_x",  s.window_padding_x}, {"window_padding_y", s.window_padding_y},
-                        {"frame_padding_x",   s.frame_padding_x},  {"frame_padding_y",  s.frame_padding_y},
-                        {"item_spacing_x",    s.item_spacing_x},   {"item_spacing_y",   s.item_spacing_y}};
+  return nlohmann::json{
+      {"rounding_general", s.rounding_general},
+      {"rounding_scroll",  s.rounding_scroll},
+      {"rounding_tabs",    s.rounding_tabs},
+      {"window_alpha",     s.window_alpha},
+      {"window_border",    s.window_border},
+      {"frame_border",     s.frame_border},
+      {"window_padding_x", s.window_padding_x},
+      {"window_padding_y", s.window_padding_y},
+      {"frame_padding_x",  s.frame_padding_x},
+      {"frame_padding_y",  s.frame_padding_y},
+      {"item_spacing_x",   s.item_spacing_x},
+      {"item_spacing_y",   s.item_spacing_y},
+  };
   // clang-format on
 }
 
 nlohmann::json settings_headers_to_json(const Gui_settings_headers& h)
 {
   // clang-format off
-  return nlohmann::json{{"view_nav",          h.view_nav},
-                        {"new_project",       h.new_project},
-                        {"ui",                h.ui},
-                        {"view_presentation", h.view_presentation},
-                        {"grid",              h.grid},
-                        {"sketch",            h.sketch},
-                        {"sketch_appearance", h.sketch_appearance},
-                        {"sketch_dimensions", h.sketch_dimensions},
-                        {"sketch_nodes",      h.sketch_nodes},
-                        {"sketch_snap",       h.sketch_snap},
-                        {"sketch_underlay",   h.sketch_underlay},
-                        {"startup",           h.startup}};
+  return nlohmann::json{
+      {"view_nav",          h.view_nav},
+      {"new_project",       h.new_project},
+      {"ui",                h.ui},
+      {"view_presentation", h.view_presentation},
+      {"grid",              h.grid},
+      {"sketch",            h.sketch},
+      {"sketch_appearance", h.sketch_appearance},
+      {"sketch_dimensions", h.sketch_dimensions},
+      {"sketch_nodes",      h.sketch_nodes},
+      {"sketch_snap",       h.sketch_snap},
+      {"sketch_underlay",   h.sketch_underlay},
+      {"startup",           h.startup},
+  };
   // clang-format on
 }
 
@@ -90,19 +100,21 @@ void parse_imgui_style_json(const nlohmann::json& obj, const Gui_imgui_style_set
     return fallback;
   };
 
+  // clang-format off
   out.rounding_general = f("rounding_general", defaults.rounding_general);
-  out.rounding_scroll  = f("rounding_scroll", defaults.rounding_scroll);
-  out.rounding_tabs    = f("rounding_tabs", defaults.rounding_tabs);
-  out.window_alpha =
-      std::clamp(f("window_alpha", defaults.window_alpha), k_gui_imgui_window_alpha_min, k_gui_imgui_window_alpha_max);
-  out.window_border    = std::clamp(f("window_border", defaults.window_border), 0.f, k_gui_imgui_border_slider_max);
-  out.frame_border     = std::clamp(f("frame_border", defaults.frame_border), 0.f, k_gui_imgui_border_slider_max);
+  out.rounding_scroll  = f("rounding_scroll",  defaults.rounding_scroll);
+  out.rounding_tabs    = f("rounding_tabs",    defaults.rounding_tabs);
+  out.window_alpha     = std::clamp(f("window_alpha", defaults.window_alpha),
+                                    k_gui_imgui_window_alpha_min, k_gui_imgui_window_alpha_max);
+  out.window_border    = std::clamp(f("window_border",    defaults.window_border),    0.f, k_gui_imgui_border_slider_max);
+  out.frame_border     = std::clamp(f("frame_border",     defaults.frame_border),     0.f, k_gui_imgui_border_slider_max);
   out.window_padding_x = std::clamp(f("window_padding_x", defaults.window_padding_x), 0.f, k_gui_imgui_padding_slider_max);
   out.window_padding_y = std::clamp(f("window_padding_y", defaults.window_padding_y), 0.f, k_gui_imgui_padding_slider_max);
-  out.frame_padding_x  = std::clamp(f("frame_padding_x", defaults.frame_padding_x), 0.f, k_gui_imgui_padding_slider_max);
-  out.frame_padding_y  = std::clamp(f("frame_padding_y", defaults.frame_padding_y), 0.f, k_gui_imgui_padding_slider_max);
-  out.item_spacing_x   = std::clamp(f("item_spacing_x", defaults.item_spacing_x), 0.f, k_gui_imgui_spacing_slider_max);
-  out.item_spacing_y   = std::clamp(f("item_spacing_y", defaults.item_spacing_y), 0.f, k_gui_imgui_spacing_slider_max);
+  out.frame_padding_x  = std::clamp(f("frame_padding_x",  defaults.frame_padding_x),  0.f, k_gui_imgui_padding_slider_max);
+  out.frame_padding_y  = std::clamp(f("frame_padding_y",  defaults.frame_padding_y),  0.f, k_gui_imgui_padding_slider_max);
+  out.item_spacing_x   = std::clamp(f("item_spacing_x",   defaults.item_spacing_x),   0.f, k_gui_imgui_spacing_slider_max);
+  out.item_spacing_y   = std::clamp(f("item_spacing_y",   defaults.item_spacing_y),   0.f, k_gui_imgui_spacing_slider_max);
+  // clang-format on
 }
 
 bool settings_imgui_style_controls_(float label_col_w, Gui_imgui_style_settings& style, const char* id_prefix)
@@ -167,69 +179,67 @@ std::string GUI::occt_view_settings_json() const
   EZY_ASSERT(m_view);
   json j;
   j["occt_view"] = build_occt_view_settings_object_(*m_view);
+  // clang-format off
   j["gui"]       = {
-      {"edge_dim_label_h", m_edge_dim_label_h},
-      {"edge_dim_line_width", m_edge_dim_line_width},
-      {"edge_dim_arrow_size", m_edge_dim_arrow_size},
-      {"edge_dim_color", {m_edge_dim_color[0], m_edge_dim_color[1], m_edge_dim_color[2]}},
-      {"edge_dim_text_scale", m_edge_dim_text_scale},
-      {"edge_dim_text_render_mode", m_edge_dim_text_render_mode},
-      {"edge_dim_arrow_style", m_edge_dim_arrow_style},
-      {"edge_dim_arrow_orientation", m_edge_dim_arrow_orientation},
-      {"show_sketch_dimensions", m_show_sketch_dimensions},
-      {k_gui_key_permanent_node_anno_scale, m_permanent_node_anno_scale},
-      {"origin_marker_color", {m_origin_marker_color[0], m_origin_marker_color[1], m_origin_marker_color[2]}},
-      {"sketch_edge_color", {m_sketch_edge_color[0], m_sketch_edge_color[1], m_sketch_edge_color[2], m_sketch_edge_color[3]}},
-      {"sketch_edge_selection_color",
-             {m_sketch_edge_selection_color[0], m_sketch_edge_selection_color[1], m_sketch_edge_selection_color[2],
-              m_sketch_edge_selection_color[3]}},
-      {"sketch_edge_highlight_color",
-             {m_sketch_edge_highlight_color[0], m_sketch_edge_highlight_color[1], m_sketch_edge_highlight_color[2],
-              m_sketch_edge_highlight_color[3]}},
-      {"sketch_edge_line_width", m_sketch_edge_line_width},
-      {"sketch_face_color", {m_sketch_face_color[0], m_sketch_face_color[1], m_sketch_face_color[2], m_sketch_face_color[3]}},
-      {"sketch_face_selection_color",
-             {m_sketch_face_selection_color[0], m_sketch_face_selection_color[1], m_sketch_face_selection_color[2],
-              m_sketch_face_selection_color[3]}},
-      {"sketch_face_highlight_color",
-             {m_sketch_face_highlight_color[0], m_sketch_face_highlight_color[1], m_sketch_face_highlight_color[2],
-              m_sketch_face_highlight_color[3]}},
-      {"add_mid_pt_edges", m_add_mid_pt_line_edges},
-      {"add_mid_pt_rect_edges", m_add_mid_pt_rect_edges},
-      {"add_mid_pt_slot_edges", m_add_mid_pt_slot_edges},
-      {"view_roll_step_deg", m_view_roll_step_deg},
-      {"view_zoom_scroll_scale", m_view_zoom_scroll_scale},
-      {"default_2d_view_width", m_default_2d_view_width},
-      {"default_2d_view_height", m_default_2d_view_height},
-      {"default_project_unit", (m_default_project_unit == Project_unit::Millimeter) ? "millimeter" : "inch"},
-      {"inspection_orthographic", m_inspection_orthographic},
-      {"snap_guide_color_node",
-             [&]()
-             {
-         float r{}, g{}, b{};
-         Sketch_nodes::get_snap_guide_color_node(r, g, b);
-         return nlohmann::json::array({r, g, b});
-       }()},
-      {"snap_guide_color_axis",
-             [&]()
-             {
-         const glm::vec3 c = Sketch_nodes::get_snap_guide_color_axis();
-         return nlohmann::json::array({c.x, c.y, c.z});
-       }()},
-      {"snap_guide_mode", static_cast<int>(Sketch_nodes::get_snap_guide_mode())},
-      {"snap_guide_line_width", Sketch_nodes::get_snap_guide_line_width()},
-      {"annotate_all_coaxial_nodes", Sketch_nodes::get_annotate_all_coaxial_nodes()},
-      {"ui_verbosity", m_ui_verbosity},
-      {"elm_list_hover_color",
-             {m_elm_list_hover_color[0], m_elm_list_hover_color[1], m_elm_list_hover_color[2], m_elm_list_hover_color[3]}},
-      {"shape_selection_color",
-             {m_shape_selection_color[0], m_shape_selection_color[1], m_shape_selection_color[2], m_shape_selection_color[3]}},
-      {"sketch_shape_faint_style", m_sketch_shape_faint_style},
-      {"sketch_shape_faint_opacity", m_sketch_shape_faint_opacity},
-      {"sketch_shape_faint_enabled", m_sketch_shape_faint_enabled},
-      {"extrude_fast_preview", m_extrude_fast_preview},
+      {"edge_dim_label_h",                   m_edge_dim_label_h},
+      {"edge_dim_line_width",                m_edge_dim_line_width},
+      {"edge_dim_arrow_size",                m_edge_dim_arrow_size},
+      {"edge_dim_color",                     {m_edge_dim_color[0], m_edge_dim_color[1], m_edge_dim_color[2]}},
+      {"edge_dim_text_scale",                m_edge_dim_text_scale},
+      {"edge_dim_text_render_mode",          m_edge_dim_text_render_mode},
+      {"edge_dim_arrow_style",               m_edge_dim_arrow_style},
+      {"edge_dim_arrow_orientation",         m_edge_dim_arrow_orientation},
+      {"show_sketch_dimensions",             m_show_sketch_dimensions},
+      {k_gui_key_permanent_node_anno_scale,  m_permanent_node_anno_scale},
+      {"origin_marker_color",                {m_origin_marker_color[0], m_origin_marker_color[1], m_origin_marker_color[2]}},
+      {"sketch_edge_color",                  {m_sketch_edge_color[0], m_sketch_edge_color[1],
+                                              m_sketch_edge_color[2], m_sketch_edge_color[3]}},
+      {"sketch_edge_selection_color",        {m_sketch_edge_selection_color[0], m_sketch_edge_selection_color[1],
+                                              m_sketch_edge_selection_color[2], m_sketch_edge_selection_color[3]}},
+      {"sketch_edge_highlight_color",        {m_sketch_edge_highlight_color[0], m_sketch_edge_highlight_color[1],
+                                              m_sketch_edge_highlight_color[2], m_sketch_edge_highlight_color[3]}},
+      {"sketch_edge_line_width",             m_sketch_edge_line_width},
+      {"sketch_face_color",                  {m_sketch_face_color[0], m_sketch_face_color[1],
+                                              m_sketch_face_color[2], m_sketch_face_color[3]}},
+      {"sketch_face_selection_color",        {m_sketch_face_selection_color[0], m_sketch_face_selection_color[1],
+                                              m_sketch_face_selection_color[2], m_sketch_face_selection_color[3]}},
+      {"sketch_face_highlight_color",        {m_sketch_face_highlight_color[0], m_sketch_face_highlight_color[1],
+                                              m_sketch_face_highlight_color[2], m_sketch_face_highlight_color[3]}},
+      {"add_mid_pt_edges",                   m_add_mid_pt_line_edges},
+      {"add_mid_pt_rect_edges",              m_add_mid_pt_rect_edges},
+      {"add_mid_pt_slot_edges",              m_add_mid_pt_slot_edges},
+      {"view_roll_step_deg",                 m_view_roll_step_deg},
+      {"view_zoom_scroll_scale",             m_view_zoom_scroll_scale},
+      {"default_2d_view_width",              m_default_2d_view_width},
+      {"default_2d_view_height",             m_default_2d_view_height},
+      {"default_project_unit",               (m_default_project_unit == Project_unit::Millimeter) ? "millimeter" : "inch"},
+      {"inspection_orthographic",            m_inspection_orthographic},
+      {"snap_guide_color_node",              [&]()
+                                              {
+                                                float r{}, g{}, b{};
+                                                Sketch_nodes::get_snap_guide_color_node(r, g, b);
+                                                return nlohmann::json::array({r, g, b});
+                                              }()},
+      {"snap_guide_color_axis",              [&]()
+                                              {
+                                                const glm::vec3 c = Sketch_nodes::get_snap_guide_color_axis();
+                                                return nlohmann::json::array({c.x, c.y, c.z});
+                                              }()},
+      {"snap_guide_mode",                    static_cast<int>(Sketch_nodes::get_snap_guide_mode())},
+      {"snap_guide_line_width",              Sketch_nodes::get_snap_guide_line_width()},
+      {"annotate_all_coaxial_nodes",         Sketch_nodes::get_annotate_all_coaxial_nodes()},
+      {"ui_verbosity",                       m_ui_verbosity},
+      {"elm_list_hover_color",               {m_elm_list_hover_color[0], m_elm_list_hover_color[1],
+                                              m_elm_list_hover_color[2], m_elm_list_hover_color[3]}},
+      {"shape_selection_color",              {m_shape_selection_color[0], m_shape_selection_color[1],
+                                              m_shape_selection_color[2], m_shape_selection_color[3]}},
+      {"sketch_shape_faint_style",           m_sketch_shape_faint_style},
+      {"sketch_shape_faint_opacity",         m_sketch_shape_faint_opacity},
+      {"sketch_shape_faint_enabled",         m_sketch_shape_faint_enabled},
+      {"extrude_fast_preview",               m_extrude_fast_preview},
       {"extrude_fast_preview_edge_threshold", m_extrude_fast_preview_edge_threshold},
   };
+  // clang-format on
   return j.dump(2);
 }
 
@@ -251,88 +261,85 @@ void GUI::save_occt_view_settings()
 
   EZY_ASSERT(m_view);
   j["occt_view"] = build_occt_view_settings_object_(*m_view);
+  // clang-format off
   j["gui"]       = {
-      {"show_options", m_show_options},
-      {"show_sketch_list", m_show_sketch_list},
-      {"show_shape_list", m_show_shape_list},
-      {"log_window_visible", m_log_window_visible},
-      {"show_settings_dialog", m_show_settings_dialog},
-      {"dark_mode", m_dark_mode},
-      {"show_lua_console", m_show_lua_console},
-      {"show_python_console", m_show_python_console},
-      {"ui_verbosity", m_ui_verbosity},
-      {"edge_dim_label_h", m_edge_dim_label_h},
-      {"edge_dim_line_width", m_edge_dim_line_width},
-      {"edge_dim_arrow_size", m_edge_dim_arrow_size},
-      {"edge_dim_color", {m_edge_dim_color[0], m_edge_dim_color[1], m_edge_dim_color[2]}},
-      {"edge_dim_text_scale", m_edge_dim_text_scale},
-      {"edge_dim_text_render_mode", m_edge_dim_text_render_mode},
-      {"edge_dim_arrow_style", m_edge_dim_arrow_style},
-      {"edge_dim_arrow_orientation", m_edge_dim_arrow_orientation},
-      {"show_sketch_dimensions", m_show_sketch_dimensions},
-      {k_gui_key_permanent_node_anno_scale, m_permanent_node_anno_scale},
-      {"origin_marker_color", {m_origin_marker_color[0], m_origin_marker_color[1], m_origin_marker_color[2]}},
-      {"sketch_edge_color", {m_sketch_edge_color[0], m_sketch_edge_color[1], m_sketch_edge_color[2], m_sketch_edge_color[3]}},
-      {"sketch_edge_selection_color",
-             {m_sketch_edge_selection_color[0], m_sketch_edge_selection_color[1], m_sketch_edge_selection_color[2],
-              m_sketch_edge_selection_color[3]}},
-      {"sketch_edge_highlight_color",
-             {m_sketch_edge_highlight_color[0], m_sketch_edge_highlight_color[1], m_sketch_edge_highlight_color[2],
-              m_sketch_edge_highlight_color[3]}},
-      {"sketch_edge_line_width", m_sketch_edge_line_width},
-      {"sketch_face_color", {m_sketch_face_color[0], m_sketch_face_color[1], m_sketch_face_color[2], m_sketch_face_color[3]}},
-      {"sketch_face_selection_color",
-             {m_sketch_face_selection_color[0], m_sketch_face_selection_color[1], m_sketch_face_selection_color[2],
-              m_sketch_face_selection_color[3]}},
-      {"sketch_face_highlight_color",
-             {m_sketch_face_highlight_color[0], m_sketch_face_highlight_color[1], m_sketch_face_highlight_color[2],
-              m_sketch_face_highlight_color[3]}},
-      {"add_mid_pt_edges", m_add_mid_pt_line_edges},
-      {"add_mid_pt_rect_edges", m_add_mid_pt_rect_edges},
-      {"add_mid_pt_slot_edges", m_add_mid_pt_slot_edges},
-      {"load_last_opened_on_startup", m_load_last_opened_on_startup},
-      {"last_opened_project_path", m_last_opened_project_path},
-      {"imgui_style_dark", imgui_style_to_json(m_imgui_style_dark)},
-      {"imgui_style_light", imgui_style_to_json(m_imgui_style_light)},
-      {"settings_headers", settings_headers_to_json(m_settings_headers)},
-      {"view_roll_step_deg", m_view_roll_step_deg},
-      {"view_zoom_scroll_scale", m_view_zoom_scroll_scale},
-      {"default_2d_view_width", m_default_2d_view_width},
-      {"default_2d_view_height", m_default_2d_view_height},
-      {"default_project_unit", (m_default_project_unit == Project_unit::Millimeter) ? "millimeter" : "inch"},
-      {"inspection_orthographic", m_inspection_orthographic},
-      {"snap_guide_color_node",
-             [&]()
-             {
-         float r{}, g{}, b{};
-         Sketch_nodes::get_snap_guide_color_node(r, g, b);
-         return nlohmann::json::array({r, g, b});
-       }()},
-      {"snap_guide_color_axis",
-             [&]()
-             {
-         const glm::vec3 c = Sketch_nodes::get_snap_guide_color_axis();
-         return nlohmann::json::array({c.x, c.y, c.z});
-       }()},
-      {"snap_guide_mode", static_cast<int>(Sketch_nodes::get_snap_guide_mode())},
-      {"snap_guide_line_width", Sketch_nodes::get_snap_guide_line_width()},
-      {"annotate_all_coaxial_nodes", Sketch_nodes::get_annotate_all_coaxial_nodes()},
+      {"show_options",                       m_show_options},
+      {"show_sketch_list",                   m_show_sketch_list},
+      {"show_shape_list",                    m_show_shape_list},
+      {"log_window_visible",                 m_log_window_visible},
+      {"show_settings_dialog",               m_show_settings_dialog},
+      {"dark_mode",                          m_dark_mode},
+      {"show_lua_console",                   m_show_lua_console},
+      {"show_python_console",                m_show_python_console},
+      {"ui_verbosity",                       m_ui_verbosity},
+      {"edge_dim_label_h",                   m_edge_dim_label_h},
+      {"edge_dim_line_width",                m_edge_dim_line_width},
+      {"edge_dim_arrow_size",                m_edge_dim_arrow_size},
+      {"edge_dim_color",                     {m_edge_dim_color[0], m_edge_dim_color[1], m_edge_dim_color[2]}},
+      {"edge_dim_text_scale",                m_edge_dim_text_scale},
+      {"edge_dim_text_render_mode",          m_edge_dim_text_render_mode},
+      {"edge_dim_arrow_style",               m_edge_dim_arrow_style},
+      {"edge_dim_arrow_orientation",         m_edge_dim_arrow_orientation},
+      {"show_sketch_dimensions",             m_show_sketch_dimensions},
+      {k_gui_key_permanent_node_anno_scale,  m_permanent_node_anno_scale},
+      {"origin_marker_color",                {m_origin_marker_color[0], m_origin_marker_color[1], m_origin_marker_color[2]}},
+      {"sketch_edge_color",                  {m_sketch_edge_color[0], m_sketch_edge_color[1],
+                                              m_sketch_edge_color[2], m_sketch_edge_color[3]}},
+      {"sketch_edge_selection_color",        {m_sketch_edge_selection_color[0], m_sketch_edge_selection_color[1],
+                                              m_sketch_edge_selection_color[2], m_sketch_edge_selection_color[3]}},
+      {"sketch_edge_highlight_color",        {m_sketch_edge_highlight_color[0], m_sketch_edge_highlight_color[1],
+                                              m_sketch_edge_highlight_color[2], m_sketch_edge_highlight_color[3]}},
+      {"sketch_edge_line_width",             m_sketch_edge_line_width},
+      {"sketch_face_color",                  {m_sketch_face_color[0], m_sketch_face_color[1],
+                                              m_sketch_face_color[2], m_sketch_face_color[3]}},
+      {"sketch_face_selection_color",        {m_sketch_face_selection_color[0], m_sketch_face_selection_color[1],
+                                              m_sketch_face_selection_color[2], m_sketch_face_selection_color[3]}},
+      {"sketch_face_highlight_color",        {m_sketch_face_highlight_color[0], m_sketch_face_highlight_color[1],
+                                              m_sketch_face_highlight_color[2], m_sketch_face_highlight_color[3]}},
+      {"add_mid_pt_edges",                   m_add_mid_pt_line_edges},
+      {"add_mid_pt_rect_edges",              m_add_mid_pt_rect_edges},
+      {"add_mid_pt_slot_edges",              m_add_mid_pt_slot_edges},
+      {"load_last_opened_on_startup",        m_load_last_opened_on_startup},
+      {"last_opened_project_path",           m_last_opened_project_path},
+      {"imgui_style_dark",                   imgui_style_to_json(m_imgui_style_dark)},
+      {"imgui_style_light",                  imgui_style_to_json(m_imgui_style_light)},
+      {"settings_headers",                   settings_headers_to_json(m_settings_headers)},
+      {"view_roll_step_deg",                 m_view_roll_step_deg},
+      {"view_zoom_scroll_scale",             m_view_zoom_scroll_scale},
+      {"default_2d_view_width",              m_default_2d_view_width},
+      {"default_2d_view_height",             m_default_2d_view_height},
+      {"default_project_unit",               (m_default_project_unit == Project_unit::Millimeter) ? "millimeter" : "inch"},
+      {"inspection_orthographic",            m_inspection_orthographic},
+      {"snap_guide_color_node",              [&]()
+                                              {
+                                                float r{}, g{}, b{};
+                                                Sketch_nodes::get_snap_guide_color_node(r, g, b);
+                                                return nlohmann::json::array({r, g, b});
+                                              }()},
+      {"snap_guide_color_axis",              [&]()
+                                              {
+                                                const glm::vec3 c = Sketch_nodes::get_snap_guide_color_axis();
+                                                return nlohmann::json::array({c.x, c.y, c.z});
+                                              }()},
+      {"snap_guide_mode",                    static_cast<int>(Sketch_nodes::get_snap_guide_mode())},
+      {"snap_guide_line_width",              Sketch_nodes::get_snap_guide_line_width()},
+      {"annotate_all_coaxial_nodes",         Sketch_nodes::get_annotate_all_coaxial_nodes()},
 #ifndef NDEBUG
-      {"show_dbg", m_show_dbg},
+      {"show_dbg",                           m_show_dbg},
 #endif
-      {"underlay_highlight_color",
-       {m_underlay_highlight_color[0], m_underlay_highlight_color[1], m_underlay_highlight_color[2],
-        m_underlay_highlight_color[3]}},
-      {"elm_list_hover_color",
-       {m_elm_list_hover_color[0], m_elm_list_hover_color[1], m_elm_list_hover_color[2], m_elm_list_hover_color[3]}},
-      {"shape_selection_color",
-       {m_shape_selection_color[0], m_shape_selection_color[1], m_shape_selection_color[2], m_shape_selection_color[3]}},
-      {"sketch_shape_faint_style", m_sketch_shape_faint_style},
-      {"sketch_shape_faint_opacity", m_sketch_shape_faint_opacity},
-      {"sketch_shape_faint_enabled", m_sketch_shape_faint_enabled},
-      {"extrude_fast_preview", m_extrude_fast_preview},
+      {"underlay_highlight_color",           {m_underlay_highlight_color[0], m_underlay_highlight_color[1],
+                                              m_underlay_highlight_color[2], m_underlay_highlight_color[3]}},
+      {"elm_list_hover_color",               {m_elm_list_hover_color[0], m_elm_list_hover_color[1],
+                                              m_elm_list_hover_color[2], m_elm_list_hover_color[3]}},
+      {"shape_selection_color",              {m_shape_selection_color[0], m_shape_selection_color[1],
+                                              m_shape_selection_color[2], m_shape_selection_color[3]}},
+      {"sketch_shape_faint_style",           m_sketch_shape_faint_style},
+      {"sketch_shape_faint_opacity",         m_sketch_shape_faint_opacity},
+      {"sketch_shape_faint_enabled",         m_sketch_shape_faint_enabled},
+      {"extrude_fast_preview",               m_extrude_fast_preview},
       {"extrude_fast_preview_edge_threshold", m_extrude_fast_preview_edge_threshold},
   };
+  // clang-format on
   j["version"]          = k_settings_version;
   const char* imgui_ini = ImGui::SaveIniSettingsToMemory(nullptr);
   if (imgui_ini && *imgui_ini)
@@ -525,10 +532,12 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
         if (i < static_cast<int>(a.size()) && a[i].is_number())
           out[i] = std::clamp(a[i].get<float>(), 0.f, 1.f);
     };
-    parse_rgba4("sketch_edge_color", m_sketch_edge_color, k_gui_sketch_edge_color_default);
+    // clang-format off
+    parse_rgba4("sketch_edge_color",           m_sketch_edge_color,           k_gui_sketch_edge_color_default);
     parse_rgba4("sketch_edge_highlight_color", m_sketch_edge_highlight_color, k_gui_sketch_edge_highlight_color_default);
-    parse_rgba4("sketch_face_color", m_sketch_face_color, k_gui_sketch_face_color_default);
+    parse_rgba4("sketch_face_color",           m_sketch_face_color,           k_gui_sketch_face_color_default);
     parse_rgba4("sketch_face_highlight_color", m_sketch_face_highlight_color, k_gui_sketch_face_highlight_color_default);
+    // clang-format on
     // Selection colors: fall back to highlight when absent (pre-split settings files).
     parse_rgba4("sketch_edge_selection_color", m_sketch_edge_selection_color,
                 g.contains("sketch_edge_selection_color") ? k_gui_sketch_edge_selection_color_default
@@ -631,9 +640,11 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
           g.contains("imgui_rounding_general") || g.contains("imgui_rounding_scroll") || g.contains("imgui_rounding_tabs");
       if (has_legacy_rounding)
       {
-        const float gen                     = round_from_json("imgui_rounding_general", dark_defaults.rounding_general);
-        const float scroll                  = round_from_json("imgui_rounding_scroll", dark_defaults.rounding_scroll);
-        const float tabs                    = round_from_json("imgui_rounding_tabs", dark_defaults.rounding_tabs);
+        // clang-format off
+        const float gen    = round_from_json("imgui_rounding_general", dark_defaults.rounding_general);
+        const float scroll = round_from_json("imgui_rounding_scroll",  dark_defaults.rounding_scroll);
+        const float tabs   = round_from_json("imgui_rounding_tabs",    dark_defaults.rounding_tabs);
+        // clang-format on
         m_imgui_style_dark.rounding_general = m_imgui_style_light.rounding_general = gen;
         m_imgui_style_dark.rounding_scroll = m_imgui_style_light.rounding_scroll = scroll;
         m_imgui_style_dark.rounding_tabs = m_imgui_style_light.rounding_tabs = tabs;
@@ -2195,16 +2206,18 @@ nlohmann::json build_occt_view_settings_object_(const Occt_view& view)
   const int             method = view.get_bg_gradient_method();
   Occt_grid_rect_params grid_rect{};
   view.get_occt_grid_rect_params(grid_rect);
+  // clang-format off
   return nlohmann::json{
-      {"bg_color1", {bg1[0], bg1[1], bg1[2]}},
-      {"bg_color2", {bg2[0], bg2[1], bg2[2]}},
-      {"bg_gradient_method", method},
-      {"grid_color1", {g1[0], g1[1], g1[2]}},
-      {"grid_color2", {g2[0], g2[1], g2[2]}},
-      {"grid_step", grid_rect.step},
-      {"grid_padding", grid_rect.grid_padding},
+      {"bg_color1",            {bg1[0], bg1[1], bg1[2]}},
+      {"bg_color2",            {bg2[0], bg2[1], bg2[2]}},
+      {"bg_gradient_method",   method},
+      {"grid_color1",          {g1[0], g1[1], g1[2]}},
+      {"grid_color2",          {g2[0], g2[1], g2[2]}},
+      {"grid_step",            grid_rect.step},
+      {"grid_padding",         grid_rect.grid_padding},
       {"grid_graphic_z_offset", grid_rect.graphic_z_offset},
-      {"grid_visible", view.get_grid_visible()},
+      {"grid_visible",          view.get_grid_visible()},
   };
+  // clang-format on
 }
 } // namespace

--- a/src/gui_settings.cpp
+++ b/src/gui_settings.cpp
@@ -371,6 +371,7 @@ void GUI::parse_occt_view_settings_(const std::string& content)
           if (a[i].is_number())
             out[i] = a[i].get<float>();
     };
+
     if (ov.contains("bg_color1"))
       arr3(ov["bg_color1"], bg1);
 
@@ -401,6 +402,7 @@ void GUI::parse_occt_view_settings_(const std::string& content)
       if (v.is_number())
         dst = v.get<double>();
     };
+
     apply_num("grid_step", grid_rect.step);
     if (!ov.contains("grid_step"))
     {
@@ -410,6 +412,7 @@ void GUI::parse_occt_view_settings_(const std::string& content)
       else if (ov.contains("grid_y_step"))
         apply_num("grid_y_step", grid_rect.step);
     }
+
     apply_num("grid_padding", grid_rect.grid_padding);
     if (!ov.contains("grid_padding") && ov.contains("grid_graphic_x_size"))
       // Legacy: treat old half-extent as padding margin around sketch content.
@@ -525,8 +528,10 @@ void GUI::parse_gui_panes_settings_(const std::string& content)
     {
       for (int i = 0; i < 4; ++i)
         out[i] = defaults[i];
+
       if (!g.contains(key) || !g[key].is_array())
         return;
+
       const json& a = g[key];
       for (int i = 0; i < 4; ++i)
         if (i < static_cast<int>(a.size()) && a[i].is_number())
@@ -902,6 +907,7 @@ bool GUI::settings_collapsing_header_(const char* label, bool& open_state)
     open_state = open;
     save_occt_view_settings();
   }
+
   return open;
 }
 
@@ -1208,6 +1214,7 @@ void GUI::settings_()
       if (ImGui::ColorEdit4("##shape_sel_color", m_shape_selection_color,
                             ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
         shape_sel_changed = true;
+
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       GUI_DOC_HELP_("Highlight color for selected 3D shapes in the viewer (edges and wires).", doc_urls::k_occt_view);
 
@@ -1253,6 +1260,7 @@ void GUI::settings_()
         m_view->set_grid_visible(grid_visible);
         save_occt_view_settings();
       }
+
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       GUI_DOC_HELP_("Show or hide the OCCT reference grid in the 3D view. When shown, the grid lies on the active "
                     "sketch plane. Click ? to open the user guide.",
@@ -1283,6 +1291,7 @@ void GUI::settings_()
       const double step_min_ui = 1e-6;
       if (ImGui::DragScalar("##gstep", ImGuiDataType_Double, &step_ui, spd_s, &step_min_ui, nullptr, "%.8g"))
         geom_changed = true;
+
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       ImGui::TextUnformatted(m_view->project_unit_suffix());
 
@@ -1294,6 +1303,7 @@ void GUI::settings_()
       const double padding_min_ui = 0.0;
       if (ImGui::DragScalar("##gpad", ImGuiDataType_Double, &padding_ui, spd_extent, &padding_min_ui, nullptr, "%.8g"))
         geom_changed = true;
+
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       ImGui::TextUnformatted(m_view->project_unit_suffix());
 
@@ -1310,6 +1320,7 @@ void GUI::settings_()
       ImGui::TableSetColumnIndex(1);
       if (ImGui::DragScalar("##ggz", ImGuiDataType_Double, &graphic_z_off_ui, spd_m, nullptr, nullptr, "%.8g"))
         geom_changed = true;
+
       ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
       ImGui::TextUnformatted(m_view->project_unit_suffix());
 
@@ -1356,6 +1367,7 @@ void GUI::settings_()
         if (ImGui::ColorEdit4("##sketch_edge_color", m_sketch_edge_color,
                               ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
           appear_changed = true;
+
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("Color and opacity of edges on the current sketch (alpha = opacity).", nullptr);
 
@@ -1385,6 +1397,7 @@ void GUI::settings_()
         if (ImGui::ColorEdit4("##sketch_edge_sel_color", m_sketch_edge_selection_color,
                               ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
           appear_changed = true;
+
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("Color and opacity for selected sketch edges.", nullptr);
 
@@ -1396,6 +1409,7 @@ void GUI::settings_()
         if (ImGui::ColorEdit4("##sketch_edge_hl_color", m_sketch_edge_highlight_color,
                               ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
           appear_changed = true;
+
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("Color and opacity for mouse-over (dynamic) highlight on sketch edges.", nullptr);
 
@@ -1407,6 +1421,7 @@ void GUI::settings_()
         if (ImGui::ColorEdit4("##sketch_face_color", m_sketch_face_color,
                               ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
           appear_changed = true;
+
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("Fill color and opacity of closed faces on the current sketch.", nullptr);
 
@@ -1418,6 +1433,7 @@ void GUI::settings_()
         if (ImGui::ColorEdit4("##sketch_face_sel_color", m_sketch_face_selection_color,
                               ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
           appear_changed = true;
+
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("Fill color and opacity for selected sketch faces.", nullptr);
 
@@ -1429,6 +1445,7 @@ void GUI::settings_()
         if (ImGui::ColorEdit4("##sketch_face_hl_color", m_sketch_face_highlight_color,
                               ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaBar))
           appear_changed = true;
+
         ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
         GUI_DOC_HELP_("Fill color and opacity for mouse-over (dynamic) highlight on sketch faces.", nullptr);
 
@@ -1444,6 +1461,7 @@ void GUI::settings_()
             m_sketch_shape_faint_enabled = faint;
             appear_changed               = true;
           }
+
           ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
           ImGui::TextUnformatted("Enabled");
         }
@@ -1492,6 +1510,7 @@ void GUI::settings_()
                 appear_changed               = true;
               }
             }
+
             ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
             GUI_DOC_HELP_("How solid faint shapes look in sketch mode (higher = closer to normal inspection "
                           "opacity). Applies to Ghost and Wire styles.",
@@ -1511,6 +1530,7 @@ void GUI::settings_()
             m_extrude_fast_preview = fast;
             appear_changed         = true;
           }
+
           ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
           ImGui::TextUnformatted("Enabled");
         }
@@ -1657,6 +1677,7 @@ void GUI::settings_()
               "Center on dimension line",
               "Automatic",
           };
+
           int h = m_edge_dim_label_h;
           ImGui::SetNextItemWidth(200.0f);
           if (ImGui::BeginCombo("##edge_dim_h", k_edge_dim_label_placement[static_cast<size_t>(h)],
@@ -1668,6 +1689,7 @@ void GUI::settings_()
                 m_edge_dim_label_h = i;
                 dim_changed        = true;
               }
+
             ImGui::EndCombo();
           }
         }
@@ -2055,10 +2077,12 @@ void GUI::settings_()
       ImGui::TextWrapped("Last opened path: %s", m_last_opened_project_path.c_str());
     else
       ImGui::TextDisabled("(No path saved yet.)");
+
     ImGui::Spacing();
 #endif
     if (ImGui::Button("Save current as startup project"))
       save_startup_project_();
+
     ImGui::SameLine();
     if (ImGui::Button("Clear saved startup"))
       clear_saved_startup_project_();
@@ -2073,9 +2097,7 @@ void GUI::settings_()
   if (ImGui::Button("Defaults"))
   {
     std::string content = settings::load_defaults();
-    if (content.empty())
-      show_message("Failed to load default settings.");
-    else
+    if (!content.empty())
     {
       try
       {
@@ -2111,6 +2133,8 @@ void GUI::settings_()
         show_message("Failed to apply default settings.");
       }
     }
+    else
+      show_message("Failed to load default settings.");
   }
 
   ImGui::End();

--- a/src/shp_create.cpp
+++ b/src/shp_create.cpp
@@ -84,6 +84,7 @@ TopoDS_Shape create_pyramid(double side)
   TopoDS_Shape pyramid = solid_maker.Solid();
   gp_Trsf      trsf;
   trsf.SetTranslation(gp_Vec(0, 0, -h / 2.0));
+
   return BRepBuilderAPI_Transform(pyramid, trsf).Shape();
 }
 
@@ -94,6 +95,7 @@ TopoDS_Shape create_cylinder(double radius, double height)
   TopoDS_Shape cyl = BRepPrimAPI_MakeCylinder(radius, height).Shape();
   gp_Trsf      trsf;
   trsf.SetTranslation(gp_Vec(0, 0, -height / 2.0));
+
   return BRepBuilderAPI_Transform(cyl, trsf).Shape();
 }
 
@@ -102,6 +104,7 @@ TopoDS_Shape create_cone(double R1, double R2, double height)
   TopoDS_Shape cone = BRepPrimAPI_MakeCone(R1, R2, height).Shape();
   gp_Trsf      trsf;
   trsf.SetTranslation(gp_Vec(0, 0, -height / 2.0));
+
   return BRepBuilderAPI_Transform(cone, trsf).Shape();
 }
 

--- a/src/shp_cross_section.cpp
+++ b/src/shp_cross_section.cpp
@@ -62,16 +62,19 @@ TopoDS_Shape          shape_world_(const Shp& shp);
 gp_Ax3                frame_world_(const Shp& shp);
 bool                  append_bounds_(const TopoDS_Shape& shape, Bnd_Box& bounds);
 std::array<gp_Pnt, 8> bbox_corners_(const Bnd_Box& bounds);
+
 void project_bbox_offsets_(const Bnd_Box& bounds, const gp_Pnt& origin, const gp_Dir& normal, double& out_min, double& out_max);
 void project_bbox_uv_(const Bnd_Box& bounds, const gp_Pln& plane, double& u_min, double& u_max, double& v_min, double& v_max);
 bool bbox_misses_plane_(const Bnd_Box& bounds, const gp_Pln& plane);
 void add_plane_annotation_(const Bnd_Box& bounds, const gp_Pln& plane, BRep_Builder& builder, TopoDS_Compound& fill,
                            TopoDS_Compound& lines);
+
 Result<Cross_section_geometry> section_one_shape_on_plane_(const TopoDS_Shape& shape, const gp_Pln& plane);
 Result<Cross_section_geometry> cross_section_shape_on_plane_(const TopoDS_Shape& shape, const gp_Pln& plane);
 Result<TopoDS_Solid>           keep_half_space_(const gp_Pln& plane, const Bnd_Box& bounds);
 Result<TopoDS_Shape>           clip_solid_to_half_space_(const TopoDS_Shape& world_shape, const TopoDS_Solid& half_space);
 void                           for_each_index_(size_t count, const std::function<void(size_t)>& fn, std::atomic<bool>* cancel);
+
 std::vector<Result<Cross_section_geometry>> section_shapes_on_plane_(const std::vector<TopoDS_Shape>& world_shapes,
                                                                      const gp_Pln& plane, std::atomic<bool>* cancel);
 Assembled_section assemble_section_geometries_(const std::vector<Result<Cross_section_geometry>>& section_results,
@@ -147,6 +150,7 @@ Result<Shp_cross_section::Shared_plane> Shp_cross_section::build_shared_plane_(c
 
   const double offset_model = view().to_model(m_offset_display);
   shared.plane              = cross_section_plane_(shared_axes, m_plane, offset_model, m_invert_normal);
+
   return shared;
 }
 
@@ -175,6 +179,7 @@ Status Shp_cross_section::request_preview(const std::vector<Shp_ptr>& shapes)
   // Keep last cyan wires until the new section job finishes (feels less flickery while dragging).
   enqueue_section_(plane_ctx);
   ctx().UpdateCurrentViewer();
+
   return Status::ok();
 }
 
@@ -183,6 +188,7 @@ Status Shp_cross_section::preview(const std::vector<Shp_ptr>& shapes)
   const Status requested = request_preview(shapes);
   if (!requested.is_ok())
     return requested;
+
   return wait_section();
 }
 
@@ -246,6 +252,7 @@ Shp_cross_section::Section_result Shp_cross_section::compute_section_result_(Sec
   out.status                        = assembled.status;
   out.compound                      = assembled.compound;
   out.plane                         = req.plane;
+
   return out;
 }
 
@@ -270,6 +277,7 @@ std::optional<Status> Shp_cross_section::finish_section_result_(Section_result r
   }
 
   ctx().UpdateCurrentViewer();
+
   return result.status;
 }
 
@@ -525,14 +533,15 @@ Status Shp_cross_section::clip(const std::vector<Shp_ptr>& shapes)
   clear();
 
   std::ostringstream msg;
-  if (added.empty())
-    msg << "Removed " << removed_fully << (removed_fully == 1 ? " fully clipped shape." : " fully clipped shapes.");
-  else
+  if (!added.empty())
   {
     msg << "Clipped " << added.size() << (added.size() == 1 ? " shape." : " shapes.");
     if (removed_fully > 0)
       msg << " Removed " << removed_fully << (removed_fully == 1 ? " fully clipped shape." : " fully clipped shapes.");
   }
+  else
+    msg << "Removed " << removed_fully << (removed_fully == 1 ? " fully clipped shape." : " fully clipped shapes.");
+
   return Status::ok(msg.str());
 }
 
@@ -547,7 +556,6 @@ void Shp_cross_section::clear()
 void Shp_cross_section::clear_ais_clips_()
 {
   if (!m_ais_clip_plane.IsNull())
-  {
     for (const Shp_ptr& shp : m_ais_clipped_shapes)
     {
       if (shp.IsNull())
@@ -556,7 +564,6 @@ void Shp_cross_section::clear_ais_clips_()
       shp->RemoveClipPlane(m_ais_clip_plane);
       ctx().Redisplay(shp, false);
     }
-  }
 
   m_ais_clipped_shapes.clear();
   m_ais_clip_plane.Nullify();
@@ -586,6 +593,7 @@ std::vector<Shape_id> Shp_cross_section::selection_ids_(const std::vector<Shp_pt
   for (const Shp_ptr& shp : shapes)
     if (!shp.IsNull())
       ids.push_back(shp->get_id());
+
   return ids;
 }
 
@@ -668,26 +676,20 @@ gp_Pln cross_section_plane_(const gp_Ax3& frame, Cross_section_plane plane, doub
 {
   gp_Dir normal;
   gp_Dir x_dir;
+  // clang-format off
   switch (plane)
   {
-  case Cross_section_plane::XY:
-    normal = frame.Direction();
-    x_dir  = frame.XDirection();
-    break;
-  case Cross_section_plane::XZ:
-    normal = frame.YDirection();
-    x_dir  = frame.XDirection();
-    break;
-  case Cross_section_plane::YZ:
-    normal = frame.XDirection();
-    x_dir  = frame.YDirection();
-    break;
+  case Cross_section_plane::XY: normal = frame.Direction();  x_dir = frame.XDirection(); break;
+  case Cross_section_plane::XZ: normal = frame.YDirection(); x_dir = frame.XDirection(); break;
+  case Cross_section_plane::YZ: normal = frame.XDirection(); x_dir = frame.YDirection(); break;
   }
+  // clang-format on
 
   if (invert_normal)
     normal.Reverse();
 
   const gp_Pnt location = frame.Location().Translated(gp_Vec(normal) * offset);
+
   return gp_Pln(gp_Ax3(location, normal, x_dir));
 }
 
@@ -738,24 +740,16 @@ Result<Cross_section_geometry> section_one_shape_on_plane_(const TopoDS_Shape& s
 
 void count_curve_type_(const TopoDS_Edge& edge, Cross_section_geometry& result)
 {
+  // clang-format off
   switch (BRepAdaptor_Curve(edge).GetType())
   {
-  case GeomAbs_Line:
-    ++result.line_count;
-    break;
-  case GeomAbs_Circle:
-    ++result.circle_count;
-    break;
-  case GeomAbs_Ellipse:
-    ++result.ellipse_count;
-    break;
-  case GeomAbs_BSplineCurve:
-    ++result.bspline_count;
-    break;
-  default:
-    ++result.other_curve_count;
-    break;
+  case GeomAbs_Line:         ++result.line_count;        break;
+  case GeomAbs_Circle:       ++result.circle_count;      break;
+  case GeomAbs_Ellipse:      ++result.ellipse_count;     break;
+  case GeomAbs_BSplineCurve: ++result.bspline_count;     break;
+  default:                   ++result.other_curve_count; break;
   }
+  // clang-format on
 }
 
 bool contains_solid_(const TopoDS_Shape& shape)
@@ -791,6 +785,7 @@ bool append_bounds_(const TopoDS_Shape& shape, Bnd_Box& bounds)
     return false;
 
   bounds.Add(local);
+
   return true;
 }
 
@@ -848,6 +843,7 @@ void for_each_index_(size_t count, const std::function<void(size_t)>& fn, std::a
   {
     if (!(cancel && cancel->load()))
       fn(0);
+
     return;
   }
 
@@ -869,6 +865,7 @@ void for_each_index_(size_t count, const std::function<void(size_t)>& fn, std::a
             const size_t i = next.fetch_add(1, std::memory_order_relaxed);
             if (i >= count)
               break;
+
             fn(i);
           }
         });
@@ -892,6 +889,7 @@ std::vector<Result<Cross_section_geometry>> section_shapes_on_plane_(const std::
         results[i] = section_one_shape_on_plane_(world_shapes[i], plane);
       },
       cancel);
+
   return results;
 }
 
@@ -919,6 +917,7 @@ Assembled_section assemble_section_geometries_(const std::vector<Result<Cross_se
 
       const std::string name = i < shape_names.size() ? shape_names[i] : "Shape";
       out.status             = Status(result.status(), name + ": " + result.message());
+
       return out;
     }
 
@@ -944,6 +943,7 @@ Assembled_section assemble_section_geometries_(const std::vector<Result<Cross_se
   msg << "Section preview: " << totals.edge_count << " edge";
   if (totals.edge_count != 1)
     msg << "s";
+
   msg << " (" << totals.line_count << " line, " << totals.circle_count << " circle, " << totals.ellipse_count << " ellipse, "
       << totals.bspline_count << " B-spline, " << totals.other_curve_count << " other)";
   if (missed > 0)
@@ -952,8 +952,10 @@ Assembled_section assemble_section_geometries_(const std::vector<Result<Cross_se
     if (missed != 1)
       msg << "s";
   }
+
   msg << ".";
   out.status = Status::ok(msg.str());
+
   return out;
 }
 

--- a/src/shp_cross_section.h
+++ b/src/shp_cross_section.h
@@ -8,7 +8,6 @@
 #include <TopoDS_Shape.hxx>
 
 #include <atomic>
-#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>

--- a/src/shp_cut.cpp
+++ b/src/shp_cut.cpp
@@ -56,6 +56,7 @@ Shp_rslt Shp_cut::cut(std::vector<Shp_ptr> shps)
   add_shp_(shp);
   view().push_undo_delta(
       std::make_unique<Shape_replace_delta>(std::move(removed), std::vector<Shape_rec>{capture_shape_rec(*shp)}));
+  
   return Shp_rslt(shp);
 }
 
@@ -65,5 +66,6 @@ Status Shp_cut::selected_cut()
   Shp_rslt r = cut(std::move(m_shps));
   if (!r.is_ok())
     return Status(r.status(), r.message());
+
   return Status::ok();
 }

--- a/src/shp_extrude.cpp
+++ b/src/shp_extrude.cpp
@@ -29,6 +29,7 @@ size_t count_shape_edges_(const TopoDS_Shape& shape)
   size_t n = 0;
   for (TopExp_Explorer ex(shape, TopAbs_EDGE); ex.More(); ex.Next())
     ++n;
+
   return n;
 }
 
@@ -38,7 +39,9 @@ gp_Pnt centroid_of_verts_(const std::vector<gp_Pnt>& verts)
   gp_XYZ sum(0.0, 0.0, 0.0);
   for (const gp_Pnt& p : verts)
     sum += p.XYZ();
+
   sum /= static_cast<double>(verts.size());
+
   return gp_Pnt(sum);
 }
 
@@ -53,6 +56,7 @@ gp_Trsf section_trsf_(const gp_Ax1& axis, double height_along_axis, double twist
   rot.SetRotation(axis, twist_rad);
   gp_Trsf trans;
   trans.SetTranslation(gp_Vec(axis.Direction()) * height_along_axis);
+
   return trans * rot;
 }
 
@@ -76,6 +80,7 @@ TopoDS_Shape loft_twisted_wire_(const TopoDS_Wire& wire, const gp_Ax1& axis, con
 
   maker.Build();
   EZY_ASSERT(maker.IsDone());
+
   return try_make_solid(maker.Shape());
 }
 
@@ -87,8 +92,10 @@ std::vector<TopoDS_Wire> face_hole_wires_(const TopoDS_Face& face, const TopoDS_
     const TopoDS_Wire w = TopoDS::Wire(ex.Current());
     if (w.IsNull() || w.IsSame(outer_wire))
       continue;
+
     holes.push_back(w);
   }
+
   return holes;
 }
 } // namespace
@@ -185,6 +192,7 @@ void Shp_extrude::on_left_click()
     lock_height_begin_twist_();
     return;
   }
+
   finalize();
 }
 
@@ -343,6 +351,7 @@ void Shp_extrude::update_twist_(const ScreenCoords& screen_coords)
     const double vy = v.Dot(y_dir);
     if (std::hypot(vx, vy) <= Precision::Confusion())
       return;
+
     twist_rad = std::atan2(vy, vx);
     if (!m_show_angle_input)
       m_entered_twist_deg.reset();
@@ -588,8 +597,10 @@ double Shp_extrude::twist_dim_radius_() const
     for (const gp_Pnt& p : face->verts_3d)
       radius = std::max(radius, m_twist_centroid.Distance(p));
   }
+
   if (radius <= Precision::Confusion() && m_to_extrude_pt)
     radius = m_twist_centroid.Distance(*m_to_extrude_pt);
+
   return radius;
 }
 
@@ -693,6 +704,7 @@ void Shp_extrude::refresh_tmp_dimension_style(const Length_dimension_style& styl
     apply_length_dimension_style(m_tmp_dim, style);
     ctx().Redisplay(m_tmp_dim, true);
   }
+
   if (!m_tmp_angle_dim.IsNull())
   {
     apply_angle_dimension_style(m_tmp_angle_dim, style);

--- a/src/shp_fuse.cpp
+++ b/src/shp_fuse.cpp
@@ -56,6 +56,7 @@ Shp_rslt Shp_fuse::fuse(std::vector<Shp_ptr> shps)
   add_shp_(shp);
   view().push_undo_delta(
       std::make_unique<Shape_replace_delta>(std::move(removed), std::vector<Shape_rec>{capture_shape_rec(*shp)}));
+  
   return Shp_rslt(shp);
 }
 
@@ -65,5 +66,6 @@ Status Shp_fuse::selected_fuse()
   Shp_rslt r = fuse(std::move(m_shps));
   if (!r.is_ok())
     return Status(r.status(), r.message());
+
   return Status::ok();
 }

--- a/src/shp_info.cpp
+++ b/src/shp_info.cpp
@@ -21,6 +21,7 @@ std::string fmt_double(const double v)
 {
   char buf[64];
   std::snprintf(buf, sizeof(buf), "%.6g", v);
+
   return buf;
 }
 

--- a/src/shp_move.cpp
+++ b/src/shp_move.cpp
@@ -107,12 +107,7 @@ void Shp_move::show_dist_edit(const ScreenCoords& screen_coords)
 void Shp_move::check_finalize_()
 {
   bool no_axis_constraints = !m_opts.constr_axis_x && !m_opts.constr_axis_y && !m_opts.constr_axis_z;
-  if (no_axis_constraints)
-  {
-    if (m_delta.override_x.has_value() && m_delta.override_y.has_value() && m_delta.override_z.has_value())
-      finalize();
-  }
-  else
+  if (!no_axis_constraints)
   {
     bool got_x = !m_opts.constr_axis_x || m_delta.override_x.has_value();
     bool got_y = !m_opts.constr_axis_y || m_delta.override_y.has_value();
@@ -121,6 +116,8 @@ void Shp_move::check_finalize_()
     if (got_x && got_y && got_z)
       finalize();
   }
+  else if (m_delta.override_x.has_value() && m_delta.override_y.has_value() && m_delta.override_z.has_value())
+    finalize();
 }
 
 void Shp_move::finalize()

--- a/src/shp_rotate.cpp
+++ b/src/shp_rotate.cpp
@@ -24,11 +24,13 @@ void Shp_rotate::begin(std::vector<Shp_ptr> shps)
     ctx().Remove(m_rotation_axis_vis, false);
     m_rotation_axis_vis = nullptr;
   }
+
   if (m_rotation_center_vis)
   {
     ctx().Remove(m_rotation_center_vis, false);
     m_rotation_center_vis = nullptr;
   }
+
   set_operation_shps_(std::move(shps));
 }
 
@@ -106,6 +108,7 @@ void Shp_rotate::update_rotation_axis_()
     axis_dir   = gp_Dir(x, y, z);
     axis_color = Quantity_Color(x, y, z, Quantity_TOC_RGB);
   };
+
   switch (m_rotation_axis)
   {
     // clang-format off
@@ -205,6 +208,7 @@ Status Shp_rotate::show_angle_edit(const ScreenCoords& screen_coords)
     if (is_final)
       finalize();
   };
+
   gui().set_angle_edit(float(to_degrees(m_angle)), std::move(std::function<void(float, bool)>(angle_edit)));
 
   return Status::ok();

--- a/src/skt.cpp
+++ b/src/skt.cpp
@@ -81,6 +81,7 @@ void Sketch::sketch_pt_move(const ScreenCoords& screen_coords)
     (void)m_nodes.try_pick_existing_node(screen_coords);
     m_dims.update_len_dim_rubber_line_(screen_coords);
     return;
+
   default:
     break;
   }


### PR DESCRIPTION
## Summary
- Document hand-aligned tabular C++ layout (including short one-line `switch` cases), blank-line vertical rhythm, and happy-path-first control flow in `docs/ezycad_code_style.md`.
- Apply those presentation rules in `gui_settings.cpp` and `shp_cross_section.cpp` (local `// clang-format off`/`on` around tables only), plus light blank-line cleanup in nearby shape/sketch files.
- No intended runtime behavior changes.

Closes #229

## Test plan
- [x] Spot-check `docs/ezycad_code_style.md` Tabular layout / Vertical rhythm / Control flow polarity sections.
- [x] Confirm `gui_settings.cpp` and `shp_cross_section.cpp` keep clang-format off/on tight to tables (not file-wide).
- [x] Build / CI green (presentation-only; no feature tests expected).
- [x] Quick sanity: Settings dialog still loads/saves; cross-section tool still previews/clips.

## Notes
- Branch is formatting/style nitpick only (`Trailcode/nitpick`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and formatting; the Defaults-button and cross-section message refactors are equivalent control flow but worth a quick sanity check in Settings and cross-section clip UX.
> 
> **Overview**
> **`docs/ezycad_code_style.md`** adds guidance for hand-aligned **tabular** blocks (JSON keys, assignments, one-line `switch` cases) with tight `// clang-format off`/`on`, plus **vertical rhythm** (blank lines around ImGui chains, lambdas, returns) and **happy-path-first** `if`/`else`.
> 
> **`gui_settings.cpp`** and **`shp_cross_section.cpp`** are the main code updates: column-aligned settings JSON builders/parsers and compact `switch` tables; many **blank lines** before `ImGui::SameLine` / help tooltips and in the Settings UI. Smaller touch-ups in **`shp_create`**, **`shp_move`**, **`shp_rotate`**, fuse/cut/extrude, **`skt.cpp`**, etc. (spacing, polarity). **`shp_cross_section.h`** drops an unused `#include <cstddef>`.
> 
> The Settings **Defaults** button is refactored to **`if (!content.empty()) { … } else show_message(...)`** (same outcomes). Clip-message and similar branches use success-first ordering; logic is unchanged per the PR intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a1900fbdf91a40046a2a4c5b00c449fc74e152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->